### PR TITLE
Fixed similarity links

### DIFF
--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -444,12 +444,12 @@ RETURN NGRAM_MATCH("quick fox", "quick blue fox", "bigram")
 
 ### NGRAM_POSITIONAL_SIMILARITY()
 
-See [String Functions](../functions-string.html#ngram_positional_similarity).
+See [String Functions](functions-string.html#ngram_positional_similarity).
 
 ### NGRAM_SIMILARITY()
 
 
-See [String Functions](../functions-string.html#ngram_similarity).
+See [String Functions](functions-string.html#ngram_similarity).
 
 ### PHRASE()
 

--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -448,7 +448,6 @@ See [String Functions](functions-string.html#ngram_positional_similarity).
 
 ### NGRAM_SIMILARITY()
 
-
 See [String Functions](functions-string.html#ngram_similarity).
 
 ### PHRASE()

--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -444,12 +444,12 @@ RETURN NGRAM_MATCH("quick fox", "quick blue fox", "bigram")
 
 ### NGRAM_POSITIONAL_SIMILARITY()
 
-See [String Functions](functions-arangosearch.html#ngram_positional_similarity).
+See [String Functions](../functions-string.html#ngram_positional_similarity).
 
 ### NGRAM_SIMILARITY()
 
 
-See [String Functions](functions-arangosearch.html#ngram_similarity).
+See [String Functions](../functions-string.html#ngram_similarity).
 
 ### PHRASE()
 

--- a/3.8/aql/functions-arangosearch.md
+++ b/3.8/aql/functions-arangosearch.md
@@ -444,12 +444,12 @@ RETURN NGRAM_MATCH("quick fox", "quick blue fox", "bigram")
 
 ### NGRAM_POSITIONAL_SIMILARITY()
 
-See [String Functions](functions-arangosearch.html#ngram_positional_similarity).
+See [String Functions](functions-string.html#ngram_positional_similarity).
 
 ### NGRAM_SIMILARITY()
 
 
-See [String Functions](functions-arangosearch.html#ngram_similarity).
+See [String Functions](functions-string.html#ngram_similarity).
 
 ### PHRASE()
 

--- a/3.8/aql/functions-arangosearch.md
+++ b/3.8/aql/functions-arangosearch.md
@@ -448,7 +448,6 @@ See [String Functions](functions-string.html#ngram_positional_similarity).
 
 ### NGRAM_SIMILARITY()
 
-
 See [String Functions](functions-string.html#ngram_similarity).
 
 ### PHRASE()


### PR DESCRIPTION
Links for ngram_similarity and ngram_positional_similarity don't point to expected String Functions pages.
- I believe I have followed correct format for links but please advise if not.