### PR TITLE
Backup: Rclone config requires quotes around true and false / multi config

### DIFF
--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -241,15 +241,26 @@ be used for restores until the download has finished.
 {% endhint %}
 
 To configure Rclone, use the `rclone-config-file` startup option to
-point arangobackup to a JSON configuration file. The option names and
-values in the [Rclone documentation](https://rclone.org/docs/){:target="_blank"}
+point arangobackup to a JSON configuration file. The expected format
+is an object with user-chosen remote names as attribute keys, and the
+actual configuration as attribute value (a nested object). The option
+names and values in the [Rclone documentation](https://rclone.org/docs/){:target="_blank"}
 directly translate into attribute/value pairs in the JSON file.
 Note that `"true"` and `"false"` must be enclosed by double quotes.
 
+```json
+{
+  "my-remote": {
+    "option": "value",
+    "boolean": "true"
+  }
+}
+```
+
 The remote path can be specified via the `remote-path` startup option.
 The syntax for remote paths is `remote:path`, where `remote` is the
-name of a top-level attribute in the configuration file, `path`
-is a remote or local path, and both are separated by a colon.
+name of a top-level attribute in the configuration file, `path` is a
+remote path, and both are separated by a colon (e.g. `my-remote:/a/b/c`).
 
 ### S3
 

--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -181,9 +181,9 @@ The output will look like this:
 2019-07-30T08:11:09Z [17465] INFO [24d75] {backup} SNGL Status: COMPLETED
 2019-07-30T08:11:09Z [17465] INFO [68cc8] {backup} Last progress update 2019-07-30T08:10:10Z: 5/5 files done
 ```
-See the [Download command](programs-arangobackup-examples.html#download) for details
-about the `remote.json` file to configure the remote site for `rclone`
-for different protocols than `S3`.
+
+See the [Download command](#download) for details about the `remote.json`
+file to configure the remote site for `rclone` for different protocols than S3.
 
 Download
 --------
@@ -225,7 +225,8 @@ The output will look like this:
 2019-07-30T08:18:07Z [17753] INFO [68cc8] {backup} Last progress update 2019-07-30T08:14:43Z: 5/5 files done
 ```
 
-### RClone configuration examples
+RClone configuration examples
+-----------------------------
 
 Enterprise Editions of ArangoDB come with a bundled version of the
 versatile open-source remote file sync program
@@ -275,9 +276,9 @@ The file `my-local.json` could look like this:
 {
   "my-local": {
     "type": "local",
-    "copy-links": false,
-    "links": false,
-    "one_file_system": false
+    "copy-links": "false",
+    "links": "false",
+    "one_file_system": "false"
   }
 }
 ```

--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -182,7 +182,7 @@ The output will look like this:
 2019-07-30T08:11:09Z [17465] INFO [68cc8] {backup} Last progress update 2019-07-30T08:10:10Z: 5/5 files done
 ```
 
-See the [Download command](#download) for details about the `remote.json`
+See [Rclone Configuration](#rclone-configuration) for details about the `remote.json`
 file to configure the remote site for `rclone` for different protocols than S3.
 
 Download
@@ -225,8 +225,8 @@ The output will look like this:
 2019-07-30T08:18:07Z [17753] INFO [68cc8] {backup} Last progress update 2019-07-30T08:14:43Z: 5/5 files done
 ```
 
-Rclone configuration examples
------------------------------
+Rclone Configuration
+--------------------
 
 [Rclone](https://rclone.org) is a versatile open-source remote file
 sync program that can deal with over 30 different remote file IO

--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -228,9 +228,9 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org) is a versatile open-source remote file
-sync program that can deal with over 30 different remote file IO
-protocols. Enterprise Editions of ArangoDB come with a bundled version
+[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+remote file sync program that can deal with over 30 different remote file
+IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
 both download and upload hot backup sets to and from local and cloud
 operated storage resources.
@@ -285,7 +285,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3).
+[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -307,7 +307,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local).
+[rclone.org/local](https://rclone.org/local){:target="_blank"}.
 
 ### WebDAV
 
@@ -330,4 +330,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav).
+[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.

--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -225,22 +225,36 @@ The output will look like this:
 2019-07-30T08:18:07Z [17753] INFO [68cc8] {backup} Last progress update 2019-07-30T08:14:43Z: 5/5 files done
 ```
 
-RClone configuration examples
+Rclone configuration examples
 -----------------------------
 
-Enterprise Editions of ArangoDB come with a bundled version of the
-versatile open-source remote file sync program
-[rclone](https://rclone.org), which is distributed under the MIT
-license. It is used to both download and upload hot backup sets to and
-from local and cloud operated storage resources. 
+[Rclone](https://rclone.org) is a versatile open-source remote file
+sync program that can deal with over 30 different remote file IO
+protocols. Enterprise Editions of ArangoDB come with a bundled version
+of Rclone, which is distributed under the MIT license. It is used to
+both download and upload hot backup sets to and from local and cloud
+operated storage resources.
 
-Hot backup directories, which are subject to an ongoing download cannot be
-used for restores until the download has finished.
+{% hint 'info' %}
+Hot backup directories, which are subject to an ongoing download cannot
+be used for restores until the download has finished.
+{% endhint %}
+
+To configure Rclone, use the `rclone-config-file` startup option to
+point arangobackup to a JSON configuration file. The option names and
+values in the [Rclone documentation](https://rclone.org/docs/){:target="_blank"}
+directly translate into attribute/value pairs in the JSON file.
+Note that `"true"` and `"false"` must be enclosed by double quotes.
+
+The remote path can be specified via the `remote-path` startup option.
+The syntax for remote paths is `remote:path`, where `remote` is the
+name of a top-level attribute in the configuration file, `path`
+is a remote or local path, and both are separated by a colon.
 
 ### S3
 
 ```bash 
-... --rclone-config-file ~/my-s3.json --remote-path my-s3://remote-endpoint/remote-directory
+… --rclone-config-file ~/my-s3.json --remote-path my-s3://remote-endpoint/remote-directory
 ```
 
 The file `my-s3.json` could look like this:
@@ -260,14 +274,12 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
+[rclone.org/s3](https://rclone.org/s3).
 
 ### Locally mounted local or remote volumes
 
 ```bash 
-... --rclone-config-file ~/my-local.json --remote-path my-local://mnt/backup/arangodb
+… --rclone-config-file ~/my-local.json --remote-path my-local://mnt/backup/arangodb
 ```
 
 The file `my-local.json` could look like this:
@@ -284,14 +296,12 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
+[rclone.org/local](https://rclone.org/local).
 
 ### WebDAV
 
 ```bash 
-... --rclone-config-file ~/my-dav.json --remote-path my-dav://remote-endpoint/remote-directory
+… --rclone-config-file ~/my-dav.json --remote-path my-dav://remote-endpoint/remote-directory
 ```
 
 Thie file `my-dav.json` could look like this:
@@ -309,14 +319,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
-
-### More examples
-
-`rclone` is a very flexible tool that can deal with over 30 different
-remote file IO protocols. Every industry standard is covered and
-documented to some detail including specificities of individual
-providers. Please refer to the [rclone documentation](https://rclone.org) 
-for more details.
+[rclone.org/webdav](https://rclone.org/webdav).

--- a/3.6/programs-arangobackup-examples.md
+++ b/3.6/programs-arangobackup-examples.md
@@ -228,9 +228,9 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org) is a versatile open-source remote file
-sync program that can deal with over 30 different remote file IO
-protocols. Enterprise Editions of ArangoDB come with a bundled version
+[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+remote file sync program that can deal with over 30 different remote file
+IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
 both download and upload hot backup sets to and from local and cloud
 operated storage resources.
@@ -285,7 +285,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3).
+[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -307,7 +307,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local).
+[rclone.org/local](https://rclone.org/local){:target="_blank"}.
 
 ### WebDAV
 
@@ -330,4 +330,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav).
+[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.

--- a/3.6/programs-arangobackup-examples.md
+++ b/3.6/programs-arangobackup-examples.md
@@ -181,9 +181,9 @@ The output will look like this:
 2019-07-30T08:11:09Z [17465] INFO [24d75] {backup} SNGL Status: COMPLETED
 2019-07-30T08:11:09Z [17465] INFO [68cc8] {backup} Last progress update 2019-07-30T08:10:10Z: 5/5 files done
 ```
-See the [Download command](programs-arangobackup-examples.html#download) for details
-about the `remote.json` file to configure the remote site for `rclone`
-for different protocols than `S3`.
+
+See [Rclone Configuration](#rclone-configuration) for details about the `remote.json`
+file to configure the remote site for `rclone` for different protocols than S3.
 
 Download
 --------
@@ -225,21 +225,47 @@ The output will look like this:
 2019-07-30T08:18:07Z [17753] INFO [68cc8] {backup} Last progress update 2019-07-30T08:14:43Z: 5/5 files done
 ```
 
-### RClone configuration examples
+Rclone Configuration
+--------------------
 
-Enterprise Editions of ArangoDB come with a bundled version of the
-versatile open-source remote file sync program
-[rclone](https://rclone.org), which is distributed under the MIT
-license. It is used to both download and upload hot backup sets to and
-from local and cloud operated storage resources. 
+[Rclone](https://rclone.org) is a versatile open-source remote file
+sync program that can deal with over 30 different remote file IO
+protocols. Enterprise Editions of ArangoDB come with a bundled version
+of Rclone, which is distributed under the MIT license. It is used to
+both download and upload hot backup sets to and from local and cloud
+operated storage resources.
 
-Hot backup directories, which are subject to an ongoing download cannot be
-used for restores until the download has finished.
+{% hint 'info' %}
+Hot backup directories, which are subject to an ongoing download cannot
+be used for restores until the download has finished.
+{% endhint %}
+
+To configure Rclone, use the `rclone-config-file` startup option to
+point arangobackup to a JSON configuration file. The expected format
+is an object with user-chosen remote names as attribute keys, and the
+actual configuration as attribute value (a nested object). The option
+names and values in the [Rclone documentation](https://rclone.org/docs/){:target="_blank"}
+directly translate into attribute/value pairs in the JSON file.
+Note that `"true"` and `"false"` must be enclosed by double quotes.
+
+```json
+{
+  "my-remote": {
+    "option": "value",
+    "boolean": "true"
+  }
+}
+```
+
+The remote path can be specified via the `remote-path` startup option.
+The syntax for remote paths is `remote:path`, where `remote` is the
+name of a top-level attribute in the configuration file, `path` is a
+remote path, and both are separated by a colon (e.g. `my-remote:/a/b/c`).
 
 ### S3
 
 ```bash 
-... --rclone-config-file ~/my-s3.json --remote-path my-s3://remote-endpoint/remote-directory
+… --rclone-config-file ~/my-s3.json --remote-path my-s3://remote-endpoint/remote-directory
 ```
 
 The file `my-s3.json` could look like this:
@@ -259,14 +285,12 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
+[rclone.org/s3](https://rclone.org/s3).
 
 ### Locally mounted local or remote volumes
 
 ```bash 
-... --rclone-config-file ~/my-local.json --remote-path my-local://mnt/backup/arangodb
+… --rclone-config-file ~/my-local.json --remote-path my-local://mnt/backup/arangodb
 ```
 
 The file `my-local.json` could look like this:
@@ -275,22 +299,20 @@ The file `my-local.json` could look like this:
 {
   "my-local": {
     "type": "local",
-    "copy-links": false,
-    "links": false,
-    "one_file_system": false
+    "copy-links": "false",
+    "links": "false",
+    "one_file_system": "false"
   }
 }
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
+[rclone.org/local](https://rclone.org/local).
 
 ### WebDAV
 
 ```bash 
-... --rclone-config-file ~/my-dav.json --remote-path my-dav://remote-endpoint/remote-directory
+… --rclone-config-file ~/my-dav.json --remote-path my-dav://remote-endpoint/remote-directory
 ```
 
 Thie file `my-dav.json` could look like this:
@@ -308,14 +330,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav). The option names and values in the
-_rclone_ configuration directly translate into attribute/value pairs in
-the JSON file.
-
-### More examples
-
-`rclone` is a very flexible tool that can deal with over 30 different
-remote file IO protocols. Every industry standard is covered and
-documented to some detail including specificities of individual
-providers. Please refer to the [rclone documentation](https://rclone.org) 
-for more details.
+[rclone.org/webdav](https://rclone.org/webdav).


### PR DESCRIPTION
- [x] true/false need to be strings
- [x] fix headline level
- [x] explain multi-config
  So the syntax is `<key>:<path>`  where `<key>` is a top level attribute key (here: `my-local`)?

  ```
  {
    "my-local": {
      "type": "local",
      "copy-links": "false",
      "links": "false",
      "one_file_system": "false"
    }
  }
  ```

