### PR TITLE
Foxx: graphql-sync is deprecated

### DIFF
--- a/3.3/foxx-graph-ql.md
+++ b/3.3/foxx-graph-ql.md
@@ -9,7 +9,7 @@ Using GraphQL in Foxx
 
 Foxx bundles version 0.6 of the [`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a synchronous wrapper for the official JavaScript GraphQL reference implementation, to allow writing GraphQL schemas directly inside Foxx.
 
-Additionally the `@arangodb/foxx/graphql` lets you create routers for serving GraphQL requests, which closely mimicks the behavior of the [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
+Additionally the `@arangodb/foxx/graphql` lets you create routers for serving GraphQL requests, which closely mimics the behavior of the [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 
 For more information on `graphql-sync` see the [`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"} (note that `graphql-sync` never wraps results in promises).
 

--- a/3.4/foxx-reference-modules-graph-ql.md
+++ b/3.4/foxx-reference-modules-graph-ql.md
@@ -13,7 +13,7 @@ synchronous wrapper for the official JavaScript GraphQL reference
 implementation, to allow writing GraphQL schemas directly inside Foxx.
 
 Additionally the `@arangodb/foxx/graphql` lets you create routers for serving
-GraphQL requests, which closely mimicks the behavior of the
+GraphQL requests, which closely mimics the behavior of the
 [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 
 For more information on `graphql-sync` see the

--- a/3.5/foxx-reference-modules-graph-ql.md
+++ b/3.5/foxx-reference-modules-graph-ql.md
@@ -1,28 +1,51 @@
 ---
 layout: default
-description: GraphQL integration
+description: >-
+  The @arangodb/foxx/graphql module lets you create routers for serving GraphQL requests
+title: GraphQL integration for Foxx
 ---
 GraphQL integration
 ===================
 
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
-Foxx bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a
-synchronous wrapper for the official JavaScript GraphQL reference
-implementation, to allow writing GraphQL schemas directly inside Foxx.
-
-Additionally the `@arangodb/foxx/graphql` lets you create routers for serving
-GraphQL requests, which closely mimicks the behavior of the
+The `@arangodb/foxx/graphql` module lets you create routers for serving
+GraphQL requests, which closely mimics the behavior of the
 [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 
-For more information on `graphql-sync` see the
-[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
-(note that `graphql-sync` never wraps results in promises).
-
 For an example of a GraphQL schema in Foxx that resolves fields using the
-database see [the GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
+database see the [GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
 (also available from the Foxx store).
+
+Starting with `graphql` version 0.12 you can use the
+[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"}
+if you include it in the `node_modules` folder of your service bundle and pass
+it to the `graphql` option:
+
+```js
+const graphql = require('graphql'); // 0.12 or later
+const graphqlSchema = new graphql.Schema({
+  //...
+});
+module.context.use(createGraphQLRouter({
+  schema: graphqlSchema,
+  graphiql: true,
+  graphql: graphql
+}))
+```
+
+Foxx also bundles version 0.6 of the
+[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+which is a synchronous wrapper for the official JavaScript GraphQL reference
+implementation.
+
+{% hint 'warning' %}
+`graphql-sync` is a thin wrapper for old versions of `graphql`, allowing it
+to run in ArangoDB. This GraphQL server/schema implementation is deprecated
+and only shipped for backward compatibility. Version 0.12 and newer of the
+official `graphql` package can be used directly. New projects should bundle
+an own copy of this module: <https://www.npmjs.com/package/graphql>
+{% endhint %}
 
 **Examples**
 
@@ -54,39 +77,9 @@ router.use('/graphql', createGraphQLRouter({
 }));
 ```
 
-**Note**: ArangoDB aims for stability which means bundled dependencies will
-generally not be updated as quickly as their maintainers make updates
-available on GitHub or NPM. Starting with ArangoDB 3.2, if you want to use a
-newer version than the one bundled with your target version of ArangoDB, you
-can provide your own version of the library by passing it via the `graphql` option:
-
-```js
-const graphql = require('graphql-sync');
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
-
-Starting with `graphql` 0.12 you can also use
-[the official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
-include it in the `node_modules` folder of your service bundle:
-
-```js
-const graphql = require('graphql'); // 0.12 or later
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
+For more information on `graphql-sync` see the
+[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
+(note that `graphql-sync` never wraps results in promises).
 
 Creating a router
 -----------------

--- a/3.6/foxx-reference-modules-graph-ql.md
+++ b/3.6/foxx-reference-modules-graph-ql.md
@@ -1,28 +1,51 @@
 ---
 layout: default
-description: GraphQL integration
+description: >-
+  The @arangodb/foxx/graphql module lets you create routers for serving GraphQL requests
+title: GraphQL integration for Foxx
 ---
 GraphQL integration
 ===================
 
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
-Foxx bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a
-synchronous wrapper for the official JavaScript GraphQL reference
-implementation, to allow writing GraphQL schemas directly inside Foxx.
-
-Additionally the `@arangodb/foxx/graphql` lets you create routers for serving
-GraphQL requests, which closely mimicks the behavior of the
+The `@arangodb/foxx/graphql` module lets you create routers for serving
+GraphQL requests, which closely mimics the behavior of the
 [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 
-For more information on `graphql-sync` see the
-[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
-(note that `graphql-sync` never wraps results in promises).
-
 For an example of a GraphQL schema in Foxx that resolves fields using the
-database see [the GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
+database see the [GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
 (also available from the Foxx store).
+
+Starting with `graphql` version 0.12 you can use the
+[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"}
+if you include it in the `node_modules` folder of your service bundle and pass
+it to the `graphql` option:
+
+```js
+const graphql = require('graphql'); // 0.12 or later
+const graphqlSchema = new graphql.Schema({
+  //...
+});
+module.context.use(createGraphQLRouter({
+  schema: graphqlSchema,
+  graphiql: true,
+  graphql: graphql
+}))
+```
+
+Foxx also bundles version 0.6 of the
+[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+which is a synchronous wrapper for the official JavaScript GraphQL reference
+implementation.
+
+{% hint 'warning' %}
+`graphql-sync` is a thin wrapper for old versions of `graphql`, allowing it
+to run in ArangoDB. This GraphQL server/schema implementation is deprecated
+and only shipped for backward compatibility. Version 0.12 and newer of the
+official `graphql` package can be used directly. New projects should bundle
+an own copy of this module: <https://www.npmjs.com/package/graphql>
+{% endhint %}
 
 **Examples**
 
@@ -54,39 +77,9 @@ router.use('/graphql', createGraphQLRouter({
 }));
 ```
 
-**Note**: ArangoDB aims for stability which means bundled dependencies will
-generally not be updated as quickly as their maintainers make updates
-available on GitHub or NPM. Starting with ArangoDB 3.2, if you want to use a
-newer version than the one bundled with your target version of ArangoDB, you
-can provide your own version of the library by passing it via the `graphql` option:
-
-```js
-const graphql = require('graphql-sync');
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
-
-Starting with `graphql` 0.12 you can also use
-[the official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
-include it in the `node_modules` folder of your service bundle:
-
-```js
-const graphql = require('graphql'); // 0.12 or later
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
+For more information on `graphql-sync` see the
+[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
+(note that `graphql-sync` never wraps results in promises).
 
 Creating a router
 -----------------

--- a/3.7/foxx-reference-modules-graph-ql.md
+++ b/3.7/foxx-reference-modules-graph-ql.md
@@ -1,28 +1,51 @@
 ---
 layout: default
-description: GraphQL integration
+description: >-
+  The @arangodb/foxx/graphql module lets you create routers for serving GraphQL requests
+title: GraphQL integration for Foxx
 ---
 GraphQL integration
 ===================
 
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
-Foxx bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a
-synchronous wrapper for the official JavaScript GraphQL reference
-implementation, to allow writing GraphQL schemas directly inside Foxx.
-
-Additionally the `@arangodb/foxx/graphql` lets you create routers for serving
-GraphQL requests, which closely mimicks the behavior of the
+The `@arangodb/foxx/graphql` module lets you create routers for serving
+GraphQL requests, which closely mimics the behavior of the
 [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 
-For more information on `graphql-sync` see the
-[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
-(note that `graphql-sync` never wraps results in promises).
-
 For an example of a GraphQL schema in Foxx that resolves fields using the
-database see [the GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
+database see the [GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
 (also available from the Foxx store).
+
+Starting with `graphql` version 0.12 you can use the
+[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"}
+if you include it in the `node_modules` folder of your service bundle and pass
+it to the `graphql` option:
+
+```js
+const graphql = require('graphql'); // 0.12 or later
+const graphqlSchema = new graphql.Schema({
+  //...
+});
+module.context.use(createGraphQLRouter({
+  schema: graphqlSchema,
+  graphiql: true,
+  graphql: graphql
+}))
+```
+
+Foxx also bundles version 0.6 of the
+[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+which is a synchronous wrapper for the official JavaScript GraphQL reference
+implementation.
+
+{% hint 'warning' %}
+`graphql-sync` is a thin wrapper for old versions of `graphql`, allowing it
+to run in ArangoDB. This GraphQL server/schema implementation is deprecated
+and only shipped for backward compatibility. Version 0.12 and newer of the
+official `graphql` package can be used directly. New projects should bundle
+an own copy of this module: <https://www.npmjs.com/package/graphql>
+{% endhint %}
 
 **Examples**
 
@@ -54,39 +77,9 @@ router.use('/graphql', createGraphQLRouter({
 }));
 ```
 
-**Note**: ArangoDB aims for stability which means bundled dependencies will
-generally not be updated as quickly as their maintainers make updates
-available on GitHub or NPM. Starting with ArangoDB 3.2, if you want to use a
-newer version than the one bundled with your target version of ArangoDB, you
-can provide your own version of the library by passing it via the `graphql` option:
-
-```js
-const graphql = require('graphql-sync');
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
-
-Starting with `graphql` 0.12 you can also use
-[the official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
-include it in the `node_modules` folder of your service bundle:
-
-```js
-const graphql = require('graphql'); // 0.12 or later
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
+For more information on `graphql-sync` see the
+[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
+(note that `graphql-sync` never wraps results in promises).
 
 Creating a router
 -----------------

--- a/3.8/appendix-java-script-modules.md
+++ b/3.8/appendix-java-script-modules.md
@@ -189,8 +189,11 @@ are preinstalled:
 
 <!-- - [**extendible**] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-- [**graphql-sync**](https://github.com/arangodb/graphql-sync){:target="_blank"}
-  is an ArangoDB-compatible GraphQL server/schema implementation.
+- **graphql-sync** is a thin wrapper for old versions of `graphql`, allowing it
+  to run in ArangoDB. This GraphQL server/schema implementation is deprecated
+  and only shipped for backward compatibility. Version 0.12 and newer of the
+  official `graphql` package can be used directly. New projects should bundle
+  an own copy of this module: <https://www.npmjs.com/package/graphql>
 
 - [**highlight.js**](https://highlightjs.org){:target="_blank"}
   is an HTML syntax highlighter.

--- a/3.8/foxx-reference-modules-graph-ql.md
+++ b/3.8/foxx-reference-modules-graph-ql.md
@@ -5,6 +5,14 @@ description: GraphQL integration
 GraphQL integration
 ===================
 
+{% hint 'warning' %}
+`graphql-sync` is a thin wrapper for old versions of `graphql`, allowing it
+to run in ArangoDB. This GraphQL server/schema implementation is deprecated
+and only shipped for backward compatibility. Version 0.12 and newer of the
+official `graphql` package can be used directly. New projects should bundle
+an own copy of this module: <https://www.npmjs.com/package/graphql>
+{% endhint %}
+
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
 Foxx bundles version 0.6 of the
@@ -72,8 +80,8 @@ module.context.use(createGraphQLRouter({
 }))
 ```
 
-Starting with `graphql` 0.12 you can also use
-[the official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
+Starting with `graphql` version 0.12 you can also use the
+[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
 include it in the `node_modules` folder of your service bundle:
 
 ```js

--- a/3.8/foxx-reference-modules-graph-ql.md
+++ b/3.8/foxx-reference-modules-graph-ql.md
@@ -1,9 +1,43 @@
 ---
 layout: default
-description: GraphQL integration
+description: >-
+  The @arangodb/foxx/graphql module lets you create routers for serving GraphQL requests
+title: GraphQL integration for Foxx
 ---
 GraphQL integration
 ===================
+
+`const createGraphQLRouter = require('@arangodb/foxx/graphql');`
+
+The `@arangodb/foxx/graphql` module lets you create routers for serving
+GraphQL requests, which closely mimics the behavior of the
+[`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
+
+For an example of a GraphQL schema in Foxx that resolves fields using the
+database see the [GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
+(also available from the Foxx store).
+
+Starting with `graphql` version 0.12 you can use the
+[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"}
+if you include it in the `node_modules` folder of your service bundle and pass
+it to the `graphql` option:
+
+```js
+const graphql = require('graphql'); // 0.12 or later
+const graphqlSchema = new graphql.Schema({
+  //...
+});
+module.context.use(createGraphQLRouter({
+  schema: graphqlSchema,
+  graphiql: true,
+  graphql: graphql
+}))
+```
+
+Foxx also bundles version 0.6 of the
+[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+which is a synchronous wrapper for the official JavaScript GraphQL reference
+implementation.
 
 {% hint 'warning' %}
 `graphql-sync` is a thin wrapper for old versions of `graphql`, allowing it
@@ -12,25 +46,6 @@ and only shipped for backward compatibility. Version 0.12 and newer of the
 official `graphql` package can be used directly. New projects should bundle
 an own copy of this module: <https://www.npmjs.com/package/graphql>
 {% endhint %}
-
-`const createGraphQLRouter = require('@arangodb/foxx/graphql');`
-
-Foxx bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a
-synchronous wrapper for the official JavaScript GraphQL reference
-implementation, to allow writing GraphQL schemas directly inside Foxx.
-
-Additionally the `@arangodb/foxx/graphql` lets you create routers for serving
-GraphQL requests, which closely mimicks the behavior of the
-[`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
-
-For more information on `graphql-sync` see the
-[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
-(note that `graphql-sync` never wraps results in promises).
-
-For an example of a GraphQL schema in Foxx that resolves fields using the
-database see [the GraphQL example service](https://github.com/arangodb-foxx/demo-graphql){:target="_blank"}
-(also available from the Foxx store).
 
 **Examples**
 
@@ -62,39 +77,9 @@ router.use('/graphql', createGraphQLRouter({
 }));
 ```
 
-**Note**: ArangoDB aims for stability which means bundled dependencies will
-generally not be updated as quickly as their maintainers make updates
-available on GitHub or NPM. Starting with ArangoDB 3.2, if you want to use a
-newer version than the one bundled with your target version of ArangoDB, you
-can provide your own version of the library by passing it via the `graphql` option:
-
-```js
-const graphql = require('graphql-sync');
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
-
-Starting with `graphql` version 0.12 you can also use the
-[official graphql library](https://github.com/graphql/graphql-js){:target="_blank"} if you
-include it in the `node_modules` folder of your service bundle:
-
-```js
-const graphql = require('graphql'); // 0.12 or later
-const graphqlSchema = new graphql.Schema({
-  //...
-});
-module.context.use(createGraphQLRouter({
-  schema: graphqlSchema,
-  graphiql: true,
-  graphql: graphql
-}))
-```
+For more information on `graphql-sync` see the
+[`graphql-js` API reference](http://graphql.org/docs/api-reference-graphql/){:target="_blank"}
+(note that `graphql-sync` never wraps results in promises).
 
 Creating a router
 -----------------


### PR DESCRIPTION
@pluma I think this doesn't go far enough yet. WDYT about moving the part about 0.12+ up, and move the legacy stuff to the bottom, under a separate headline?