### PR TITLE
Document change to ternary operator evaluation

### DIFF
--- a/3.7/aql/operators.md
+++ b/3.7/aql/operators.md
@@ -293,20 +293,29 @@ evaluates to true, and the third operand otherwise.
 
 *Examples*
 
+The expression gives back `u.userId` if `u.age` is greater than 15 or if
+`u.active` is *true*. Otherwise it returns *null*:
+
 ```js
 u.age > 15 || u.active == true ? u.userId : null
 ```
 
 There is also a shortcut variant of the ternary operator with just two
 operands. This variant can be used when the expression for the boolean
-condition and the return value should be the same:
+condition and the return value should be the same.
 
 *Examples*
+
+The expression evaluates to `u.value` if `u.value` is truthy, otherwise a
+fixed string is given back:
 
 ```js
 u.value ? : 'value is null, 0 or not present'
 ```
 
+The condition (here just `u.value`) is only evaluated once if the second
+operand between `?` and `:` is omitted, whereas it would be evaluated twice
+in case of `u.value ? u.value : 'value is null'`.
 
 Range operator
 --------------

--- a/3.7/release-notes-new-features37.md
+++ b/3.7/release-notes-new-features37.md
@@ -55,6 +55,12 @@ and threw query parse errors when they were used.
 The performance of parsing ISO 8601 date/time string values in AQL has improved
 significantly thanks to a specialized parser, replacing a regular expression.
 
+### Ternary operator
+
+Improved the lazy evaluation capabilities of the [ternary operator](aql/operators.html#ternary-operator).
+If the second operand is left out, the expression of the condition is only
+evaluated once now, instead of once more for the true branch.
+
 ArangoSearch
 ------------
 


### PR DESCRIPTION
https://github.com/arangodb/arangodb/pull/10634

Unsure if this should be documented at all, if it's a pure performance optimization. Or were there cases where the double-evaluation led to side effects?