### PR TITLE
add documentation for query timeout

### DIFF
--- a/3.6/aql/invocation-with-arangosh.md
+++ b/3.6/aql/invocation-with-arangosh.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: Within the ArangoDB shell, the _query and _createStatement methods of thedb object can be used to execute AQL queries
+description: Within the ArangoDB shell, the _query and _createStatement methods of the db object can be used to execute AQL queries
 ---
 Executing queries from Arangosh
 ===============================
@@ -16,6 +16,7 @@ One can execute queries with the *_query* method of the *db* object.
 This will run the specified query in the context of the currently
 selected database and return the query results in a cursor. The results of the cursor
 can be printed using its *toArray* method:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}    
     @startDocuBlockInline 01_workWithAQL_all
     @EXAMPLE_ARANGOSH_OUTPUT{01_workWithAQL_all}
@@ -27,10 +28,12 @@ can be printed using its *toArray* method:
     @endDocuBlock 01_workWithAQL_all
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 ### db._query Bind parameters
 
 To pass bind parameters into a query, they can be specified as second argument to the
 *_query* method:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 02_workWithAQL_bindValues
     @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_bindValues}
@@ -43,6 +46,7 @@ To pass bind parameters into a query, they can be specified as second argument t
     @endDocuBlock 02_workWithAQL_bindValues
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 ### ES6 template strings
 
 It is also possible to use ES6 template strings for generating AQL queries. There is
@@ -59,6 +63,7 @@ aql`FOR c IN mycollection FILTER c._key == ${key} RETURN c._key`;
   } 
 }
 ```
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 02_workWithAQL_aqlQuery
     @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_aqlQuery}
@@ -70,8 +75,10 @@ aql`FOR c IN mycollection FILTER c._key == ${key} RETURN c._key`;
     @endDocuBlock 02_workWithAQL_aqlQuery
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
-Arbitrary JavaScript expressions can be used in queries that are generated with the 
+
+Arbitrary JavaScript expressions can be used in queries that are generated with the
 *aql* template string generator. Collection objects are handled automatically:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 02_workWithAQL_aqlCollectionQuery
     @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_aqlCollectionQuery}
@@ -82,13 +89,15 @@ Arbitrary JavaScript expressions can be used in queries that are generated with 
     @endDocuBlock 02_workWithAQL_aqlCollectionQuery
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 Note: data-modification AQL queries normally do not return a result (unless the AQL query 
 contains an extra *RETURN* statement). When not using a *RETURN* statement in the query, the 
 *toArray* method will return an empty array.
 
 ### Statistics and extra Information
- 
+
 It is always possible to retrieve statistics for a query with the *getExtra* method:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 03_workWithAQL_getExtra
     @EXAMPLE_ARANGOSH_OUTPUT{03_workWithAQL_getExtra}
@@ -100,6 +109,7 @@ It is always possible to retrieve statistics for a query with the *getExtra* met
     @endDocuBlock 03_workWithAQL_getExtra
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 The meaning of the statistics values is described in [Execution statistics](execution-and-performance-query-statistics.html).
 You also will find warnings in here; If you're designing queries on the shell be sure to also look at it.
 
@@ -111,6 +121,7 @@ allowed to use. When a single AQL query reaches the specified limit value,
 the query will be aborted with a *resource limit exceeded* exception. In a 
 cluster, the memory accounting is done per shard, so the limit value is 
 effectively a memory limit per query per shard.
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 02_workWithAQL_memoryLimit
     @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_memoryLimit}
@@ -122,6 +133,7 @@ effectively a memory limit per query per shard.
     @endDocuBlock 02_workWithAQL_memoryLimit
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 If no memory limit is specified, then the server default value (controlled by
 startup option *--query.memory-limit* will be used for restricting the maximum amount 
 of memory the query can use. A memory limit value of *0* means that the maximum
@@ -170,7 +182,7 @@ There are further options that can be passed in the *options* attribute of the *
   after the query is finished. 
   The default value is *false*
 
-- *timeout*: The query has to be executed within the given time or it will be killed.
+- *timeout*: The query has to be executed within the given time (in seconds) or it will be killed.
   The default is not to use a timeout.
 
 The following additional attributes can be passed to queries in the RocksDB storage engine:
@@ -199,6 +211,7 @@ The *_query* method is a shorthand for creating an ArangoStatement object,
 executing it and iterating over the resulting cursor. If more control over the
 result set iteration is needed, it is recommended to first create an
 ArangoStatement object as follows:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 04_workWithAQL_statements1
     @EXAMPLE_ARANGOSH_OUTPUT{04_workWithAQL_statements1}
@@ -208,7 +221,9 @@ ArangoStatement object as follows:
     @endDocuBlock 04_workWithAQL_statements1
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 To execute the query, use the *execute* method of the statement:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements2
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements2}
@@ -218,12 +233,14 @@ To execute the query, use the *execute* method of the statement:
     @endDocuBlock 05_workWithAQL_statements2
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 ### Cursors
 
 Once the query executed the query results are available in a cursor. 
 The cursor can return all its results at once using the *toArray* method.
 This is a short-cut that you can use if you want to access the full result
 set without iterating over it yourself.
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements3
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements3}
@@ -234,7 +251,6 @@ set without iterating over it yourself.
     @endDocuBlock 05_workWithAQL_statements3
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}    
-
 
 Cursors can also be used to iterate over the result set document-by-document.
 To do so, use the *hasNext* and *next* methods of the cursor:
@@ -248,10 +264,11 @@ To do so, use the *hasNext* and *next* methods of the cursor:
     @endDocuBlock 05_workWithAQL_statements4
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 Please note that you can iterate over the results of a cursor only once, and that
 the cursor will be empty when you have fully iterated over it. To iterate over
 the results again, the query needs to be re-executed.
- 
+
 Additionally, the iteration can be done in a forward-only fashion. There is no 
 backwards iteration or random access to elements in a cursor.    
 
@@ -259,6 +276,7 @@ backwards iteration or random access to elements in a cursor.
 
 To execute an AQL query using bind parameters, you need to create a statement first
 and then bind the parameters to it before execution:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements5
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements5}
@@ -271,8 +289,10 @@ and then bind the parameters to it before execution:
     @endDocuBlock 05_workWithAQL_statements5
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 The cursor results can then be dumped or iterated over as usual, e.g.:
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}    
+
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements6
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements6}
     ~var stmt = db._createStatement( { "query": "FOR i IN [ @one, @two ] RETURN i * 2" } );
@@ -284,7 +304,9 @@ The cursor results can then be dumped or iterated over as usual, e.g.:
     @endDocuBlock 05_workWithAQL_statements6
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
-or 
+
+or
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements7
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements7}
@@ -297,9 +319,11 @@ or
     @endDocuBlock 05_workWithAQL_statements7
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 Please note that bind parameters can also be passed into the *_createStatement* method directly,
 making it a bit more convenient:
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}    
+
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements8
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements8}
     |stmt = db._createStatement( { 
@@ -313,11 +337,13 @@ making it a bit more convenient:
     @endDocuBlock 05_workWithAQL_statements8
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 ### Counting with a cursor
-    
+
 Cursors also optionally provide the total number of results. By default, they do not. 
 To make the server return the total number of results, you may set the *count* attribute to 
 *true* when creating a statement:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}    
     @startDocuBlockInline 05_workWithAQL_statements9
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements9}
@@ -328,8 +354,10 @@ To make the server return the total number of results, you may set the *count* a
     @endDocuBlock 05_workWithAQL_statements9
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 After executing this query, you can use the *count* method of the cursor to get the 
 number of total results from the result set:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 05_workWithAQL_statements10
     @EXAMPLE_ARANGOSH_OUTPUT{05_workWithAQL_statements10}
@@ -340,6 +368,7 @@ number of total results from the result set:
     @endDocuBlock 05_workWithAQL_statements10
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 Please note that the *count* method returns nothing if you did not specify the *count*
 attribute when creating the query.
 
@@ -357,13 +386,13 @@ This may change in the future. Future versions of ArangoDB may create result set
 on the server-side and may be able to apply optimizations if a result set is not fully fetched by 
 a client.
 
-
 ### Using cursors to obtain additional information on internal timings
 
 Cursors can also optionally provide statistics of the internal execution phases. By default, they do not. 
 To get to know how long parsing, optimization, instantiation and execution took,
 make the server return that by setting the *profile* attribute to
 *true* when creating a statement:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 06_workWithAQL_statements11
     @EXAMPLE_ARANGOSH_OUTPUT{06_workWithAQL_statements11}
@@ -374,8 +403,10 @@ make the server return that by setting the *profile* attribute to
     @endDocuBlock 06_workWithAQL_statements11
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 After executing this query, you can use the *getExtra()* method of the cursor to get the 
 produced statistics:
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 06_workWithAQL_statements12
     @EXAMPLE_ARANGOSH_OUTPUT{06_workWithAQL_statements12}
@@ -386,11 +417,13 @@ produced statistics:
     @endDocuBlock 06_workWithAQL_statements12
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
+
 Query validation
 ----------------
 
 The *_parse* method of the *db* object can be used to parse and validate a
 query syntactically, without actually executing it.
+
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline 06_workWithAQL_statements13
     @EXAMPLE_ARANGOSH_OUTPUT{06_workWithAQL_statements13}

--- a/3.6/aql/invocation-with-arangosh.md
+++ b/3.6/aql/invocation-with-arangosh.md
@@ -170,6 +170,9 @@ There are further options that can be passed in the *options* attribute of the *
   after the query is finished. 
   The default value is *false*
 
+- *timeout*: The query has to be executed within the given time or it will be killed.
+  The default is not to use a timeout.
+
 The following additional attributes can be passed to queries in the RocksDB storage engine:
  
 - *maxTransactionSize*: transaction size limit in bytes

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -132,7 +132,10 @@ into a set of equal-distance buckets.
 
 ### Miscellaneous AQL changes
 
-ArangoDB 3.6 provides a new AQL function `GEO_AREA` for area calculations.
+ArangoDB 3.6 provides the following new AQL functionality:
+
+- function `GEO_AREA` for area calculations
+- query option `timeout` to restrict the execution time.
 
 HTTP API extensions
 -------------------

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -134,8 +134,8 @@ into a set of equal-distance buckets.
 
 ArangoDB 3.6 provides the following new AQL functionality:
 
-- function `GEO_AREA` for area calculations
-- query option `timeout` to restrict the execution time.
+- a function `GEO_AREA()` for area calculations
+- a query option `timeout` to restrict the execution to a given time in seconds
 
 HTTP API extensions
 -------------------


### PR DESCRIPTION
I think https://www.arangodb.com/docs/stable/aql/invocation-with-arangosh.html#setting-options is not the best location for options. I think It is a bit too hidden.