### PR TITLE
Add docs for so far undocumented Aardvark API

### DIFF
--- a/3.5/http/aardvark.md
+++ b/3.5/http/aardvark.md
@@ -1,0 +1,87 @@
+Aardvark
+========
+
+ArangoDB's frontend, the web interface (Aardvark), uses several endpoints
+provided by a system service on the server side. These endpoints are
+documented below.
+
+{% hint 'warning' %}
+The Aardvark API is a private interface. The API may change at any time
+unannounced. The endpoints should not be called directly by users.
+{% endhint %}
+
+`/_admin/aardvark/api/*` (Swagger)
+
+`/_admin/aardvark/cluster/amICoordinator`
+
+`/_admin/aardvark/config.js (?)`
+
+`/_admin/aardvark/disableVersionCheck`
+
+`/_admin/aardvark/foxxes/billboard`
+
+`/_admin/aardvark/foxxes/config`
+
+`/_admin/aardvark/foxxes/config`
+
+`/_admin/aardvark/foxxes/deps`
+
+`/_admin/aardvark/foxxes/devel`
+
+`/_admin/aardvark/foxxes/docs`
+
+`/_admin/aardvark/foxxes/docs/standalone`
+
+`/_admin/aardvark/foxxes/download/nonce`
+
+`/_admin/aardvark/foxxes/download/zip`
+
+`/_admin/aardvark/foxxes/fishbowl`
+
+`/_admin/aardvark/foxxes/generate`
+
+`/_admin/aardvark/foxxes/git`
+
+`/_admin/aardvark/foxxes/raw`
+
+`/_admin/aardvark/foxxes/scripts/:name`
+
+`/_admin/aardvark/foxxes/store`
+
+`/_admin/aardvark/foxxes/tests`
+
+`/_admin/aardvark/foxxes/thumbnail`
+
+`/_admin/aardvark/foxxes/url`
+
+`/_admin/aardvark/foxxes/zip`
+
+`/_admin/aardvark/graph-examples/create/:name`
+
+`/_admin/aardvark/graph/:name`
+
+`/_admin/aardvark/job`
+
+`/_admin/aardvark/job/:id`
+
+`/_admin/aardvark/query/debugDump`
+
+`/_admin/aardvark/query/download/:user`
+
+`/_admin/aardvark/query/explain`
+
+`/_admin/aardvark/query/profile`
+
+`/_admin/aardvark/query/result/download/:query`
+
+`/_admin/aardvark/query/upload/:user`
+
+`/_admin/aardvark/replication/mode`
+
+`/_admin/aardvark/shouldCheckVersion`
+
+`/_admin/aardvark/statistics/cluster`
+
+`/_admin/aardvark/statistics/coordshort`
+
+`/_admin/aardvark/whoAmI`

--- a/_data/3.5-http.yml
+++ b/_data/3.5-http.yml
@@ -163,3 +163,5 @@
   href: miscellaneous-functions.html
 - text: Repair Jobs
   href: repairs.html
+- text: Aardvark
+  href: aardvark.html


### PR DESCRIPTION
Also see https://github.com/arangodb/planning/issues/3897

Aardvark Swagger JSON is available via Web UI (using documentation router?):
http://localhost:8529/_db/_system/_admin/aardvark/foxxes/docs/swagger.json?mount=/_admin/aardvark