### PR TITLE
Hide wildcard search content for 3.7 GA

### DIFF
--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -502,8 +502,10 @@ Object tokens:
 - `{TERMS: [token1, ..., tokenN]}`: one of `token1, ..., tokenN` can be found
   in specified position. Inside an array the object syntax can be replaced with
   the object field value, e.g., `[..., [token1, ..., tokenN], ...]`.
+{% comment %}
 - `{WILDCARD: [token]}`: see [LIKE()](#like).
   Array brackets are optional
+{% endcomment %}
 
 An array token inside an array can be used in the `TERMS` case only.
 
@@ -778,6 +780,7 @@ FOR doc IN viewName
   RETURN doc.text
 ```
 
+{% comment %}
 ### LIKE()
 
 <small>Introduced in: v3.7.0</small>
@@ -807,6 +810,7 @@ FOR doc IN viewName
   SEARCH ANALYZER(doc.text LIKE "foo%b_r", "text_en")
   RETURN doc.text
 ```
+{% endcomment %}
 
 ### TOKENS()
 

--- a/3.7/highlights.md
+++ b/3.7/highlights.md
@@ -12,7 +12,7 @@ Version 3.7
 **All Editions**
 
 - **ArangoSearch**:
-  [Wildcard](aql/functions-arangosearch.html#like) and fuzzy search
+  Fuzzy search
   ([Levenshtein distance](aql/functions-string.html#levenshtein_distance) and
   [n-gram based](aql/functions-arangosearch.html#ngram_match)),
   [enhanced phrase](aql/functions-arangosearch.html#phrase) and

--- a/3.7/highlights.md
+++ b/3.7/highlights.md
@@ -13,7 +13,7 @@ Version 3.7
 
 - **ArangoSearch**:
   Fuzzy search
-  ([Levenshtein distance](aql/functions-string.html#levenshtein_distance) and
+  ([Levenshtein distance](aql/functions-arangosearch.html#levenshtein_match) and
   [n-gram based](aql/functions-arangosearch.html#ngram_match)),
   [enhanced phrase](aql/functions-arangosearch.html#phrase) and
   [proximity search](aql/functions-array.html#jaccard),

--- a/3.7/release-notes-new-features37.md
+++ b/3.7/release-notes-new-features37.md
@@ -12,6 +12,7 @@ here.
 ArangoSearch
 ------------
 
+{% comment %}
 ### Wildcard search
 
 ArangoSearch was extended to support the `LIKE()` function and `LIKE` operator
@@ -29,6 +30,7 @@ FOR doc IN viewName
 ```
 
 See [ArangoSearch functions](aql/functions-arangosearch.html#like)
+{% endcomment %}
 
 ### Covering Indexes
 

--- a/3.8/highlights.md
+++ b/3.8/highlights.md
@@ -26,7 +26,7 @@ Version 3.7
 
 - **ArangoSearch**:
   Fuzzy search
-  ([Levenshtein distance](aql/functions-string.html#levenshtein_distance) and
+  ([Levenshtein distance](aql/functions-arangosearch.html#levenshtein_match) and
   [n-gram based](aql/functions-arangosearch.html#ngram_match)),
   [enhanced phrase](aql/functions-arangosearch.html#phrase) and
   [proximity search](aql/functions-array.html#jaccard),

--- a/3.8/highlights.md
+++ b/3.8/highlights.md
@@ -25,7 +25,7 @@ Version 3.7
 **All Editions**
 
 - **ArangoSearch**:
-  [Wildcard](aql/functions-arangosearch.html#like) and fuzzy search
+  Fuzzy search
   ([Levenshtein distance](aql/functions-string.html#levenshtein_distance) and
   [n-gram based](aql/functions-arangosearch.html#ngram_match)),
   [enhanced phrase](aql/functions-arangosearch.html#phrase) and


### PR DESCRIPTION
Comment out LIKE() function content, remove reference from highlights.