### PR TITLE
Fixed #12605: If unset sub-document is to be updated, keepNull is ignored

### DIFF
--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -57,23 +57,24 @@ The preferred way to start a breadth-first search from now on is with
 `order: "bfs"`. The default remains depth-first search if no `order` is
 specified, but can also be explicitly requested with `order: "dfs"`.
 
-### UPDATE queries with keepNull = false
+### UPDATE queries with `keepNull: false`
 
-AQL update queries using the `keepNull` option set to false had an inconsistent 
-behavior in previous versions of ArangoDB. 
+AQL update queries using the `keepNull` option set to false had an inconsistent
+behavior in previous versions of ArangoDB.
 
-For example, given a collection `test` with an empty document with just key `testDoc`, 
-the following query would return different results when running for the first time or 
-the second time:
+For example, given a collection `test` with an empty document with just key
+`testDoc`, the following query would return different results when running for
+the first time and the second time:
 
-```
+```js
 UPDATE 'testDoc' 
-WITH {test: {sub1: true, sub2: null}} IN test
+WITH { test: { sub1: true, sub2: null } } IN test
 OPTIONS { keepNull: false, mergeObjects: true }
 ```
 
-On its first run, the query would return
-```
+On its first run, the query would return:
+
+```json
 {
   "_key": "testDoc",
   "test": {
@@ -82,9 +83,11 @@ On its first run, the query would return
   }
 }
 ```
+
 (with the `null` attribute value not being removed). For all subsequent runs, 
-the same query would return
-```      
+the same query would return:
+
+```json
 {
   "_key": "testDoc",
   "test": {
@@ -92,6 +95,7 @@ the same query would return
   }
 }
 ```
+
 (with the `null` value removed as requested). 
 
 This inconsistency was due to how the `keepNull` attribute was handled if
@@ -101,53 +105,23 @@ sub-attributes even if in the to-be-updated document the target attribute
 did not yet exist. This makes such updates idempotent again.
 
 This a behavior change compared previous versions, but it will only have
-effect when `keepNull` is set to `false` (the default value is `true` however),
+effect when `keepNull` is set to `false` (the default value is `true`),
 and only when just-inserted object sub-attributes contained `null` values.
 
 Document operations
 -------------------
 
-### Update operations with keepNull = false
+### Update operations with `keepNull: false`
 
 Non-AQL document update operations using the `keepNull` option set to false had 
 an inconsistent behavior in previous versions of ArangoDB. 
 
 For example, given a collection `test` with an empty document with just key `testDoc`, 
 the following operation would produce different documents when running for the first 
-time or the second time:
+time and the second time:
 
-```
-db.test.update("testDoc", {test: {sub1: true, sub2: null}}", {keepNull: false});
+```js
+db.test.update("testDoc", { test: { sub1: true, sub2: null } }, { keepNull: false });
 ```
 
-On its first run, the operation would produce the following document:
-```
-{
-  "_key": "testDoc",
-  "test": {
-    "sub1": true,
-    "sub2": null
-  }
-}
-```
-(with the `null` attribute value not being removed). For all subsequent runs, 
-the same operation would produce just
-```      
-{
-  "_key": "testDoc",
-  "test": {
-    "sub1": true,
-  }
-}
-```
-(with the `null` value removed as requested). 
-
-This inconsistency was due to how the `keepNull` attribute was handled if
-the attribute already existed in the to-be-updated document or not. The 
-behavior is now consistent, so `null` values are now properly removed from 
-sub-attributes even if in the to-be-updated document the target attribute
-did not yet exist. This makes such updates idempotent again.
-
-This a behavior change compared previous versions, but it will only have
-effect when `keepNull` is set to `false` (the default value is `true` however),
-and only when just-inserted object sub-attributes contained `null` values.
+Also see [AQL UPDATE queries with `keepNull: false`](#update-queries-with-keepnull--false)

--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -56,3 +56,98 @@ option `order`.
 The preferred way to start a breadth-first search from now on is with
 `order: "bfs"`. The default remains depth-first search if no `order` is
 specified, but can also be explicitly requested with `order: "dfs"`.
+
+### UPDATE queries with keepNull = false
+
+AQL update queries using the `keepNull` option set to false had an inconsistent 
+behavior in previous versions of ArangoDB. 
+
+For example, given a collection `test` with an empty document with just key `testDoc`, 
+the following query would return different results when running for the first time or 
+the second time:
+
+```
+UPDATE 'testDoc' 
+WITH {test: {sub1: true, sub2: null}} IN test
+OPTIONS { keepNull: false, mergeObjects: true }
+```
+
+On its first run, the query would return
+```
+{
+  "_key": "testDoc",
+  "test": {
+    "sub1": true,
+    "sub2": null
+  }
+}
+```
+(with the `null` attribute value not being removed). For all subsequent runs, 
+the same query would return
+```      
+{
+  "_key": "testDoc",
+  "test": {
+    "sub1": true,
+  }
+}
+```
+(with the `null` value removed as requested). 
+
+This inconsistency was due to how the `keepNull` attribute was handled if
+the attribute already existed in the to-be-updated document or not. The 
+behavior is now consistent, so `null` values are now properly removed from 
+sub-attributes even if in the to-be-updated document the target attribute
+did not yet exist. This makes such updates idempotent again.
+
+This a behavior change compared previous versions, but it will only have
+effect when `keepNull` is set to `false` (the default value is `true` however),
+and only when just-inserted object sub-attributes contained `null` values.
+
+Document operations
+-------------------
+
+### Update operations with keepNull = false
+
+Non-AQL document update operations using the `keepNull` option set to false had 
+an inconsistent behavior in previous versions of ArangoDB. 
+
+For example, given a collection `test` with an empty document with just key `testDoc`, 
+the following operation would produce different documents when running for the first 
+time or the second time:
+
+```
+db.test.update("testDoc", {test: {sub1: true, sub2: null}}", {keepNull: false});
+```
+
+On its first run, the operation would produce the following document:
+```
+{
+  "_key": "testDoc",
+  "test": {
+    "sub1": true,
+    "sub2": null
+  }
+}
+```
+(with the `null` attribute value not being removed). For all subsequent runs, 
+the same operation would produce just
+```      
+{
+  "_key": "testDoc",
+  "test": {
+    "sub1": true,
+  }
+}
+```
+(with the `null` value removed as requested). 
+
+This inconsistency was due to how the `keepNull` attribute was handled if
+the attribute already existed in the to-be-updated document or not. The 
+behavior is now consistent, so `null` values are now properly removed from 
+sub-attributes even if in the to-be-updated document the target attribute
+did not yet exist. This makes such updates idempotent again.
+
+This a behavior change compared previous versions, but it will only have
+effect when `keepNull` is set to `false` (the default value is `true` however),
+and only when just-inserted object sub-attributes contained `null` values.

--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -124,4 +124,4 @@ time and the second time:
 db.test.update("testDoc", { test: { sub1: true, sub2: null } }, { keepNull: false });
 ```
 
-Also see [AQL UPDATE queries with `keepNull: false`](#update-queries-with-keepnull--false)
+Also see [AQL UPDATE queries with `keepNull: false`](#update-queries-with-keepnull-false)


### PR DESCRIPTION
Docs for https://github.com/arangodb/arangodb/pull/12605