### PR TITLE
Fix redirects for stable = 3.5

### DIFF
--- a/3.4/smartjoins.md
+++ b/3.4/smartjoins.md
@@ -3,7 +3,7 @@ layout: default
 description: SmartJoins allow to execute co-located join operations among identically sharded collections.
 title: SmartJoins for ArangoDB Clusters
 redirect_from:
-  - /3.4/smart-joins.html
+  - /3.4/smart-joins.html # 3.4 -> 3.4
 ---
 SmartJoins
 ==========

--- a/3.5/aql/functions-arangosearch.md
+++ b/3.5/aql/functions-arangosearch.md
@@ -2,6 +2,9 @@
 layout: default
 description: ArangoSearch is integrated into AQL and used mainly through the use of special functions.
 title: ArangoSearch related AQL Functions
+redirect_from:
+  - /3.5/views-arango-search-scorers.html # 3.4 -> 3.5
+  - /3.5/aql/views-arango-search.html # 3.4 -> 3.5
 ---
 ArangoSearch Functions
 ======================

--- a/3.5/aql/operations-search.md
+++ b/3.5/aql/operations-search.md
@@ -4,7 +4,6 @@ description: The SEARCH keyword starts the language construct to filter Views of
 title: The SEARCH operation in AQL
 redirect_from:
   - /3.5/aql/views.html
-  - /3.5/aql/views-arango-search.html
 ---
 SEARCH
 ======

--- a/3.5/arangosearch-analyzers.md
+++ b/3.5/arangosearch-analyzers.md
@@ -2,7 +2,8 @@
 layout: default
 description: Analyzers parse input values and transform them into sets of sub-values, for example by breaking up text into words.
 title: ArangoSearch Analyzers
-redirect_from: /3.5/analyzers.html
+redirect_from:
+  - /3.5/views-arango-search-analyzers.html # 3.4 -> 3.5
 ---
 ArangoSearch Analyzers
 ======================

--- a/3.5/arangosearch-examples.md
+++ b/3.5/arangosearch-examples.md
@@ -2,6 +2,8 @@
 layout: default
 description: View and Analyzer usage examples
 title: ArangoSearch Examples
+redirect_from:
+  - /3.5/views-arango-search-getting-started.html # 3.4 -> 3.5
 ---
 ArangoSearch Examples
 =====================

--- a/3.5/arangosearch-views.md
+++ b/3.5/arangosearch-views.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 description: ArangoSearch Views
-redirect_from: /3.5/views-arango-search-detailed-overview.html
+redirect_from:
+  - /3.5/views-arango-search-detailed-overview.html # 3.4 -> 3.5
 ---
 ArangoSearch Views
 ==================

--- a/3.5/arangosearch.md
+++ b/3.5/arangosearch.md
@@ -2,7 +2,8 @@
 layout: default
 description: ArangoSearch is a C++ based full-text search engine including similarity ranking capabilities natively integrated into ArangoDB.
 title: ArangoSearch - Integrated Full-text Search Engine
-redirect_from: /3.5/views-arangosearch.html
+redirect_from:
+  - /3.5/views-arango-search.html # 3.4 -> 3.5
 ---
 # ArangoSearch
 

--- a/3.5/drivers/java-reference-view-arangosearch.md
+++ b/3.5/drivers/java-reference-view-arangosearch.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 description: These functions implement theHTTP API for ArangoSearch views
-redirect_from: /3.5/java-reference-view-arango-search.html
+redirect_from:
+  - /3.5/java-reference-view-arango-search.html # 3.4 -> 3.5
 ---
 
 # ArangoSearch API

--- a/3.5/http/views-arangosearch.md
+++ b/3.5/http/views-arangosearch.md
@@ -2,7 +2,12 @@
 layout: default
 description: HTTP interface to manage Views of type ArangoSearch
 title: ArangoSearch Views HTTP API
-redirect_from: /3.5/http/views-arango-search.html
+redirect_from:
+  - /3.5/http/views-creating.html # 3.4 -> 3.5
+  - /3.5/http/views-dropping.html # 3.4 -> 3.5
+  - /3.5/http/views-modifying.html # 3.4 -> 3.5
+  - /3.5/http/views-getting.html # 3.4 -> 3.5
+  - /3.5/http/views-arango-search.html # 3.4 -> 3.5
 ---
 ArangoSearch View
 =================

--- a/3.5/smartjoins.md
+++ b/3.5/smartjoins.md
@@ -2,6 +2,8 @@
 layout: default
 description: SmartJoins allow to execute co-located join operations among identically sharded collections.
 title: SmartJoins for ArangoDB Clusters
+redirect_from:
+  - /3.5/smart-joins.html # 3.4 -> 3.4
 ---
 SmartJoins
 ==========

--- a/3.6/aql/functions-arangosearch.md
+++ b/3.6/aql/functions-arangosearch.md
@@ -2,6 +2,9 @@
 layout: default
 description: ArangoSearch is integrated into AQL and used mainly through the use of special functions.
 title: ArangoSearch related AQL Functions
+redirect_from:
+  - /3.6/views-arango-search-scorers.html # 3.4 -> 3.5
+  - /3.6/aql/views-arango-search.html # 3.4 -> 3.5
 ---
 ArangoSearch Functions
 ======================

--- a/3.6/aql/operations-search.md
+++ b/3.6/aql/operations-search.md
@@ -3,8 +3,7 @@ layout: default
 description: The SEARCH keyword starts the language construct to filter Views of type ArangoSearch.
 title: The SEARCH operation in AQL
 redirect_from:
-  - /3.5/aql/views.html
-  - /3.5/aql/views-arango-search.html
+  - /3.6/aql/views.html
 ---
 SEARCH
 ======

--- a/3.6/arangosearch-analyzers.md
+++ b/3.6/arangosearch-analyzers.md
@@ -2,7 +2,8 @@
 layout: default
 description: Analyzers parse input values and transform them into sets of sub-values, for example by breaking up text into words.
 title: ArangoSearch Analyzers
-redirect_from: /3.5/analyzers.html
+redirect_from:
+  - /3.6/views-arango-search-analyzers.html # 3.4 -> 3.5
 ---
 ArangoSearch Analyzers
 ======================

--- a/3.6/arangosearch-examples.md
+++ b/3.6/arangosearch-examples.md
@@ -2,6 +2,8 @@
 layout: default
 description: View and Analyzer usage examples
 title: ArangoSearch Examples
+redirect_from:
+  - /3.6/views-arango-search-getting-started.html # 3.4 -> 3.5
 ---
 ArangoSearch Examples
 =====================

--- a/3.6/arangosearch-views.md
+++ b/3.6/arangosearch-views.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 description: ArangoSearch Views
-redirect_from: /3.5/views-arango-search-detailed-overview.html
+redirect_from:
+  - /3.6/views-arango-search-detailed-overview.html # 3.4 -> 3.5
 ---
 ArangoSearch Views
 ==================

--- a/3.6/arangosearch.md
+++ b/3.6/arangosearch.md
@@ -2,7 +2,8 @@
 layout: default
 description: ArangoSearch is a C++ based full-text search engine including similarity ranking capabilities natively integrated into ArangoDB.
 title: ArangoSearch - Integrated Full-text Search Engine
-redirect_from: /3.5/views-arangosearch.html
+redirect_from:
+  - /3.6/views-arango-search.html # 3.4 -> 3.5
 ---
 # ArangoSearch
 

--- a/3.6/drivers/java-reference-view-arangosearch.md
+++ b/3.6/drivers/java-reference-view-arangosearch.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 description: These functions implement theHTTP API for ArangoSearch views
-redirect_from: /3.5/java-reference-view-arango-search.html
+redirect_from:
+  - /3.6/java-reference-view-arango-search.html # 3.4 -> 3.5
 ---
 
 # ArangoSearch API

--- a/3.6/http/views-arangosearch.md
+++ b/3.6/http/views-arangosearch.md
@@ -2,7 +2,12 @@
 layout: default
 description: HTTP interface to manage Views of type ArangoSearch
 title: ArangoSearch Views HTTP API
-redirect_from: /3.5/http/views-arango-search.html
+redirect_from:
+  - /3.6/http/views-creating.html # 3.4 -> 3.5
+  - /3.6/http/views-dropping.html # 3.4 -> 3.5
+  - /3.6/http/views-modifying.html # 3.4 -> 3.5
+  - /3.6/http/views-getting.html # 3.4 -> 3.5
+  - /3.6/http/views-arango-search.html # 3.4 -> 3.5
 ---
 ArangoSearch View
 =================

--- a/3.6/smartjoins.md
+++ b/3.6/smartjoins.md
@@ -2,6 +2,8 @@
 layout: default
 description: SmartJoins allow to execute co-located join operations among identically sharded collections.
 title: SmartJoins for ArangoDB Clusters
+redirect_from:
+  - /3.6/smart-joins.html # 3.4 -> 3.4
 ---
 SmartJoins
 ==========


### PR DESCRIPTION
To be tested: does the space in front of `#` matter? Do the 3.5 and 3.6 redirects work and not overwrite 3.4 pages?