### PR TITLE
Remove mention of scatter-arangosearch-view-in-cluster

### DIFF
--- a/3.7/aql/execution-and-performance-optimizer.md
+++ b/3.7/aql/execution-and-performance-optimizer.md
@@ -728,11 +728,6 @@ The following optimizer rules may appear in the `rules` attribute of
   the query, and when the shard keys are covered by a single index (this is
   always true if the shard key is the default `_key`).
 
-- `scatter-arangosearch-view-in-cluster`:
-  will appear when scatter, gather, and remote nodes are inserted into a
-  distributed View query. This is not an optimization rule, and it cannot be
-  turned off.
-
 - `scatter-in-cluster`:
   will appear when scatter, gather, and remote nodes are inserted into a
   distributed query. This is not an optimization rule, and it cannot be


### PR DESCRIPTION
This rule has been removed

Wait for https://github.com/arangodb/arangodb/pull/11400 to be merged before this is merged.