### PR TITLE
Temporary script for manual sitemap generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,23 @@ twitter_username: jekyllrb
 github_username:  jekyll
 
 url: "https://www.arangodb.com" # the base hostname & protocol for your site
-plugins:
-  - jekyll-sitemap
+
+# Certain directories can be excluded from sitemap,
+# but including the stable folder (symlink) does not work.
+#plugins:
+#  - jekyll-sitemap
+#
+#defaults:
+#  -
+#    scope:
+#      path: 3.5/**
+#    values:
+#      sitemap: false
+#  -
+#    scope:
+#      path: stable/**
+#    values:
+#      sitemap: true
 
 # Build settings
 markdown: kramdown
@@ -33,7 +48,6 @@ kramdown:
 
 theme: minima
 plugins:
-  - jekyll-sitemap
   - jekyll-feed
   - jekyll-redirect-from
 
@@ -65,6 +79,7 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - scripts
+  - sitemap.rb
   - Dockerfile
   - TODO.md
   - htmltest

--- a/_config.yml
+++ b/_config.yml
@@ -27,12 +27,6 @@ url: "https://www.arangodb.com" # the base hostname & protocol for your site
 #  - jekyll-sitemap
 #
 #defaults:
-#  -
-#    scope:
-#      path: 3.5/**
-#    values:
-#      sitemap: false
-#  -
 #    scope:
 #      path: stable/**
 #    values:

--- a/sitemap.rb
+++ b/sitemap.rb
@@ -1,0 +1,28 @@
+# Generate sitemap.xml from all HTML files of stable version
+#
+# This is a temporary way to build a sitemap with canonical links only.
+# The jekyll-sitemap plugin does not work with our symlinked folders.
+
+require 'yaml'
+
+config = YAML.load_file('_config.yml')
+version = config['versions']['stable']
+baseurl = config['url'] + config['baseurl']
+dir = "_site/#{version}"
+
+if not Dir.exist?(dir)
+    raise IOError, "Source directory does not exist: #{dir}"
+end
+
+f = File.open('_site/sitemap.xml', 'w')
+
+f.write('<?xml version="1.0" encoding="UTF-8"?>' + "\n")
+f.write('<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' + "\n")
+
+Dir.glob("#{dir}/**/*.html").each do |file|
+    path = file.gsub(Regexp.new("^#{Regexp.quote(dir)}"), 'stable')
+    f.write("<url><loc>#{baseurl}/#{path}</loc></url>\n")
+end
+
+f.write('</urlset>')
+f.close()


### PR DESCRIPTION
We need a sitemap.xml, but the one generated by jekyll-sitemap plugin does not include the canonical links (stable version).

Pantheon's .gitignore rules prevented the docs sitemap from being committed, so there was none available so far at https://www.arangodb.com/docs/sitemap.xml. Changed in dev env:

```diff
commit 28f9ab4f914b2a4e9219ec02cab8216ca25b0518
tree e163edd3e8f806cf91c6434340ee11d250727c89
parent 2e8456b5534536e07cf0bac335d5dcf2e06a5ec8

    Add exception for docs sitemap to .gitignore

diff --git a/.gitignore b/.gitignore
index 0b55b14..31da344 100644
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ sitemap.xml
 sitemap.xml.gz
 *.log
 
+# Documentation
+!docs/sitemap.xml
+
 # @TODO writable paths
 wp-content/cache/
 wp-content/backups/
```