### PR TITLE
Remove GATHER and REMOTE from the subquery splicing naughty list

### DIFF
--- a/3.6/aql/execution-and-performance-optimizer.md
+++ b/3.6/aql/execution-and-performance-optimizer.md
@@ -640,8 +640,8 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
 - `splice-subqueries`:
   will appear when a subquery has been spliced into the surrounding query.
   Only suitable subqueries can be spliced.
-  A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
-  node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+  A subquery becomes unsuitable if it contains a `LIMIT` node or a
+  `COLLECT WITH COUNT INTO …` construct (but not due to a
   `COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
   unsuitable if it is contained in a (sub)query containing unsuitable parts
   *after* the subquery.

--- a/3.6/release-notes-new-features36.md
+++ b/3.6/release-notes-new-features36.md
@@ -238,8 +238,8 @@ On subqueries with few results per input, there was a serious performance impact
 
 Subquery splicing inlines the execution of subqueries using an optimizer rule
 called `splice-subqueries`. Only suitable queries can be spliced.
-A subquery becomes unsuitable if it contains a `LIMIT`, `REMOTE`, `GATHER`
-node or a `COLLECT WITH COUNT INTO …` construct (but not due to a
+A subquery becomes unsuitable if it contains a `LIMIT` node or a
+`COLLECT WITH COUNT INTO …` construct (but not due to a
 `COLLECT var = <expr> WITH COUNT INTO …`). A subquery *also* becomes
 unsuitable if it is contained in a (sub)query containing unsuitable parts
 *after* the subquery.


### PR DESCRIPTION
GATHER and REMOTE do not prevent subquery splicing anymore.