### PR TITLE
Fix external links on mobile

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -162,7 +162,7 @@ $(document).ready(function handleNav() {
         hrefAttr.startsWith("http://") ||
         hrefAttr.startsWith("https://"))) {
       // let browser handle external link in navigation
-      return
+      return true;
     }
     event.preventDefault();
     loadPage(event.target, function(title) {


### PR DESCRIPTION
In Chrome for Android, clicking one of the reference links does not open a new tab with the absolute URL, but just blanks the main area.