### PR TITLE
General Graphs API supported in Stream Transactions since v3.5.1

### DIFF
--- a/3.5/http/transaction-stream-transaction.md
+++ b/3.5/http/transaction-stream-transaction.md
@@ -33,7 +33,7 @@ Supported transactional API operations include:
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
 5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
-   of managed graphs (General Graph / Gharial API, since v3.5.1)
+   of managed graphs (_General Graph_ / _Gharial_ API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.5/http/transaction-stream-transaction.md
+++ b/3.5/http/transaction-stream-transaction.md
@@ -32,8 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
-5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
-   (_Gharial_ based, since v3.5.1)
+5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
+   of managed graphs (General Graph / Gharial API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.5/http/transaction-stream-transaction.md
+++ b/3.5/http/transaction-stream-transaction.md
@@ -32,6 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
+5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
+   (_Gharial_ based, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.6/http/transaction-stream-transaction.md
+++ b/3.6/http/transaction-stream-transaction.md
@@ -33,7 +33,7 @@ Supported transactional API operations include:
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
 5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
-   of managed graphs (General Graph / Gharial API, since v3.5.1)
+   of managed graphs (_General Graph_ / _Gharial_ API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.6/http/transaction-stream-transaction.md
+++ b/3.6/http/transaction-stream-transaction.md
@@ -32,8 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
-5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
-   (_Gharial_ based, since v3.5.1)
+5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
+   of managed graphs (General Graph / Gharial API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.6/http/transaction-stream-transaction.md
+++ b/3.6/http/transaction-stream-transaction.md
@@ -32,6 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
+5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
+   (_Gharial_ based, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.7/http/transaction-stream-transaction.md
+++ b/3.7/http/transaction-stream-transaction.md
@@ -33,7 +33,7 @@ Supported transactional API operations include:
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
 5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
-   of managed graphs (General Graph / Gharial API, since v3.5.1)
+   of managed graphs (_General Graph_ / _Gharial_ API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.7/http/transaction-stream-transaction.md
+++ b/3.7/http/transaction-stream-transaction.md
@@ -32,8 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
-5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
-   (_Gharial_ based, since v3.5.1)
+5. Handle [vertices](gharial-vertices.html) and [edges](gharial-edges.html)
+   of managed graphs (General Graph / Gharial API, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible

--- a/3.7/http/transaction-stream-transaction.md
+++ b/3.7/http/transaction-stream-transaction.md
@@ -32,6 +32,8 @@ Supported transactional API operations include:
 2. Number of documents via the [Collection API](collection-getting.html#return-number-of-documents-in-a-collection)
 3. Truncate a collection via the [Collection API](collection-creating.html#truncate-collection)
 4. Create an AQL cursor via the [Cursor API](aql-query-cursor-accessing-cursors.html)
+5. Managed Graph operations via the [General Graphs API](graphs-general-graphs.html)
+   (_Gharial_ based, since v3.5.1)
 
 Note that a client *always needs to start the transaction first* and it is required to
 explicitly specify the collections used for write accesses. The client is responsible


### PR DESCRIPTION
I suppose the General Graphs JS API uses the Gharial HTTP API, so this should be correct. I'm not sure what "supports stream transactions" means exactly however.