### PR TITLE
Allow external links in navigation

### DIFF
--- a/3.6/drivers/spring-data.md
+++ b/3.6/drivers/spring-data.md
@@ -11,6 +11,5 @@ layout: default
 
 - [ArangoDB](https://www.arangodb.com/){:target="_blank"}
 - [Demo](https://github.com/arangodb/spring-data-demo){:target="_blank"}
-- [JavaDoc 1.0.0](http://arangodb.github.io/spring-data/javadoc-1_0/index.html){:target="_blank"}
-- [JavaDoc 2.0.0](http://arangodb.github.io/spring-data/javadoc-2_0/index.html){:target="_blank"}
+- [JavaDoc](http://arangodb.github.io/spring-data/){:target="_blank"}
 - [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#changelog){:target="_blank"}

--- a/3.7/drivers/spring-data.md
+++ b/3.7/drivers/spring-data.md
@@ -11,6 +11,5 @@ layout: default
 
 - [ArangoDB](https://www.arangodb.com/){:target="_blank"}
 - [Demo](https://github.com/arangodb/spring-data-demo){:target="_blank"}
-- [JavaDoc 1.0.0](http://arangodb.github.io/spring-data/javadoc-1_0/index.html){:target="_blank"}
-- [JavaDoc 2.0.0](http://arangodb.github.io/spring-data/javadoc-2_0/index.html){:target="_blank"}
+- [JavaDoc](http://arangodb.github.io/spring-data/){:target="_blank"}
 - [Changelog](https://github.com/arangodb/spring-data/blob/master/ChangeLog.md#changelog){:target="_blank"}

--- a/_data/3.6-drivers.yml
+++ b/_data/3.6-drivers.yml
@@ -18,6 +18,10 @@
     - text: Reference
       href: java-reference.html
       children:
+        - text: JavaDoc
+          href: http://arangodb.github.io/arangodb-java-driver/
+        - text: JavaDoc VelocyPack
+          href: http://arangodb.github.io/java-velocypack/
         - text: Driver Setup
           href: java-reference-setup.html
         - text: Database
@@ -157,6 +161,8 @@
       href: php-getting-started.html
     - text: Tutorial
       href: php-tutorial.html
+    - text: Reference
+      href: http://arangodb.github.io/arangodb-php/
 - text: ArangoDB Go Driver
   href: go.html
   children:
@@ -166,6 +172,8 @@
       href: go-example-requests.html
     - text: Connection Management
       href: go-connection-management.html
+    - text: Reference
+      href: https://godoc.org/github.com/arangodb/go-driver
 - subtitle: Integrations
 - text: Spring Data ArangoDB
   href: spring-data.html
@@ -175,6 +183,8 @@
     - text: Reference
       href: spring-data-reference.html
       children:
+        - text: JavaDoc
+          href: http://arangodb.github.io/spring-data/
         - text: Template
           href: spring-data-reference-template.html
           children:

--- a/_data/3.7-drivers.yml
+++ b/_data/3.7-drivers.yml
@@ -18,6 +18,10 @@
     - text: Reference
       href: java-reference.html
       children:
+        - text: JavaDoc
+          href: http://arangodb.github.io/arangodb-java-driver/
+        - text: JavaDoc VelocyPack
+          href: http://arangodb.github.io/java-velocypack/
         - text: Driver Setup
           href: java-reference-setup.html
         - text: Database
@@ -157,6 +161,8 @@
       href: php-getting-started.html
     - text: Tutorial
       href: php-tutorial.html
+    - text: Reference
+      href: http://arangodb.github.io/arangodb-php/
 - text: ArangoDB Go Driver
   href: go.html
   children:
@@ -166,6 +172,8 @@
       href: go-example-requests.html
     - text: Connection Management
       href: go-connection-management.html
+    - text: Reference
+      href: https://godoc.org/github.com/arangodb/go-driver
 - subtitle: Integrations
 - text: Spring Data ArangoDB
   href: spring-data.html
@@ -175,6 +183,8 @@
     - text: Reference
       href: spring-data-reference.html
       children:
+        - text: JavaDoc
+          href: http://arangodb.github.io/spring-data/
         - text: Template
           href: spring-data-reference-template.html
           children:

--- a/_plugins/NavigationTag.rb
+++ b/_plugins/NavigationTag.rb
@@ -27,14 +27,18 @@ class NavigationTag < Liquid::Tag
                 children = ""
                 classNames = "chapter"
                 if element["href"]
-                    children += localIndent + "<a href=\"" + element['href'] + "\">" + element["text"] + "</a>\n"
-                    fileurl = context.environments.first["page"]["url"]
-                    if fileurl.end_with?("/")
-                        fileurl += "index.html"
-                    end
-                    if fileurl == context.environments.first["page"]["dir"] + element["href"]
-                        found = true
-                        classNames += " selected active"
+                    if element["href"].start_with?("http://", "https://")
+                        children += localIndent + "<a href=\"" + element['href'] + "\" target=\"_blank\" rel=\"noopener noreferrer\">" + element["text"] + " <i class=\"fa fa-external-link\"></i></a>\n"
+                    else
+                        children += localIndent + "<a href=\"" + element['href'] + "\">" + element["text"] + "</a>\n"
+                        fileurl = context.environments.first["page"]["url"]
+                        if fileurl.end_with?("/")
+                            fileurl += "index.html"
+                        end
+                        if fileurl == context.environments.first["page"]["dir"] + element["href"]
+                            found = true
+                            classNames += " selected active"
+                        end
                     end
                 end
                 if element["children"]

--- a/js/site.js
+++ b/js/site.js
@@ -156,6 +156,12 @@ $(document).ready(function scrollToAnchor() {
 
 $(document).ready(function handleNav() {
   $("div.book-summary nav a").click(function(event) {
+    if (event.target.href && (
+        event.target.href.startsWith("http://") ||
+        event.target.href.startsWith("https://"))) {
+      // let browser handle external link in navigation
+      return
+    }
     event.preventDefault();
     loadPage(event.target, function(title) {
       $(event.target)


### PR DESCRIPTION
Open external links in new tab (noopener noreferrer), use `fa fa-external-link` to indicate such entries:

```yaml
    - text: Reference
      href: java-reference.html
      children:
        - text: JavaDoc
          href: http://arangodb.github.io/arangodb-java-driver/
        - text: JavaDoc VelocyPack
          href: http://arangodb.github.io/java-velocypack/
```

![image](https://user-images.githubusercontent.com/7819991/78663674-dc237d00-78d2-11ea-8d90-a4c0afb825bd.png)
