### PR TITLE
Document subquery splicing

### DIFF
--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -471,6 +471,13 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   the output from the `LimitNode` is similar in size to the input. In exceptionally rare 
   cases, this rule could result in some small slowdown. If observed, one can 
   disable the rule for the affected query at the cost of increased memory usage.
+* `splice-subqueries`: will appear when a subquery has been spliced into the
+  surrounding query. This optimisation is applied after all other optimisations,
+  and reduces overhead for executing subqueries.
+  Only suitable subqueries can be spliced. A subquery becomes unsuitable if it
+  contains a *LIMIT*, *REMOTE*, *GATHER*, *NORESULTS*, or a *COLLECT*
+  node where the operation is not *COUNT*.
+  A subquery *also* becomes unsuitable if it is contained in an unsuitable subquery.
 
 The following optimizer rules may appear in the `rules` attribute of cluster plans:
 

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -292,7 +292,7 @@ the `warnings` attribute of the `explain` result:
     @endDocuBlock AQLEXP_10_explainWarn
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
-There is an upper bound on the number of warning a query may produce. If that
+There is an upper bound on the number of warnings a query may produce. If that
 bound is reached, no further warnings will be returned.
 
 

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -472,10 +472,10 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   cases, this rule could result in some small slowdown. If observed, one can 
   disable the rule for the affected query at the cost of increased memory usage.
 * `splice-subqueries`: will appear when a subquery has been spliced into the
-  surrounding query. This optimisation is applied after all other optimisations,
+  surrounding query. This optimization is applied after all other optimizations,
   and reduces overhead for executing subqueries.
   Only suitable subqueries can be spliced. A subquery becomes unsuitable if it
-  contains a *LIMIT*, *REMOTE*, *GATHER*, *NORESULTS*, or a *COLLECT*
+  contains a *LIMIT*, *REMOTE*, *GATHER* or a *COLLECT*
   node where the operation is not *COUNT*.
   A subquery *also* becomes unsuitable if it is contained in an unsuitable subquery.
 


### PR DESCRIPTION
This adds documentation for the new optimizer rule that splices subqueries. This is a 3.6+ feature.

I also fixed a typo on the way.