### PR TITLE
Fix free-text links

### DIFF
--- a/3.4/drivers/index.md
+++ b/3.4/drivers/index.md
@@ -13,19 +13,19 @@ Official drivers
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
-[ArangoDB-Java-Driver](java.html) | Java | https://github.com/arangodb/arangodb-java-driver | [Changelog](https://github.com/arangodb/arangodb-java-driver/blob/master/ChangeLog.md#readme){:target="_blank"}
-<span title="Same API as synchronous driver, except that it returns a CompletableFuture&lt;T&gt; instead of the result T directly" style="cursor: help;">ArangoDB-Java-Driver-Async</span> | Java | https://github.com/arangodb/arangodb-java-driver-async | [Changelog](https://github.com/arangodb/arangodb-java-driver-async/blob/master/ChangeLog.md#readme){:target="_blank"}
-[ArangoJS](js.html) | JavaScript | https://github.com/arangodb/arangojs | [Changelog](https://github.com/arangodb/arangojs/blob/master/CHANGELOG.md#readme){:target="_blank"}
-[ArangoDB-PHP](php.html) | PHP | https://github.com/arangodb/arangodb-php | [Changelog](https://github.com/arangodb/arangodb-php/blob/devel/CHANGELOG.md#readme){:target="_blank"}
-[Go-Driver](go.html) | Go | https://github.com/arangodb/go-driver | [Changelog](https://github.com/arangodb/go-driver/blob/master/CHANGELOG.md#readme){:target="_blank"}
+[ArangoDB-Java-Driver](java.html) | Java | [github.com/arangodb/arangodb-java-driver](https://github.com/arangodb/arangodb-java-driver){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-java-driver/blob/master/ChangeLog.md#readme){:target="_blank"}
+<span title="Same API as synchronous driver, except that it returns a CompletableFuture&lt;T&gt; instead of the result T directly" style="cursor: help;">ArangoDB-Java-Driver-Async</span> | Java | [github.com/arangodb/arangodb-java-driver-async](https://github.com/arangodb/arangodb-java-driver-async){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-java-driver-async/blob/master/ChangeLog.md#readme){:target="_blank"}
+[ArangoJS](js.html) | JavaScript | [github.com/arangodb/arangojs](https://github.com/arangodb/arangojs){:target="_blank"} | [Changelog](https://github.com/arangodb/arangojs/blob/master/CHANGELOG.md#readme){:target="_blank"}
+[ArangoDB-PHP](php.html) | PHP | [github.com/arangodb/arangodb-php](https://github.com/arangodb/arangodb-php){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-php/blob/devel/CHANGELOG.md#readme){:target="_blank"}
+[Go-Driver](go.html) | Go | [github.com/arangodb/go-driver](https://github.com/arangodb/go-driver){:target="_blank"} | [Changelog](https://github.com/arangodb/go-driver/blob/master/CHANGELOG.md#readme){:target="_blank"}
 
 Integrations
 ------------
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
-[Spring Data](spring-data.html) | Java | https://github.com/arangodb/spring-data | [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#readme){:target="_blank"}
-[ArangoDB-Spark-Connector](spark-connector.html) | Scala, Java | https://github.com/arangodb/arangodb-spark-connector | [Changelog](https://github.com/arangodb/arangodb-spark-connector/blob/master/ChangeLog.md#readme){:target="_blank"}
+[Spring Data](spring-data.html) | Java | [github.com/arangodb/spring-data](https://github.com/arangodb/spring-data){:target="_blank"} | [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#readme){:target="_blank"}
+[ArangoDB-Spark-Connector](spark-connector.html) | Scala, Java | [github.com/arangodb/arangodb-spark-connector](https://github.com/arangodb/arangodb-spark-connector){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-spark-connector/blob/master/ChangeLog.md#readme){:target="_blank"}
 
 Community drivers
 -----------------
@@ -34,12 +34,12 @@ Please note that this list is not exhaustive.
 
 Name | Language | Repository
 -----|----------|-----------
-ArangoDB-PHP-Core | PHP | https://github.com/frankmayer/ArangoDB-PHP-Core
-ArangoDB-NET | .NET | https://github.com/yojimbo87/ArangoDB-NET
-aranGO | Go | https://github.com/diegogub/aranGO
-arangolite | Go | https://github.com/solher/arangolite
-aranGoDriver | Go | https://github.com/TobiEiss/aranGoDriver
-pyArango | Python | http://www.github.com/tariqdaouda/pyArango
-python-arango | Python | https://github.com/Joowani/python-arango
-Scarango | Scala | https://github.com/outr/scarango
-ArangoRB | Ruby | https://github.com/StefanoMartin/ArangoRB
+ArangoDB-PHP-Core | PHP | [github.com/frankmayer/ArangoDB-PHP-Core](https://github.com/frankmayer/ArangoDB-PHP-Core){:target="_blank"}
+ArangoDB-NET | .NET | [github.com/yojimbo87/ArangoDB-NET](https://github.com/yojimbo87/ArangoDB-NET){:target="_blank"}
+aranGO | Go | [github.com/diegogub/aranGO](https://github.com/diegogub/aranGO){:target="_blank"}
+arangolite | Go | [github.com/solher/arangolite](https://github.com/solher/arangolite){:target="_blank"}
+aranGoDriver | Go | [github.com/TobiEiss/aranGoDriver](https://github.com/TobiEiss/aranGoDriver){:target="_blank"}
+pyArango | Python | [www.github.com/tariqdaouda/pyArango](http://www.github.com/tariqdaouda/pyArango){:target="_blank"}
+python-arango | Python | [github.com/Joowani/python-arango](https://github.com/Joowani/python-arango){:target="_blank"}
+Scarango | Scala | [github.com/outr/scarango](https://github.com/outr/scarango){:target="_blank"}
+ArangoRB | Ruby | [github.com/StefanoMartin/ArangoRB](https://github.com/StefanoMartin/ArangoRB){:target="_blank"}

--- a/3.5/architecture-storage-engines.md
+++ b/3.5/architecture-storage-engines.md
@@ -103,8 +103,8 @@ It is also possible to override these thresholds per transaction.
 RocksDB is based on a log-structured merge tree. A good introduction can be
 found in:
 
-- http://www.benstopford.com/2015/02/14/log-structured-merge-trees/
-- https://blog.acolyer.org/2014/11/26/the-log-structured-merge-tree-lsm-tree/
+- [www.benstopford.com/2015/02/14/log-structured-merge-trees/](http://www.benstopford.com/2015/02/14/log-structured-merge-trees/){:target="_blank"}
+- [blog.acolyer.org/2014/11/26/the-log-structured-merge-tree-lsm-tree/](https://blog.acolyer.org/2014/11/26/the-log-structured-merge-tree-lsm-tree/){:target="_blank"}
 
 The basic idea is that data is organized in levels were each level is a factor
 larger than the previous. New data will reside in smaller levels while old data
@@ -119,8 +119,8 @@ using the options below.
 
 Performance reports for the storage engine can be found here:
 
-- https://github.com/facebook/rocksdb/wiki/performance-benchmarks
-- https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide
+- [github.com/facebook/rocksdb/wiki/performance-benchmarks](https://github.com/facebook/rocksdb/wiki/performance-benchmarks){:target="_blank"}
+- [github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide){:target="_blank"}
 
 ### ArangoDB options
 

--- a/3.5/cookbook/cloud-node-js-docker.md
+++ b/3.5/cookbook/cloud-node-js-docker.md
@@ -13,11 +13,9 @@ I'm looking for a head start in using the ArangoDB docker image.
 Solution
 --------
 
-We will use the guesser game for ArangoDB from
+We will use the guesser game for ArangoDB from:
 
-```
-https://github.com/arangodb/guesser
-```
+[github.com/arangodb/guesser](https://github.com/arangodb/guesser){:target="_blank"}
 
 This is a simple game guessing animals or things. It learns while playing
 and stores the learned information in an ArangoDB instance. The game is written using the
@@ -54,11 +52,9 @@ browser to port 8000. You should see the start-up screen. However, without a sto
 backend it will be pretty useless. Therefore, stop the container and proceed with the next
 step.
 
-If you want to build the container locally, check out the guesser game from
+If you want to build the container locally, check out the guesser game from:
 
-```
-https://github.com/arangodb/example-guesser
-```
+[github.com/arangodb/guesser](https://github.com/arangodb/example-guesser){:target="_blank"}
 
 Switch into the `docker/node` subdirectory and execute `docker build .`.
 

--- a/3.5/cookbook/compiling-debian.md
+++ b/3.5/cookbook/compiling-debian.md
@@ -21,7 +21,8 @@ This solution was made using a fresh Debian Testing machine on Amazon EC2. For c
 
 Login to your AWS account and launch an instance of Debian Testing. I used an 'm3.xlarge' since that has a bunch of cores, more than enough memory, optimized network and the instance store is on SSDs which can be switched to provisioned IOPs.
 
-The Current AMI ID's can be found in the Debian Wiki: https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
+The Current AMI ID's can be found in the Debian Wiki:
+[wiki.debian.org/Cloud/AmazonEC2Image/Jessie](https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie){:target="_blank"}
 
 ### Upgrade to the very latest version
 

--- a/3.5/cookbook/compiling-windows.md
+++ b/3.5/cookbook/compiling-windows.md
@@ -80,7 +80,8 @@ Note that the V8 build scripts and gyp aren't compatible with Python 3.x hence y
 
 ### Building ArangoDB
 
-Download and extract the release tarball from https://www.arangodb.com/download/
+Download and extract the release tarball from
+[www.arangodb.com/download/](https://www.arangodb.com/download/){:target="_blank"}
 
 Or clone the GitHub repository and checkout the branch or tag you need (e.g. `devel`)
 

--- a/3.5/cookbook/index.md
+++ b/3.5/cookbook/index.md
@@ -5,11 +5,13 @@ title: The Multi-Model Database Cookbook
 ---
 # Cookbook
 
-This cookbook is filled with recipes to help you understand the [multi-model database ArangoDB](https://www.arangodb.com/){:target="_blank"} better
-and to help you with specific problems.
+This cookbook is filled with recipes to help you understand the
+[multi-model database ArangoDB](https://www.arangodb.com/){:target="_blank"}
+better and to help you with specific problems.
 
-You can participate and [write your own recipes][2]. 
-You only need to write a recipe in markdown and make a [pull request to our repository][2]. 
+You can participate and write your own recipes. 
+You only need to write a recipe in Markdown and make a
+[pull request to our repository](https://github.com/arangodb/docs/){:target="_blank"}. 
 
 **Recipes**
 
@@ -26,5 +28,3 @@ Every recipe is divided into three parts:
 Every recipe has tags to for a better overview:
 
 *#api*, *#aql*, *#arangosh*, *#collection*, *#database*, *#debian*, *#docker*, *#document*, *#driver*, *#foxx*, *#giantswarm*, *#graph*, *#howto*, *#java*, *#javascript*, *#join*, *#nodejs*, *#windows*
-
-[2]: https://github.com/arangodb/arangodb/tree/devel/Documentation/Books/Cookbook

--- a/3.5/cookbook/use-cases-exporting-data.md
+++ b/3.5/cookbook/use-cases-exporting-data.md
@@ -5,7 +5,7 @@ description: In this recipe we will learn how to use the export API to extract d
 Exporting Data for Offline Processing
 =====================================
 
-In this recipe we will learn how to use the [export API][1] to extract data and process it with PHP. At the end of the recipe you can download the complete PHP script.
+In this recipe we will learn how to use the [export API][1]{:target="_blank"} to extract data and process it with PHP. At the end of the recipe you can download the complete PHP script.
 
 **Note**: The following recipe is written using an ArangoDB server with version 2.6 or higher. You can also use the `devel` branch, since version 2.6 hasn't been an official release yet.
 
@@ -14,7 +14,7 @@ Howto
 
 ### Importing example data
 
-First of all we need some data in an ArangoDB collection. For this example we will use a collection named `users` which we will populate with 100.000 [example documents][2]. This way you can get the data into ArangoDB:
+First of all we need some data in an ArangoDB collection. For this example we will use a collection named `users` which we will populate with 100.000 [example documents][2]{:target="_blank"}. This way you can get the data into ArangoDB:
 
 ```bash
 # download data file
@@ -27,7 +27,7 @@ arangoimport --file users-100000.json --collection users --create-collection tru
 
 ### Setting up ArangoDB-PHP
 
-For this recipe we will use the [ArangoDB PHP driver][3]:
+For this recipe we will use the [ArangoDB PHP driver][3]{:target="_blank"}:
 
 ```bash
 git clone -b devel "https://github.com/arangodb/arangodb-php.git"
@@ -277,7 +277,7 @@ export('users', $connection);
 
 In this script only the `_key` and `name` attributes are extracted. In the prints the `_key`/`name` pairs are in CSV format.
 
-**Note**: The whole script [can be downloaded][4].
+**Note**: The whole script [can be downloaded][4]{:target="_blank"}.
 
 ### Using the API without PHP
 
@@ -308,7 +308,7 @@ curl
 **Tags**: #howto #php
 
 
-[1]: https://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/
-[2]: https://jsteemann.github.io/downloads/code/users-100000.json.tar.gz
-[3]: https://github.com/arangodb/arangodb-php
-[4]: https://jsteemann.github.io/downloads/code/export-csv.php
+[1]: [jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/](https://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/){:target="_blank"}
+[2]: [jsteemann.github.io/downloads/code/users-100000.json.tar.gz](https://jsteemann.github.io/downloads/code/users-100000.json.tar.gz){:target="_blank"}
+[3]: [github.com/arangodb/arangodb-php](https://github.com/arangodb/arangodb-php){:target="_blank"}
+[4]: [jsteemann.github.io/downloads/code/export-csv.php](https://jsteemann.github.io/downloads/code/export-csv.php){:target="_blank"}

--- a/3.5/cookbook/use-cases-exporting-data.md
+++ b/3.5/cookbook/use-cases-exporting-data.md
@@ -308,7 +308,7 @@ curl
 **Tags**: #howto #php
 
 
-[1]: [jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/](https://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/){:target="_blank"}
-[2]: [jsteemann.github.io/downloads/code/users-100000.json.tar.gz](https://jsteemann.github.io/downloads/code/users-100000.json.tar.gz){:target="_blank"}
-[3]: [github.com/arangodb/arangodb-php](https://github.com/arangodb/arangodb-php){:target="_blank"}
-[4]: [jsteemann.github.io/downloads/code/export-csv.php](https://jsteemann.github.io/downloads/code/export-csv.php){:target="_blank"}
+[1]: https://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/
+[2]: https://jsteemann.github.io/downloads/code/users-100000.json.tar.gz
+[3]: https://github.com/arangodb/arangodb-php
+[4]: https://jsteemann.github.io/downloads/code/export-csv.php

--- a/3.5/deployment-active-failover-manual-start.md
+++ b/3.5/deployment-active-failover-manual-start.md
@@ -262,6 +262,7 @@ options:
    Let ArangoDB generate a random root password.
        
 For an in depth guide about Docker and ArangoDB please check the official documentation:
-https://hub.docker.com/r/arangodb/arangodb/ . Note that we are using the image
-`arangodb/arangodb` here which is always the most current one. There is also the
-"official" one called `arangodb` whose documentation is here: https://hub.docker.com/_/arangodb/
+[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/){:target="_blank"}.
+Note that we are using the image `arangodb/arangodb` here which is always the most current one.
+There is also the "official" one called `arangodb` whose documentation is here:
+[hub.docker.com/_/arangodb/](https://hub.docker.com/_/arangodb/){:target="_blank"}

--- a/3.5/deployment-active-failover-using-the-starter.md
+++ b/3.5/deployment-active-failover-using-the-starter.md
@@ -81,9 +81,9 @@ variable by adding this option to the above `docker` command:
     -e ARANGO_LICENSE_KEY=<thekey>
 ```
 
-You can get a free evaluation license key by visiting
+You can get a free evaluation license key by visiting:
 
-     https://www.arangodb.com/download-arangodb-enterprise/
+[www.arangodb.com/download-arangodb-enterprise/](https://www.arangodb.com/download-arangodb-enterprise/){:target="_blank"}
 
 Then replace `<thekey>` above with the actual license key. The start
 will then hand on the license key to the Docker containers it launches

--- a/3.5/deployment-cluster-manual-start.md
+++ b/3.5/deployment-cluster-manual-start.md
@@ -387,6 +387,7 @@ options:
    Let ArangoDB generate a random root password.
        
 For an in depth guide about Docker and ArangoDB please check the official documentation:
-https://hub.docker.com/r/arangodb/arangodb/ . Note that we are using the image
-`arangodb/arangodb` here which is always the most current one. There is also the
-"official" one called `arangodb` whose documentation is here: https://hub.docker.com/_/arangodb/
+[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/){:target="_blank"}.
+Note that we are using the image `arangodb/arangodb` here which is always the most current one.
+There is also the "official" one called `arangodb` whose documentation is here:
+[hub.docker.com/_/arangodb/](https://hub.docker.com/_/arangodb/){:target="_blank"}

--- a/3.5/deployment-cluster-using-the-starter.md
+++ b/3.5/deployment-cluster-using-the-starter.md
@@ -66,9 +66,9 @@ variable by adding this option to the above `docker` command:
     -e ARANGO_LICENSE_KEY=<thekey>
 ```
 
-You can get a free evaluation license key by visiting
+You can get a free evaluation license key by visiting:
 
-     https://www.arangodb.com/download-arangodb-enterprise/
+[www.arangodb.com/download-arangodb-enterprise/](https://www.arangodb.com/download-arangodb-enterprise/){:target="_blank"}
 
 Then replace `<thekey>` above with the actual license key. The start
 will then hand on the license key to the Docker containers it launches

--- a/3.5/deployment-single-instance-manual-start.md
+++ b/3.5/deployment-single-instance-manual-start.md
@@ -71,6 +71,7 @@ options:
    Let ArangoDB generate a random root password.
        
 For an in depth guide about Docker and ArangoDB please check the official documentation:
-https://hub.docker.com/r/arangodb/arangodb/ . Note that we are using the image
-`arangodb/arangodb` here which is always the most current one. There is also the
-"official" one called `arangodb` whose documentation is here: https://hub.docker.com/_/arangodb/
+[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/){:target="_blank"}.
+Note that we are using the image `arangodb/arangodb` here which is always the most current one.
+There is also the "official" one called `arangodb` whose documentation is here:
+[hub.docker.com/_/arangodb/](https://hub.docker.com/_/arangodb/){:target="_blank"}

--- a/3.5/deployment-single-instance-using-the-starter.md
+++ b/3.5/deployment-single-instance-using-the-starter.md
@@ -44,9 +44,9 @@ variable by adding this option to the above `docker` command:
     -e ARANGO_LICENSE_KEY=<thekey>
 ```
 
-You can get a free evaluation license key by visiting
+You can get a free evaluation license key by visiting:
 
-     https://www.arangodb.com/download-arangodb-enterprise/
+[www.arangodb.com/download-arangodb-enterprise/](https://www.arangodb.com/download-arangodb-enterprise/){:target="_blank"}
 
 Then replace `<thekey>` above with the actual license key. The start
 will then hand on the license key to the Docker container it launches

--- a/3.5/drivers/go-getting-started.md
+++ b/3.5/drivers/go-getting-started.md
@@ -114,7 +114,9 @@ All error checking functions use the `Cause` function to get the cause of an err
 Note that `WithStack` and `Cause` are actually variables to you can implement it using your own error 
 wrapper library. 
 
-If you for example use https://github.com/pkg/errors, you want to initialize to go driver like this:
+If you for example use [github.com/pkg/errors](https://github.com/pkg/errors){:target="_blank"},
+you want to initialize to go driver like this:
+
 ```go
 import (
     driver "github.com/arangodb/go-driver"

--- a/3.5/drivers/index.md
+++ b/3.5/drivers/index.md
@@ -13,19 +13,19 @@ Official drivers
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
-[ArangoDB-Java-Driver](java.html) | Java | https://github.com/arangodb/arangodb-java-driver | [Changelog](https://github.com/arangodb/arangodb-java-driver/blob/master/ChangeLog.md#readme){:target="_blank"}
-<span title="Same API as synchronous driver, except that it returns a CompletableFuture&lt;T&gt; instead of the result T directly" style="cursor: help;">ArangoDB-Java-Driver-Async</span> | Java | https://github.com/arangodb/arangodb-java-driver-async | [Changelog](https://github.com/arangodb/arangodb-java-driver-async/blob/master/ChangeLog.md#readme){:target="_blank"}
-[ArangoJS](js.html) | JavaScript | https://github.com/arangodb/arangojs | [Changelog](https://github.com/arangodb/arangojs/blob/master/CHANGELOG.md#readme){:target="_blank"}
-[ArangoDB-PHP](php.html) | PHP | https://github.com/arangodb/arangodb-php | [Changelog](https://github.com/arangodb/arangodb-php/blob/devel/CHANGELOG.md#readme){:target="_blank"}
-[Go-Driver](go.html) | Go | https://github.com/arangodb/go-driver | [Changelog](https://github.com/arangodb/go-driver/blob/master/CHANGELOG.md#readme){:target="_blank"}
+[ArangoDB-Java-Driver](java.html) | Java | [github.com/arangodb/arangodb-java-driver](https://github.com/arangodb/arangodb-java-driver){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-java-driver/blob/master/ChangeLog.md#readme){:target="_blank"}
+<span title="Same API as synchronous driver, except that it returns a CompletableFuture&lt;T&gt; instead of the result T directly" style="cursor: help;">ArangoDB-Java-Driver-Async</span> | Java | [github.com/arangodb/arangodb-java-driver-async](https://github.com/arangodb/arangodb-java-driver-async){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-java-driver-async/blob/master/ChangeLog.md#readme){:target="_blank"}
+[ArangoJS](js.html) | JavaScript | [github.com/arangodb/arangojs](https://github.com/arangodb/arangojs){:target="_blank"} | [Changelog](https://github.com/arangodb/arangojs/blob/master/CHANGELOG.md#readme){:target="_blank"}
+[ArangoDB-PHP](php.html) | PHP | [github.com/arangodb/arangodb-php](https://github.com/arangodb/arangodb-php){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-php/blob/devel/CHANGELOG.md#readme){:target="_blank"}
+[Go-Driver](go.html) | Go | [github.com/arangodb/go-driver](https://github.com/arangodb/go-driver){:target="_blank"} | [Changelog](https://github.com/arangodb/go-driver/blob/master/CHANGELOG.md#readme){:target="_blank"}
 
 Integrations
 ------------
 
 Name | Language | Repository | &nbsp;
 -----|----------|------------|-------
-[Spring Data](spring-data.html) | Java | https://github.com/arangodb/spring-data | [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#readme){:target="_blank"}
-[ArangoDB-Spark-Connector](spark-connector.html) | Scala, Java | https://github.com/arangodb/arangodb-spark-connector | [Changelog](https://github.com/arangodb/arangodb-spark-connector/blob/master/ChangeLog.md#readme){:target="_blank"}
+[Spring Data](spring-data.html) | Java | [github.com/arangodb/spring-data](https://github.com/arangodb/spring-data){:target="_blank"} | [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#readme){:target="_blank"}
+[ArangoDB-Spark-Connector](spark-connector.html) | Scala, Java | [github.com/arangodb/arangodb-spark-connector](https://github.com/arangodb/arangodb-spark-connector){:target="_blank"} | [Changelog](https://github.com/arangodb/arangodb-spark-connector/blob/master/ChangeLog.md#readme){:target="_blank"}
 
 Community drivers
 -----------------
@@ -34,12 +34,12 @@ Please note that this list is not exhaustive.
 
 Name | Language | Repository
 -----|----------|-----------
-ArangoDB-PHP-Core | PHP | https://github.com/frankmayer/ArangoDB-PHP-Core
-ArangoDB-NET | .NET | https://github.com/yojimbo87/ArangoDB-NET
-aranGO | Go | https://github.com/diegogub/aranGO
-arangolite | Go | https://github.com/solher/arangolite
-aranGoDriver | Go | https://github.com/TobiEiss/aranGoDriver
-pyArango | Python | http://www.github.com/tariqdaouda/pyArango
-python-arango | Python | https://github.com/Joowani/python-arango
-Scarango | Scala | https://github.com/outr/scarango
-ArangoRB | Ruby | https://github.com/StefanoMartin/ArangoRB
+ArangoDB-PHP-Core | PHP | [github.com/frankmayer/ArangoDB-PHP-Core](https://github.com/frankmayer/ArangoDB-PHP-Core){:target="_blank"}
+ArangoDB-NET | .NET | [github.com/yojimbo87/ArangoDB-NET](https://github.com/yojimbo87/ArangoDB-NET){:target="_blank"}
+aranGO | Go | [github.com/diegogub/aranGO](https://github.com/diegogub/aranGO){:target="_blank"}
+arangolite | Go | [github.com/solher/arangolite](https://github.com/solher/arangolite){:target="_blank"}
+aranGoDriver | Go | [github.com/TobiEiss/aranGoDriver](https://github.com/TobiEiss/aranGoDriver){:target="_blank"}
+pyArango | Python | [www.github.com/tariqdaouda/pyArango](http://www.github.com/tariqdaouda/pyArango){:target="_blank"}
+python-arango | Python | [github.com/Joowani/python-arango](https://github.com/Joowani/python-arango){:target="_blank"}
+Scarango | Scala | [github.com/outr/scarango](https://github.com/outr/scarango){:target="_blank"}
+ArangoRB | Ruby | [github.com/StefanoMartin/ArangoRB](https://github.com/StefanoMartin/ArangoRB){:target="_blank"}

--- a/3.5/drivers/java-reference-serialization.md
+++ b/3.5/drivers/java-reference-serialization.md
@@ -12,7 +12,8 @@ registering additional `VPackModule`s on `ArangoDB.Builder`.
 
 ### Java 8 types
 
-GitHub: https://github.com/arangodb/java-velocypack-module-jdk8
+GitHub:
+[github.com/arangodb/java-velocypack-module-jdk8](https://github.com/arangodb/java-velocypack-module-jdk8){:target="_blank"}
 
 Added support for:
 
@@ -43,7 +44,8 @@ ArangoDB arangoDB = new ArangoDB.Builder().registerModule(new VPackJdk8Module())
 
 ### Scala types
 
-GitHub: https://github.com/arangodb/java-velocypack-module-scala
+GitHub:
+[github.com/arangodb/java-velocypack-module-scala](https://github.com/arangodb/java-velocypack-module-scala){:target="_blank"}
 
 Added support for:
 
@@ -69,7 +71,8 @@ val arangoDB: ArangoDB = new ArangoDB.Builder().registerModule(new VPackScalaMod
 
 ### Joda-Time
 
-GitHub: https://github.com/arangodb/java-velocypack-module-joda
+GitHub:
+[github.com/arangodb/java-velocypack-module-joda](https://github.com/arangodb/java-velocypack-module-joda){:target="_blank"}
 
 Added support for:
 

--- a/3.5/getting-started-web-interface.md
+++ b/3.5/getting-started-web-interface.md
@@ -1,6 +1,7 @@
 ---
 layout: default
-description: The server itself (arangod) speaks HTTP / REST, but you can use thegraphical web interface to keep it simple
+description: Arangod serves a frontend also known as Aardvark that allows you to easily manage ArangoDB through a GUI.
+title: ArangoDB Web Interface
 ---
 Web Interface
 =============
@@ -22,7 +23,8 @@ want to use the raw interface.
 To get familiar with the database system you can even put drivers aside and
 use the web interface (code name *Aardvark*) for basic interaction.
 The web interface will become available shortly after you started `arangod`.
-You can access it in your browser at http://localhost:8529 - if not, please
+You can access it in your browser at
+[http://localhost:8529](http://localhost:8529){:target="_blank"} - if not, please
 see [Troubleshooting](troubleshooting.html).
 
 By default, authentication is enabled. The default user is `root`.

--- a/3.5/graphs-pregel.md
+++ b/3.5/graphs-pregel.md
@@ -287,7 +287,8 @@ HITS is a link analysis algorithm that rates Web pages, developed by Jon Kleinbe
 The idea behind Hubs and Authorities comes from the typical structure of the web: Certain websites known as hubs, serve as large directories that are not actually 
 authoritative on the information that they hold. These hubs are used as compilations of a broad catalog of information that leads users direct to other authoritative webpages.
 The algorithm assigns each vertex two scores: The authority-score and the hub-score. The authority score rates how many good hubs point to a particular
-vertex (or webpage), the hub score rates how good (authoritative) the vertices pointed to are. For more see https://en.wikipedia.org/wiki/HITS_algorithm
+vertex (or webpage), the hub score rates how good (authoritative) the vertices pointed to are. For more see
+[en.wikipedia.org/wiki/HITS_algorithm](https://en.wikipedia.org/wiki/HITS_algorithm){:target="_blank"}
 
 Our version of the algorithm
 converges after a certain amount of time. The parameter *threshold* can be used to set a limit for the convergence (measured as maximum absolute difference of the hub and 

--- a/3.5/http/general.md
+++ b/3.5/http/general.md
@@ -169,7 +169,7 @@ ArangoDB uses a standard JWT based authentication method.
 To authenticate via JWT you must first obtain a JWT token with a signature generated via HMAC with SHA-256. 
 The secret may either be set using `--server.jwt-secret` or will be randomly generated upon server startup.
 
-For more information on JWT please consult RFC7519 and https://jwt.io
+For more information on JWT please consult RFC7519 and [jwt.io](https://jwt.io){:target="_blank"}.
 
 #### User JWT-Token
 

--- a/3.5/http/repairs.md
+++ b/3.5/http/repairs.md
@@ -229,4 +229,5 @@ $ wget --method=PUT -qSO - http://localhost:8529/_api/job/152223973119118 | jq .
 
 The final response will look like the response of the `GET` call.
 If an error occurred the response should contain details on how to proceed.
-If in doubt, ask as on Slack: https://arangodb.com/community/
+If in doubt, ask as on Slack:
+[arangodb.com/community/](https://arangodb.com/community/){:target="_blank"}

--- a/3.5/installation.md
+++ b/3.5/installation.md
@@ -21,7 +21,8 @@ is available for the Linux and macOS platforms.
 Besides the official images which are provided for the most popular linux distributions
 there are also a variety of unofficial images provided by the community. We are
 tracking most of the community contributions (including new or updated images) in
-our newsletter: https://www.arangodb.com/category/newsletter/
+our newsletter:
+[www.arangodb.com/category/newsletter/](https://www.arangodb.com/category/newsletter/){:target="_blank"}
 
 - [Linux](installation-linux.html)
 - [macOS](installation-mac-osx.html)

--- a/3.5/release-notes-new-features26.md
+++ b/3.5/release-notes-new-features26.md
@@ -39,7 +39,7 @@ The export API is available at endpoint `POST /_api/export?collection=...`. The 
 same return value structure as the already established cursor API (`POST /_api/cursor`). 
 
 An introduction to the export API is given in this blog post:
-http://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/
+[jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/](http://jsteemann.github.io/blog/2015/04/04/more-efficient-data-exports/){:target="_blank"}
 
 AQL improvements
 ----------------
@@ -62,14 +62,14 @@ This optimization avoids copying intermediate results into subqueries that are n
 by the subquery.
 
 A brief description can be found here:
-http://jsteemann.github.io/blog/2015/05/04/subquery-optimizations/
+[jsteemann.github.io/blog/2015/05/04/subquery-optimizations/](http://jsteemann.github.io/blog/2015/05/04/subquery-optimizations/){:target="_blank"}
 
 ### Return value optimization for AQL queries
 
 This optimization avoids copying the final query result inside the query's main `ReturnNode`.
 
 A brief description can be found here:
-http://jsteemann.github.io/blog/2015/05/04/return-value-optimization-for-aql/
+[jsteemann.github.io/blog/2015/05/04/return-value-optimization-for-aql/](http://jsteemann.github.io/blog/2015/05/04/return-value-optimization-for-aql/){:target="_blank"}
 
 ### Speed up AQL queries containing big `IN` lists for index lookups
 
@@ -78,7 +78,7 @@ These issues have been addressed in 2.6 so using bigger `IN` lists for filtering
 faster.
 
 A brief description can be found here:
-http://jsteemann.github.io/blog/2015/05/07/in-list-improvements/
+[jsteemann.github.io/blog/2015/05/07/in-list-improvements/](http://jsteemann.github.io/blog/2015/05/07/in-list-improvements/){:target="_blank"}
 
 ### Added alternative implementation for AQL COLLECT
 
@@ -110,7 +110,7 @@ suffixing a `COLLECT` statement with `OPTIONS { "method" : "sorted" }`. This wil
 optimizer guesswork and only produce the *sorted* variant of `COLLECT`.
 
 A blog post on the new `COLLECT` implementation can be found here:
-http://jsteemann.github.io/blog/2015/04/22/collecting-with-a-hash-table/
+[jsteemann.github.io/blog/2015/04/22/collecting-with-a-hash-table/](http://jsteemann.github.io/blog/2015/04/22/collecting-with-a-hash-table/){:target="_blank"}
 
 ### Simplified return value syntax for data-modification AQL queries
 
@@ -142,7 +142,7 @@ Still not every construct is allowed after a data-modification clause. For examp
 can be called that may access documents.
 
 More information can be found here:
-http://jsteemann.github.io/blog/2015/03/27/improvements-for-data-modification-queries/
+[jsteemann.github.io/blog/2015/03/27/improvements-for-data-modification-queries/](http://jsteemann.github.io/blog/2015/03/27/improvements-for-data-modification-queries/){:target="_blank"}
 
 ### Added AQL `UPSERT` statement
 
@@ -177,7 +177,7 @@ RETURN { found: OLD, updated: NEW }
 ```
 
 A more detailed description of `UPSERT` can be found here:
-http://jsteemann.github.io/blog/2015/03/27/preview-of-the-upsert-command/
+[jsteemann.github.io/blog/2015/03/27/preview-of-the-upsert-command/](http://jsteemann.github.io/blog/2015/03/27/preview-of-the-upsert-command/){:target="_blank"}
 
 ### Miscellaneous AQL changes
 
@@ -206,18 +206,18 @@ Foxx improvements
 Foxx app manifests can now define configuration options, as well as dependencies on other Foxx apps.
 
 An introduction to Foxx configurations can be found in the blog:
-https://www.arangodb.com/2015/05/reusable-foxx-apps-with-configurations/
+[www.arangodb.com/2015/05/reusable-foxx-apps-with-configurations/](https://www.arangodb.com/2015/05/reusable-foxx-apps-with-configurations/){:target="_blank"}
 
 And the blog post on Foxx dependencies can be found here:
-https://www.arangodb.com/2015/05/foxx-dependencies-for-more-composable-foxx-apps/
+[www.arangodb.com/2015/05/foxx-dependencies-for-more-composable-foxx-apps/](https://www.arangodb.com/2015/05/foxx-dependencies-for-more-composable-foxx-apps/){:target="_blank"}
 
 ### Mocha Tests
 
 You can now write tests for your Foxx apps using the Mocha testing framework:
-https://www.arangodb.com/2015/04/testing-foxx-mocha/
+[www.arangodb.com/2015/04/testing-foxx-mocha/](https://www.arangodb.com/2015/04/testing-foxx-mocha/){:target="_blank"}
 
 A recipe for writing tests for your Foxx apps can be found in the cookbook:
-https://docs.arangodb.com/2.8/Cookbook/FoxxTesting.html
+[www.arangodb.com/docs/2.8/cookbook/foxx-testing.html](https://www.arangodb.com/docs/2.8/cookbook/foxx-testing.html){:target="_blank"}
 
 ### API Documentation
 
@@ -225,7 +225,7 @@ The API documentation has been updated to Swagger 2. You can now also mount API
 documentation in your own Foxx apps.
 
 Also see the blog post introducing this feature:
-https://www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/
+[www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/](https://www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/){:target="_blank"}
 
 ### Custom Scripts and Foxx Queue
 
@@ -289,7 +289,7 @@ option `--on-duplicate`. The option can have one of the following values:
 The default value is `error`.
 
 A few examples for using arangoimp with the `--on-duplicate` option can be found here:
-http://jsteemann.github.io/blog/2015/04/14/updating-documents-with-arangoimp/
+[jsteemann.github.io/blog/2015/04/14/updating-documents-with-arangoimp/](http://jsteemann.github.io/blog/2015/04/14/updating-documents-with-arangoimp/){:target="_blank"}
 
 Miscellaneous changes
 ---------------------

--- a/3.5/release-notes-upgrading-changes34.md
+++ b/3.5/release-notes-upgrading-changes34.md
@@ -878,4 +878,4 @@ removed in future versions of ArangoDB:
 
 * the `foxx-manager` executable is deprecated and will be removed in ArangoDB 4.
   
-  Please use foxx-cli instead: https://docs.arangodb.com/3.4/Manual/Foxx/Deployment/FoxxCLI/
+  Please use [Foxx CLI](programs-foxx-cli.html) instead.

--- a/3.5/security-security-options.md
+++ b/3.5/security-security-options.md
@@ -223,5 +223,6 @@ in an ArangoDB server:
 - `--foxx.store`:
   If set to `false`, this option disables the Foxx app store in ArangoDB's web interface,
   which will also prevent ArangoDB and its web interface from making calls to the main Foxx 
-  application Github repository at https://github.com/arangodb/foxx-apps.
+  application Github repository at
+  [github.com/arangodb/foxx-apps](https://github.com/arangodb/foxx-apps){:target="_blank"}.
   The default value is `true`.

--- a/3.5/upgrading-manually-active-failover.md
+++ b/3.5/upgrading-manually-active-failover.md
@@ -49,7 +49,8 @@ install a specific package using
 $ dpkg -i arangodb3-3.3.16-1_amd64.deb
 ```
 
-after you have downloaded the corresponding file from https://download.arangodb.com/.
+after you have downloaded the corresponding file from
+[download.arangodb.com](https://download.arangodb.com/){:target="_blank"}.
 
 
 #### Stop the Standalone Instance

--- a/3.5/upgrading-manually-cluster.md
+++ b/3.5/upgrading-manually-cluster.md
@@ -56,7 +56,8 @@ install a specific package using
 $ dpkg -i arangodb3-3.3.9-1_amd64.deb
 ```
 
-after you have downloaded the corresponding file from https://download.arangodb.com/.
+after you have downloaded the corresponding file from
+[download.arangodb.com](https://download.arangodb.com/){:target="_blank"}.
 
 #### Stop the Standalone Instance
 

--- a/3.5/upgrading-starter.md
+++ b/3.5/upgrading-starter.md
@@ -65,7 +65,8 @@ install a specific package using
 dpkg -i arangodb3-3.3.14-1_amd64.deb
 ```
 
-after you have downloaded the corresponding file from https://www.arangodb.com/download/.
+after you have downloaded the corresponding file from
+[www.arangodb.com/download/](https://www.arangodb.com/download/){:target="_blank"}.
 
 If you are using the `.tar.gz` distribution (only available from v3.4.0),
 you can simply extract the new archive in a different


### PR DESCRIPTION
Check 3.5\cookbook\use-cases-exporting-data.md in particular, as it uses `[label][n]{:attrs}` syntax