### PR TITLE
Set JEKYLL_ENV environment variable for Netlify builds

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -19,7 +19,7 @@
       {%- else -%}
         {%- assign version_number = v.version.name -%}
       {%- endif -%}
-      {%- if v.version.tag -%}
+      {%- if v.version.tag and jekyll.environment != "netlify" -%}
         {%- assign version_alias = v.version.tag -%}
       {%- else -%}
         {%- assign version_alias = v.version.name -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
       <script type="text/javascript">
           var availableVersions = [
             {%- for v in page.versions -%}
-              {%- if v.version.tag -%}
+              {%- if v.version.tag and jekyll.environment != "netlify" -%}
                 {%- assign version_alias = v.version.tag -%}
               {%- else -%}
                 {%- assign version_alias = v.version.name -%}

--- a/netlify.sh
+++ b/netlify.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-jekyll build
+JEKYLL_ENV="netlify" jekyll build
 ruby sitemap.rb
 rm -rf htmltest
 mkdir -p htmltest


### PR DESCRIPTION
Can be checked in Liquid template via `jekyll.environment`

Partially related to #79. It should fix the version switcher in Netlify previews, but not the redirects #95.