### PR TITLE
TEST: experimental usage of snippets with includes

### DIFF
--- a/3.6/aql/graphs.md
+++ b/3.6/aql/graphs.md
@@ -7,6 +7,14 @@ redirect_from:
 Graphs in AQL
 =============
 
+{% assign version = page.dir | replace_first: "/", "" | split: "/" | first -%}
+
+## Direct Include
+
+{% include blocks/snippet.md version=version %}
+
+---
+
 There are multiple ways to work with [graphs in ArangoDB](../graphs.html),
 as well as different ways to query your graphs using AQL.
 

--- a/3.6/graphs.md
+++ b/3.6/graphs.md
@@ -5,6 +5,20 @@ description: A Graph consists of vertices and edges
 ArangoDB Graphs
 ===============
 
+<!-- NOTE: this gets us the raw version, not its alias (i.e. stable or devel) -->
+{% assign version = page.dir | replace_first: "/", "" | split: "/" | first -%}
+
+## Direct Include
+
+{% include blocks/snippet.md version=version %}
+
+## Captured Include
+
+{% capture my_include %}{% include blocks/snippet.md version=version %}{% endcapture %}
+{{ my_include | markdownify }}
+
+---
+
 First Steps with Graphs
 -----------------------
 

--- a/_config.yml
+++ b/_config.yml
@@ -91,9 +91,6 @@ exclude:
   - 3.3/generated
   - 3.7/
 # - 3.6/
-  - 3.6/drivers
-  - 3.6/http
-  - 3.6/oasis
   - 3.5/
   - 3.4/
   - 3.3/

--- a/_config.yml
+++ b/_config.yml
@@ -89,11 +89,14 @@ exclude:
   - 3.5/generated
   - 3.4/generated
   - 3.3/generated
-# - 3.7/
+  - 3.7/
 # - 3.6/
-# - 3.5/
-# - 3.4/
-# - 3.3/
+  - 3.6/drivers
+  - 3.6/http
+  - 3.6/oasis
+  - 3.5/
+  - 3.4/
+  - 3.3/
 
 versions:
   stable: "3.6"

--- a/_includes/blocks/snippet.md
+++ b/_includes/blocks/snippet.md
@@ -1,0 +1,37 @@
+# Snippet
+
+This tests the include tag, whether the frontmatter is added as well.
+
+## Markdown
+
+This is **bold**, _italic_, ***both***, a [link](https://www.google.com){:target="_blank"}.
+Inline `code`.
+
+[Relative HTML link](aql/graphs.html) vs
+[Jekyll link]({% link {{ include.version }}/aql/graphs.md %})
+
+- Foo
+- Bar
+- Baz
+
+```js
+for (let i = 1; i < 3; i++) {
+    console.log(i); // highlighted JavaScript code
+}
+```
+
+## HTML
+
+This is <strong>bold</strong>, <em>italic</em>, <strong><em>both</em></strong>,
+a <a href="https://www.google.com" target="_blank">link</a>.
+Inline <code>code</code>.
+
+<ul>
+<li>Foo</li>
+<li>Bar</li>
+<li>Baz</li>
+</ul>
+
+<pre><code>for (let i = 1; i < 3; i++) {
+    console.log(i); // JavaScript code in pre + code tags
+}</code></pre>


### PR DESCRIPTION
Goal is to get correct links no matter where a block is included, but at the same time not require a hardcoded version number

Jekyll does not do us any favor here... it makes it really hard to properly include snippets without hard-coding a version number in the content (to stay copy-pasteable to new version folders): https://github.com/arangodb/docs/commit/1c700ecd00850cae8c72f1413bd1be565dcd8a92

The example code gets the version from the root folder name, which means it does not handle version aliases (stable, devel), nor is it future proof for "version-free" content.