### PR TITLE
Clarified two things about splice-subqueries

### DIFF
--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -640,8 +640,8 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
 - `splice-subqueries`:
   will appear when a subquery has been spliced into the surrounding query.
   Only suitable subqueries can be spliced.
-  A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
-  node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+  A subquery becomes unsuitable if it contains a `LIMIT` node or a
+  `COLLECT WITH COUNT INTO …` construct (but not due to a
   `COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
   unsuitable if it is contained in a (sub)query containing unsuitable parts
   *after* the subquery.

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -577,8 +577,9 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
 - `splice-subqueries`:
   will appear when a subquery has been spliced into the surrounding query.
   Only suitable subqueries can be spliced.
-  A subquery becomes unsuitable if it contains a *LIMIT*, *REMOTE*, *GATHER*
-  node or a *COLLECT WITH COUNT INTO* construct. A subquery *also* becomes
+  A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
+  node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+  `COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
   unsuitable if it is contained in a (sub)query containing unsuitable parts
   *after* the subquery.
 

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -579,7 +579,8 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   Only suitable subqueries can be spliced.
   A subquery becomes unsuitable if it contains a *LIMIT*, *REMOTE*, *GATHER*
   or a *COLLECT WITH COUNT INTO* node. A subquery *also* becomes unsuitable if
-  it is contained in a subquery containing unsuitable nodes.
+  it is contained in a (sub)query containing unsuitable nodes *after* the
+  subquery.
 
   This optimization is applied after all other optimizations, and reduces
   overhead for executing subqueries by inlining the execution. This mainly

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -411,7 +411,9 @@ For queries in the cluster, the following nodes may appear in execution plans:
 
 - **GatherNode**:
   used on a coordinator to aggregate results from one or many shards
-  into a combined stream of results.
+  into a combined stream of results. Parallelizes work for certain types
+  of queries when there are multiple database servers involved
+  (`GATHER   /* parallel */` in query explain).
 
 - **DistributeNode**:
   used on a coordinator to fan-out data to one or multiple shards,

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -364,12 +364,18 @@ The following execution node types will appear in the output of `explain`:
   evaluates an expression. The expression result may be used by
   other nodes, e.g. *FilterNode*, *EnumerateListNode*, *SortNode* etc.
 
+- **CollectNode**:
+  
+
 - **EnumerateCollectionNode**:
   enumeration over documents of a collection (given in its *collection*
   attribute) without using an index.
 
 - **EnumerateListNode**:
   enumeration over a list of (non-collection) values.
+
+- **EnumerateViewNode**:
+  
 
 - **FilterNode**:
   only lets values pass that satisfy a filter condition. Will appear once
@@ -384,9 +390,15 @@ The following execution node types will appear in the output of `explain`:
   inserts documents into a collection (given in its *collection* attribute).
   Will appear exactly once in a query that contains an *INSERT* statement.
 
+- **KShortestPathsNode**:
+  
+
 - **LimitNode**:
   limits the number of results passed to other processing steps. Will appear
   once per *LIMIT* statement.
+
+- **MaterializeNode**:
+  
 
 - **RemoveNode**:
   removes documents from a collection (given in its *collection* attribute).
@@ -405,11 +417,23 @@ The following execution node types will appear in the output of `explain`:
   used as input for other processing steps. Each execution plan will contain
   exactly one *SingletonNode* as its top node.
 
+- **ShortestPathNode**:
+  
+
 - **SortNode**:
   performs a sort of its input values.
 
+- **SubqueryEndNode**:
+  
+
 - **SubqueryNode**:
   executes a subquery.
+
+- **SubqueryStartNode**:
+  
+
+- **TraversalNode**:
+  
 
 - **UpdateNode**:
   updates documents in a collection (given in its *collection* attribute).
@@ -424,6 +448,9 @@ For queries in the cluster, the following nodes may appear in execution plans:
 - **DistributeNode**:
   used on a coordinator to fan-out data to one or multiple shards,
   taking into account a collection's shard key.
+
+- **DistributeConsumer**:
+  
 
 - **GatherNode**:
   used on a coordinator to aggregate results from one or many shards

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -578,9 +578,9 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   will appear when a subquery has been spliced into the surrounding query.
   Only suitable subqueries can be spliced.
   A subquery becomes unsuitable if it contains a *LIMIT*, *REMOTE*, *GATHER*
-  or a *COLLECT WITH COUNT INTO* node. A subquery *also* becomes unsuitable if
-  it is contained in a (sub)query containing unsuitable nodes *after* the
-  subquery.
+  node or a *COLLECT WITH COUNT INTO* construct. A subquery *also* becomes
+  unsuitable if it is contained in a (sub)query containing unsuitable parts
+  *after* the subquery.
 
   This optimization is applied after all other optimizations, and reduces
   overhead for executing subqueries by inlining the execution. This mainly

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -356,19 +356,17 @@ List of execution nodes
 
 The following execution node types will appear in the output of `explain`:
 
-- **SingletonNode**:
-  the purpose of a *SingletonNode* is to produce an empty document that is
-  used as input for other processing steps. Each execution plan will contain
-  exactly one *SingletonNode* as its top node.
+- **AggregateNode**:
+  aggregates its input and produces new output variables. This will appear
+  once per *COLLECT* statement.
+
+- **CalculationNode**:
+  evaluates an expression. The expression result may be used by
+  other nodes, e.g. *FilterNode*, *EnumerateListNode*, *SortNode* etc.
 
 - **EnumerateCollectionNode**:
   enumeration over documents of a collection (given in its *collection*
   attribute) without using an index.
-
-- **IndexNode**:
-  enumeration over one or many indexes (given in its *indexes* attribute)
-  of a collection. The index ranges are specified in the *condition* attribute
-  of the node.
 
 - **EnumerateListNode**:
   enumeration over a list of (non-collection) values.
@@ -377,31 +375,18 @@ The following execution node types will appear in the output of `explain`:
   only lets values pass that satisfy a filter condition. Will appear once
   per *FILTER* statement.
 
-- **LimitNode**:
-  limits the number of results passed to other processing steps. Will appear
-  once per *LIMIT* statement.
-
-- **CalculationNode**:
-  evaluates an expression. The expression result may be used by
-  other nodes, e.g. *FilterNode*, *EnumerateListNode*, *SortNode* etc.
-
-- **SubqueryNode**:
-  executes a subquery.
-
-- **SortNode**:
-  performs a sort of its input values.
-
-- **AggregateNode**:
-  aggregates its input and produces new output variables. This will appear
-  once per *COLLECT* statement.
-
-- **ReturnNode**:
-  returns data to the caller. Will appear in each read-only query at
-  least once. Subqueries will also contain *ReturnNode*s.
+- **IndexNode**:
+  enumeration over one or many indexes (given in its *indexes* attribute)
+  of a collection. The index ranges are specified in the *condition* attribute
+  of the node.
 
 - **InsertNode**:
   inserts documents into a collection (given in its *collection* attribute).
   Will appear exactly once in a query that contains an *INSERT* statement.
+
+- **LimitNode**:
+  limits the number of results passed to other processing steps. Will appear
+  once per *LIMIT* statement.
 
 - **RemoveNode**:
   removes documents from a collection (given in its *collection* attribute).
@@ -410,6 +395,21 @@ The following execution node types will appear in the output of `explain`:
 - **ReplaceNode**:
   replaces documents in a collection (given in its *collection* attribute).
   Will appear exactly once in a query that contains a *REPLACE* statement.
+
+- **ReturnNode**:
+  returns data to the caller. Will appear in each read-only query at
+  least once. Subqueries will also contain *ReturnNode*s.
+
+- **SingletonNode**:
+  the purpose of a *SingletonNode* is to produce an empty document that is
+  used as input for other processing steps. Each execution plan will contain
+  exactly one *SingletonNode* as its top node.
+
+- **SortNode**:
+  performs a sort of its input values.
+
+- **SubqueryNode**:
+  executes a subquery.
 
 - **UpdateNode**:
   updates documents in a collection (given in its *collection* attribute).
@@ -421,22 +421,15 @@ The following execution node types will appear in the output of `explain`:
 
 For queries in the cluster, the following nodes may appear in execution plans:
 
-- **SingleRemoteOperationNode**:
-  used on a coordinator to directly work with a single
-  document on a DB-Server that was referenced by its `_key`.
-
-- **ScatterNode**:
-  used on a coordinator to fan-out data to one or multiple shards.
+- **DistributeNode**:
+  used on a coordinator to fan-out data to one or multiple shards,
+  taking into account a collection's shard key.
 
 - **GatherNode**:
   used on a coordinator to aggregate results from one or many shards
   into a combined stream of results. Parallelizes work for certain types
   of queries when there are multiple database servers involved
   (shown as `GATHER   /* parallel */` in query explain).
-
-- **DistributeNode**:
-  used on a coordinator to fan-out data to one or multiple shards,
-  taking into account a collection's shard key.
 
 - **RemoteNode**:
   a *RemoteNode* will perform communication with another ArangoDB instances
@@ -445,6 +438,13 @@ For queries in the cluster, the following nodes may appear in execution plans:
   via *RemoteNode*s. The data servers themselves might again pull further data
   from the coordinator, and thus might also employ *RemoteNode*s. So, all of
   the above cluster relevant nodes will be accompanied by a *RemoteNode*.
+
+- **ScatterNode**:
+  used on a coordinator to fan-out data to one or multiple shards.
+
+- **SingleRemoteOperationNode**:
+  used on a coordinator to directly work with a single
+  document on a DB-Server that was referenced by its `_key`.
 
 List of optimizer rules
 -----------------------

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -356,16 +356,13 @@ List of execution nodes
 
 The following execution node types will appear in the output of `explain`:
 
-- **AggregateNode**:
-  aggregates its input and produces new output variables. This will appear
-  once per *COLLECT* statement.
-
 - **CalculationNode**:
   evaluates an expression. The expression result may be used by
   other nodes, e.g. *FilterNode*, *EnumerateListNode*, *SortNode* etc.
 
 - **CollectNode**:
-  
+  aggregates its input and produces new output variables. This will appear
+  once per *COLLECT* statement.
 
 - **EnumerateCollectionNode**:
   enumeration over documents of a collection (given in its *collection*
@@ -375,7 +372,7 @@ The following execution node types will appear in the output of `explain`:
   enumeration over a list of (non-collection) values.
 
 - **EnumerateViewNode**:
-  
+  enumeration over documents of a View.
 
 - **FilterNode**:
   only lets values pass that satisfy a filter condition. Will appear once
@@ -391,14 +388,15 @@ The following execution node types will appear in the output of `explain`:
   Will appear exactly once in a query that contains an *INSERT* statement.
 
 - **KShortestPathsNode**:
-  
+  indicates a traversal for k Shortest Paths (`K_SHORTEST_PATHS` in AQL).
 
 - **LimitNode**:
   limits the number of results passed to other processing steps. Will appear
   once per *LIMIT* statement.
 
 - **MaterializeNode**:
-  
+  the presence of this node means that the query is not fully covered by
+  indexes and therefore needs to involve the storage engine.
 
 - **RemoveNode**:
   removes documents from a collection (given in its *collection* attribute).
@@ -418,22 +416,23 @@ The following execution node types will appear in the output of `explain`:
   exactly one *SingletonNode* as its top node.
 
 - **ShortestPathNode**:
-  
+  indicates a traversal for a Shortest Path (`SHORTEST_PATH` in AQL).
 
 - **SortNode**:
   performs a sort of its input values.
 
 - **SubqueryEndNode**:
-  
+  end of a spliced (inlined) subquery.
 
 - **SubqueryNode**:
   executes a subquery.
 
 - **SubqueryStartNode**:
-  
+  beginning of a spliced (inlined) subquery.
 
 - **TraversalNode**:
-  
+  indicates a regular graph traversal, as opposed to a shortest path(s)
+  traversal.
 
 - **UpdateNode**:
   updates documents in a collection (given in its *collection* attribute).
@@ -448,9 +447,6 @@ For queries in the cluster, the following nodes may appear in execution plans:
 - **DistributeNode**:
   used on a coordinator to fan-out data to one or multiple shards,
   taking into account a collection's shard key.
-
-- **DistributeConsumer**:
-  
 
 - **GatherNode**:
   used on a coordinator to aggregate results from one or many shards
@@ -494,6 +490,14 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   will appear if a query contains multiple *FOR* statements whose order were
   permuted. Permutation of *FOR* statements is performed because it may enable
   further optimizations by other rules.
+
+- `late-document-materialization`:
+  tries to read from collections as late as possible if the involved attributes
+  are covered by regular indexes.
+
+- `late-document-materialization-arangosearch`:
+  tries to read from the underlying collections of a View as late as possible
+  if the involved attributes are covered by the View index.
 
 - `move-calculations-down`:
   will appear if a *CalculationNode* was moved down in a plan. The intention of

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -655,6 +655,8 @@ The following optimizer rules may appear in the `rules` attribute of cluster pla
   will appear if a RemoveNode can be pushed into the same query part that
   enumerates over the documents of a collection. This saves inter-cluster
   roundtrips between the EnumerateCollectionNode and the RemoveNode.
+  From v3.6.0 on, it includes simple *UPDATE* and *REPLACE* operations
+  that modify multiple documents and do not use *LIMIT*.
 
 Note that some rules may appear multiple times in the list, with number suffixes.
 This is due to the same rule being applied multiple times, at different positions

--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -578,9 +578,9 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
   will appear when a subquery has been spliced into the surrounding query.
   Only suitable subqueries can be spliced.
   A subquery becomes unsuitable if it contains a *LIMIT*, *REMOTE*, *GATHER*
-  or a *COLLECT* node where the operation is *WITH COUNT INTO*. A subquery
-  *also* becomes unsuitable if it is contained in an unsuitable subquery.
-  
+  or a *COLLECT WITH COUNT INTO* node. A subquery *also* becomes unsuitable if
+  it is contained in a subquery containing unsuitable nodes.
+
   This optimization is applied after all other optimizations, and reduces
   overhead for executing subqueries by inlining the execution. This mainly
   benefits queries which execute subqueries very often that only return a

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -238,8 +238,8 @@ On subqueries with few results per input, there was a serious performance impact
 
 Subquery splicing inlines the execution of subqueries using an optimizer rule
 called `splice-subqueries`. Only suitable queries can be spliced.
-A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
-node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+A subquery becomes unsuitable if it contains a `LIMIT` node or a
+`COLLECT WITH COUNT INTO …` construct (but not due to a
 `COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
 unsuitable if it is contained in a (sub)query containing unsuitable parts
 *after* the subquery.

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -238,11 +238,11 @@ On subqueries with few results per input, there was a serious performance impact
 
 Subquery splicing inlines the execution of subqueries using an optimizer rule
 called `splice-subqueries`. Only suitable queries can be spliced.
-A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER` or a
-`COLLECT WITH COUNT INTO` (but not due to a
-`COLLECT var = <expr> WITH COUNT INTO`). A subquery also becomes unsuitable if
-it is contained in a (sub)query containing unsuitable parts after (sic) the
-subquery.
+A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
+node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+`COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
+unsuitable if it is contained in a (sub)query containing unsuitable parts
+*after* the subquery.
 
 Consider the following query to illustrates the difference.
 

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -241,7 +241,7 @@ called `splice-subqueries`. Only suitable queries can be spliced.
 A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER` or a
 `COLLECT WITH COUNT INTO` (but not due to a
 `COLLECT var = <expr> WITH COUNT INTO`). A subquery also becomes unsuitable if
-it is contained in a (sub)query containing unsuitable nodes after (sic) the
+it is contained in a (sub)query containing unsuitable parts after (sic) the
 subquery.
 
 Consider the following query to illustrates the difference.

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -239,8 +239,8 @@ On subqueries with few results per input, there was a serious performance impact
 Subquery splicing inlines the execution of subqueries using an optimizer rule
 called `splice-subqueries`. Only suitable queries can be spliced.
 A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER` or a
-`COLLECT` node where the operation is `WITH COUNT INTO`. A subquery also becomes
-unsuitable if it is contained in an unsuitable subquery.
+`COLLECT WITH COUNT INTO`. A subquery also becomes unsuitable if it is contained
+in a subquery containing unsuitable nodes.
 
 Consider the following query to illustrates the difference.
 

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -239,8 +239,10 @@ On subqueries with few results per input, there was a serious performance impact
 Subquery splicing inlines the execution of subqueries using an optimizer rule
 called `splice-subqueries`. Only suitable queries can be spliced.
 A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER` or a
-`COLLECT WITH COUNT INTO`. A subquery also becomes unsuitable if it is contained
-in a subquery containing unsuitable nodes.
+`COLLECT WITH COUNT INTO` (but not due to a
+`COLLECT var = <expr> WITH COUNT INTO`). A subquery also becomes unsuitable if
+it is contained in a (sub)query containing unsuitable nodes after (sic) the
+subquery.
 
 Consider the following query to illustrates the difference.
 

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -290,7 +290,7 @@ Optimization rules applied:
   3   remove-unnecessary-calculations-2
 ```
 
-Note in particular the `SubqueryNode`s, followed by a `SingleNode` in
+Note in particular the `SubqueryNode`s, followed by a `SingletonNode` in
 both cases.
 
 When using the optimizer rule `splice-subqueries` the plan is as follows:


### PR DESCRIPTION
Followup to #218 .

* Clarify that only `COLLECT WITH COUNT INTO` is affected, and no other `COLLECT` variants
* Avoid a possible misinterpretation that an unsuitable subquery would make contained subqueries recursively unsuitable