### PR TITLE
ArangoSearch refactor (part 2)

### DIFF
--- a/3.5/aql/functions-arangosearch.md
+++ b/3.5/aql/functions-arangosearch.md
@@ -381,6 +381,19 @@ PHRASE(doc.text, "lorem", 0, "ipsum", "text_en")
 PHRASE(doc.text, "ipsum", -1, "lorem", "text_en")
 ```
 
+`PHRASE(path, [ phrasePart1, skipTokens1, ... phrasePartN, skipTokensN ], analyzer)`
+
+The `PHRASE()` function also accepts an array as second argument with
+*phrasePart* and *skipTokens* parameters as elements. This syntax variation
+enables the usage of computed expressions:
+
+```js
+LET proximityCondition = [ "foo", ROUND(RAND()*10), "bar" ]
+FOR doc IN viewName
+  SEARCH PHRASE(doc.text, proximityCondition, "text_en")
+  RETURN doc
+```
+
 ### STARTS_WITH()
 
 `STARTS_WITH(path, prefix)`

--- a/3.5/arangosearch-analyzers.md
+++ b/3.5/arangosearch-analyzers.md
@@ -90,7 +90,7 @@ Available normalizations are case conversion and accent removal
 (conversion of characters with diacritical marks to the base characters).
 
 Feature / Analyzer | Identity | N-gram  | Delimiter | Stem | Norm | Text
--------------------|----------|---------|-----------|------|------|-----
+:------------------|:---------|:--------|:----------|:-----|:-----|:----
 **Tokenization**   | No       | No      | (Yes)     | No   | No   | Yes
 **Stemming**       | No       | No      | No        | Yes  | No   | Yes
 **Normalization**  | No       | No      | No        | No   | Yes  | Yes

--- a/3.5/arangosearch-views.md
+++ b/3.5/arangosearch-views.md
@@ -14,7 +14,7 @@ the documents that satisfy the search criteria by relevance.
 Comparison with the [Full-text Index](indexing-fulltext.html):
 
 Feature                           | ArangoSearch | Full-text Index
-----------------------------------|--------------|----------------
+:---------------------------------|:-------------|:---------------
 Term search                       | Yes          | Yes
 Prefix search                     | Yes          | Yes
 Boolean expressions               | Yes          | Restricted

--- a/3.6/aql/functions-arangosearch.md
+++ b/3.6/aql/functions-arangosearch.md
@@ -381,6 +381,19 @@ PHRASE(doc.text, "lorem", 0, "ipsum", "text_en")
 PHRASE(doc.text, "ipsum", -1, "lorem", "text_en")
 ```
 
+`PHRASE(path, [ phrasePart1, skipTokens1, ... phrasePartN, skipTokensN ], analyzer)`
+
+The `PHRASE()` function also accepts an array as second argument with
+*phrasePart* and *skipTokens* parameters as elements. This syntax variation
+enables the usage of computed expressions:
+
+```js
+LET proximityCondition = [ "foo", ROUND(RAND()*10), "bar" ]
+FOR doc IN viewName
+  SEARCH PHRASE(doc.text, proximityCondition, "text_en")
+  RETURN doc
+```
+
 ### STARTS_WITH()
 
 `STARTS_WITH(path, prefix)`

--- a/3.6/arangosearch-analyzers.md
+++ b/3.6/arangosearch-analyzers.md
@@ -90,7 +90,7 @@ Available normalizations are case conversion and accent removal
 (conversion of characters with diacritical marks to the base characters).
 
 Feature / Analyzer | Identity | N-gram  | Delimiter | Stem | Norm | Text
--------------------|----------|---------|-----------|------|------|-----
+:------------------|:---------|:--------|:----------|:-----|:-----|:----
 **Tokenization**   | No       | No      | (Yes)     | No   | No   | Yes
 **Stemming**       | No       | No      | No        | Yes  | No   | Yes
 **Normalization**  | No       | No      | No        | No   | Yes  | Yes

--- a/3.6/arangosearch-views.md
+++ b/3.6/arangosearch-views.md
@@ -14,7 +14,7 @@ the documents that satisfy the search criteria by relevance.
 Comparison with the [Full-text Index](indexing-fulltext.html):
 
 Feature                           | ArangoSearch | Full-text Index
-----------------------------------|--------------|----------------
+:---------------------------------|:-------------|:---------------
 Term search                       | Yes          | Yes
 Prefix search                     | Yes          | Yes
 Boolean expressions               | Yes          | Restricted


### PR DESCRIPTION
- PHRASE() function also accepts an array with phraseParts and skipTokens
- table alignment
- moved questions/notes to https://github.com/arangodb/docs/issues/222