### PR TITLE
Add --server.allow-deprecated-storage-engine

### DIFF
--- a/3.7/programs-arangod-server.md
+++ b/3.7/programs-arangod-server.md
@@ -161,7 +161,13 @@ Since ArangoDB v3.2.0, an alternative engine based on
 turned on manually. Since ArangoDB v3.4.0, the RocksDB storage engine is the
 default storage engine for new installations.
 
-The MMFiles engine is [deprecated](appendix-deprecated.html) from v3.6.0 on.
+The MMFiles engine is [deprecated](appendix-deprecated.html) from v3.6.0 on
+and new deployments created with v3.7 do not allow MMFiles as storage engine
+anymore unless the startup option `--server.allow-deprecated-storage-engine`
+is set to *true*. Deployments upgraded to v3.7 from earlier versions that are
+using the MMFiles storage engine will still continue to work in ArangoDB 3.7.
+However, 3.7 will be the last ArangoDB version supporting the MMFiles storage
+engines, so users are asked to migrate to the RocksDB storage engine soon.
 
 One storage engine type is supported per server per installation.
 Live switching of storage engines on already installed systems isn't supported.

--- a/3.7/release-notes-upgrading-changes37.md
+++ b/3.7/release-notes-upgrading-changes37.md
@@ -14,7 +14,7 @@ MMFiles storage engine
 ----------------------
 
 This version of ArangoDB does not allow creating any new deployments with the
-MMFiles storage engine, unless the new [startup option](programs-arangod-server.html#allow-deprecated-storage-engine)
+MMFiles storage engine, unless the new [startup option](programs-arangod-server.html#storage-engine)
 `--server.allow-deprecated-storage-engine` is set to *true*.
 
 All storage engine selection functionality has been removed from the ArangoDB

--- a/3.7/release-notes-upgrading-changes37.md
+++ b/3.7/release-notes-upgrading-changes37.md
@@ -14,16 +14,19 @@ MMFiles storage engine
 ----------------------
 
 This version of ArangoDB does not allow creating any new deployments with the
-MMFiles storage engine. All storage engine selection functionality has been removed
-from the ArangoDB package installers. The RocksDB storage engine will be selected
-for any new deployments created with ArangoDB 3.7.
-The RocksDB storage engine is the default storage engine since ArangoDB 3.4, and
-the MMFiles storage engine has been deprecated in ArangoDB 3.6.
+MMFiles storage engine, unless the new [startup option](programs-arangod-server.html#allow-deprecated-storage-engine)
+`--server.allow-deprecated-storage-engine` is set to *true*.
 
-Deployments upgrading from ArangoDB 3.6 that are using the MMFiles storage engine 
-will still continue to work in ArangoDB 3.7. However, 3.7 will be the last ArangoDB
-version supporting the MMFiles storage engines, so users are asked to migrate to the
-RocksDB storage engine soon.
+All storage engine selection functionality has been removed from the ArangoDB
+package installers. The RocksDB storage engine will be selected for any new
+deployments created with ArangoDB 3.7 by default. The RocksDB storage engine is
+the default storage engine since ArangoDB 3.4, and the MMFiles storage engine
+has been deprecated in ArangoDB 3.6.
+
+Deployments upgrading from ArangoDB 3.6 that are using the MMFiles storage
+engine will still continue to work in ArangoDB 3.7. However, 3.7 will be the
+last ArangoDB version supporting the MMFiles storage engines, so users are
+asked to migrate to the RocksDB storage engine soon.
 
 HTTP REST API
 -------------


### PR DESCRIPTION
Not sure if the option is supposed to be documented or if it's only for internal use (tests):
https://github.com/arangodb/arangodb/pull/10994

Anyway, we should tell users whether they can still use MMFiles in the upgrade case or not (MMFiles code removal postponed to 4.0?)