### PR TITLE
Deprecation warning for DATE_COMPARE()

### DIFF
--- a/3.6/aql/functions-date.md
+++ b/3.6/aql/functions-date.md
@@ -579,6 +579,11 @@ with decimal places.
 
 Check if two partial dates match.
 
+{% hint 'warning' %}
+This function is deprecated and will be removed in v4.0.0.
+You may use `DATE_TRUNC(date1, unit1) == DATE_TRUNC(date2, unit2)` instead.
+{% endhint %}
+
 - **date1** (number\|string): numeric timestamp or ISO 8601 date time string
 - **date2** (number\|string): numeric timestamp or ISO 8601 date time string
 - **unitRangeStart** (string): unit to start from, see below


### PR DESCRIPTION
`DATE_COMPARE()` compares datestring substring and can thus not utilize any indexes.

Since we added `DATE_TRUNC()` there is no use for it anymore and therefore I would like to get it removed in v4.0.0.

In Addition, I think we should revise `DATE_ADD()` / `DATE_SUBSTRACT` and `DATE_DIFF()` and possibly change their behavior in v4.0.0 to make them more useful / behave as expected / return correct results. Should warnings be added for that as well, or will it be sufficient to note in the upgrading-changes-40.md in the future?