### PR TITLE
Remove Merkle tree docublock tags from 3.7

### DIFF
--- a/3.7/http/replications-replication-dump.md
+++ b/3.7/http/replications-replication-dump.md
@@ -38,14 +38,6 @@ parts of the dump results in the same order as they are provided.
 <!-- arangod/RestHandler/RestReplicationHandler.cpp -->
 {% docublock get_api_replication_dump %}
 
-{% comment %}
-<!-- arangod/RestHandler/RestReplicationHandler.cpp -->
-{% docublock get_api_replication_revisions_tree %}
-{% docublock post_api_replication_revisions_tree %}
-{% docublock put_api_replication_revisions_ranges %}
-{% docublock put_api_replication_revisions_documents %}
-{% endcomment %}
-
 <!-- arangod/RestHandler/RestReplicationHandler.cpp -->
 {% docublock put_api_replication_synchronize %}
 

--- a/3.7/http/replications-replication-dump.md
+++ b/3.7/http/replications-replication-dump.md
@@ -38,11 +38,13 @@ parts of the dump results in the same order as they are provided.
 <!-- arangod/RestHandler/RestReplicationHandler.cpp -->
 {% docublock get_api_replication_dump %}
 
+{% comment %}
 <!-- arangod/RestHandler/RestReplicationHandler.cpp -->
 {% docublock get_api_replication_revisions_tree %}
 {% docublock post_api_replication_revisions_tree %}
 {% docublock put_api_replication_revisions_ranges %}
 {% docublock put_api_replication_revisions_documents %}
+{% endcomment %}
 
 <!-- arangod/RestHandler/RestReplicationHandler.cpp -->
 {% docublock put_api_replication_synchronize %}


### PR DESCRIPTION
The feature was disabled for 3.7 GA and the docublocks are thus missing.

References: #361, #473 and https://github.com/arangodb/arangodb/pull/11935 

Related: https://github.com/arangodb/arangodb/pull/12392