### PR TITLE
Doc - fixed typo for option: "--auth.jwt-secret"

### DIFF
--- a/3.4/programs-starter-options.md
+++ b/3.4/programs-starter-options.md
@@ -61,9 +61,9 @@ does not make sense. The default 3 allows for the failure of one agent.
 `addr` is the address under which this server is reachable from the
 outside.
 
-Use this option only in the case that `--cluster.agency-size` is set to 1. 
+Use this option only in the case that `--cluster.agency-size` is set to 1.
 In a single agent setup, the sole starter has to start on its own with
-no reliable way to learn its own address. Using this option the master will 
+no reliable way to learn its own address. Using this option the master will
 know under which address it can be reached from the outside. If you specify
 `localhost` here, then all instances must run on the local machine.
 
@@ -95,7 +95,7 @@ a docker container, the starter will auto-detect its container name.
 The arango starter by default creates a cluster that uses no authentication.
 
 To create a cluster that uses authentication, create a file containing a random JWT secret (single line)
-and pass it through the `--auth.jwt-secret-path` option.
+and pass it through the `--auth.jwt-secret` option.
 
 For example:
 

--- a/3.5/programs-starter-options.md
+++ b/3.5/programs-starter-options.md
@@ -61,9 +61,9 @@ does not make sense. The default 3 allows for the failure of one agent.
 `addr` is the address under which this server is reachable from the
 outside.
 
-Use this option only in the case that `--cluster.agency-size` is set to 1. 
+Use this option only in the case that `--cluster.agency-size` is set to 1.
 In a single agent setup, the sole starter has to start on its own with
-no reliable way to learn its own address. Using this option the master will 
+no reliable way to learn its own address. Using this option the master will
 know under which address it can be reached from the outside. If you specify
 `localhost` here, then all instances must run on the local machine.
 
@@ -95,7 +95,7 @@ a docker container, the starter will auto-detect its container name.
 The arango starter by default creates a cluster that uses no authentication.
 
 To create a cluster that uses authentication, create a file containing a random JWT secret (single line)
-and pass it through the `--auth.jwt-secret-path` option.
+and pass it through the `--auth.jwt-secret` option.
 
 For example:
 

--- a/3.6/programs-starter-options.md
+++ b/3.6/programs-starter-options.md
@@ -61,9 +61,9 @@ does not make sense. The default 3 allows for the failure of one agent.
 `addr` is the address under which this server is reachable from the
 outside.
 
-Use this option only in the case that `--cluster.agency-size` is set to 1. 
+Use this option only in the case that `--cluster.agency-size` is set to 1.
 In a single agent setup, the sole starter has to start on its own with
-no reliable way to learn its own address. Using this option the master will 
+no reliable way to learn its own address. Using this option the master will
 know under which address it can be reached from the outside. If you specify
 `localhost` here, then all instances must run on the local machine.
 
@@ -95,7 +95,7 @@ a docker container, the starter will auto-detect its container name.
 The arango starter by default creates a cluster that uses no authentication.
 
 To create a cluster that uses authentication, create a file containing a random JWT secret (single line)
-and pass it through the `--auth.jwt-secret-path` option.
+and pass it through the `--auth.jwt-secret` option.
 
 For example:
 


### PR DESCRIPTION
fixed in:
-3.4
-3.5
-devel