### PR TITLE
Adjust Gemfile.lock to require newer nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       filesize (~> 0.1)
       jekyll (>= 3.6, < 5.0)
       json (~> 2.0)
-      nokogiri (~> 1.6)
+      nokogiri (~> 1.10.4)
       progressbar (~> 1.9)
       verbal_expressions (~> 0.1.5)
     jekyll-redirect-from (0.15.0)


### PR DESCRIPTION
jekyll-algolia plugin is not maintained, hence no deps bump to be expected