### PR TITLE
Canonical redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,4 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 #gem 'jekyll-sitemap', "~> 1.3.1"
-gem "jekyll-redirect-from", "~> 0.12"
+#gem "jekyll-redirect-from", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       nokogiri (~> 1.6)
       progressbar (~> 1.9)
       verbal_expressions (~> 0.1.5)
-    jekyll-redirect-from (0.16.0)
-      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -100,7 +98,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.1.1)
   jekyll-algolia (~> 1.0)
-  jekyll-redirect-from (~> 0.12)
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/_config.yml
+++ b/_config.yml
@@ -28,9 +28,9 @@ kramdown:
     ndash: "--"
 
 #theme: minima
-plugins:
- #- jekyll-feed
-  - jekyll-redirect-from
+#plugins:
+# - jekyll-feed
+# - jekyll-redirect-from # Modified version inlined to redirect to canonical versions
 
 # Certain directories can be excluded from sitemap,
 # but including the stable folder (symlink) does not work.

--- a/_plugins/jekyll-redirect-from.rb
+++ b/_plugins/jekyll-redirect-from.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "jekyll"
+require "jekyll-redirect-from/version"
+require "jekyll-redirect-from/generator"
+
+module JekyllRedirectFrom
+  # Jekyll classes which should be redirectable
+  CLASSES = [Jekyll::Page, Jekyll::Document].freeze
+
+  autoload :Context,          "jekyll-redirect-from/context"
+  autoload :RedirectPage,     "jekyll-redirect-from/redirect_page"
+  autoload :Redirectable,     "jekyll-redirect-from/redirectable"
+  autoload :Layout,           "jekyll-redirect-from/layout"
+  autoload :PageWithoutAFile, "jekyll-redirect-from/page_without_a_file"
+end
+
+JekyllRedirectFrom::CLASSES.each do |klass|
+  klass.send :include, JekyllRedirectFrom::Redirectable
+end

--- a/_plugins/jekyll-redirect-from.rb
+++ b/_plugins/jekyll-redirect-from.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 require "jekyll"
-require "jekyll-redirect-from/version"
-require "jekyll-redirect-from/generator"
+require_relative "jekyll-redirect-from/version"
+require_relative "jekyll-redirect-from/generator"
 
 module JekyllRedirectFrom
   # Jekyll classes which should be redirectable
   CLASSES = [Jekyll::Page, Jekyll::Document].freeze
 
-  autoload :Context,          "jekyll-redirect-from/context"
-  autoload :RedirectPage,     "jekyll-redirect-from/redirect_page"
-  autoload :Redirectable,     "jekyll-redirect-from/redirectable"
-  autoload :Layout,           "jekyll-redirect-from/layout"
-  autoload :PageWithoutAFile, "jekyll-redirect-from/page_without_a_file"
+  autoload :Context,          "./jekyll-redirect-from/context"
+  autoload :RedirectPage,     "./jekyll-redirect-from/redirect_page"
+  autoload :Redirectable,     "./jekyll-redirect-from/redirectable"
+  autoload :Layout,           "./jekyll-redirect-from/layout"
+  autoload :PageWithoutAFile, "./jekyll-redirect-from/page_without_a_file"
 end
 
 JekyllRedirectFrom::CLASSES.each do |klass|

--- a/_plugins/jekyll-redirect-from/context.rb
+++ b/_plugins/jekyll-redirect-from/context.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  # Stubbed LiquidContext to support relative_url and absolute_url helpers
+  class Context
+    attr_reader :site
+
+    def initialize(site)
+      @site = site
+    end
+
+    def registers
+      { :site => site }
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/generator.rb
+++ b/_plugins/jekyll-redirect-from/generator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  class Generator < Jekyll::Generator
+    safe true
+    attr_reader :site, :redirects
+
+    def generate(site)
+      @site = site
+      @redirects = {}
+
+      # Inject our layout, unless the user has already specified a redirect layout'
+      unless site.layouts.key?("redirect")
+        site.layouts["redirect"] = JekyllRedirectFrom::Layout.new(site)
+      end
+
+      # Must duplicate pages to modify while in loop
+      (site.docs_to_write + site.pages.dup).each do |doc|
+        next unless redirectable_document?(doc)
+
+        generate_redirect_from(doc)
+        generate_redirect_to(doc)
+      end
+
+      generate_redirects_json if generate_redirects_json?
+    end
+
+    private
+
+    # For every `redirect_from` entry, generate a redirect page
+    def generate_redirect_from(doc)
+      doc.redirect_from.each do |path|
+        page = RedirectPage.redirect_from(doc, path)
+        doc.site.pages << page
+        redirects[page.redirect_from] = page.redirect_to
+      end
+    end
+
+    def generate_redirect_to(doc)
+      return unless doc.redirect_to
+
+      page = RedirectPage.redirect_to(doc, doc.redirect_to)
+      doc.data.merge!(page.data)
+      doc.content = doc.output = page.output
+      redirects[page.redirect_from] = page.redirect_to
+    end
+
+    def generate_redirects_json
+      return if File.exist? site.in_source_dir("redirects.json")
+
+      page = PageWithoutAFile.new(site, "", "", "redirects.json")
+      page.content = redirects.to_json
+      page.data["layout"] = nil
+      site.pages << page
+    end
+
+    def redirectable_document?(doc)
+      doc.is_a?(Jekyll::Document) || doc.is_a?(Jekyll::Page)
+    end
+
+    def generate_redirects_json?
+      site.config.dig("redirect_from", "json") != false
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/layout.rb
+++ b/_plugins/jekyll-redirect-from/layout.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  # A stubbed layout for our default redirect template
+  # We cannot use the standard Layout class because of site.in_source_dir
+  class Layout < Jekyll::Layout
+    def initialize(site)
+      @site = site
+      @base = __dir__
+      @name = "redirect.html"
+      @path = File.expand_path(@name, @base)
+      @relative_path = "_layouts/redirect.html"
+
+      self.data = {}
+      self.ext = "html"
+      self.content = File.read(@path)
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/page_without_a_file.rb
+++ b/_plugins/jekyll-redirect-from/page_without_a_file.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  class PageWithoutAFile < Jekyll::Page
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/redirect.html
+++ b/_plugins/jekyll-redirect-from/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <script>location="{{ page.redirect.to }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+</html>

--- a/_plugins/jekyll-redirect-from/redirect_page.rb
+++ b/_plugins/jekyll-redirect-from/redirect_page.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  # Specialty page which implements the redirect path logic
+  class RedirectPage < Jekyll::Page
+    # Use Jekyll's native absolute_url filter
+    include Jekyll::Filters::URLFilters
+
+    DEFAULT_DATA = {
+      "sitemap" => false,
+      "layout"  => "redirect",
+    }.freeze
+
+    # Creates a new RedirectPage instance from a source path and redirect path
+    #
+    # site - The Site object
+    # from - the (URL) path, relative to the site root to redirect from
+    # to   - the relative path or URL which the page should redirect to
+    def self.from_paths(site, from, to)
+      page = RedirectPage.new(site, site.source, "", "redirect.html")
+      page.set_paths(from, to)
+      page
+    end
+
+
+    # Creates a new RedirectPage instance from the path to the given doc
+    def self.redirect_from(doc, path)
+      RedirectPage.from_paths(doc.site, path, doc.url)
+    end
+
+    # Creates a new RedirectPage instance from the doc to the given path
+    def self.redirect_to(doc, path)
+      RedirectPage.from_paths(doc.site, doc.url, path)
+    end
+
+    # Overwrite the default read_yaml method since the file doesn't exist
+    def read_yaml(_base, _name, _opts = {})
+      self.content = self.output = ""
+      self.data ||= DEFAULT_DATA.dup
+    end
+
+    # Helper function to set the appropriate path metadata
+    #
+    # from - the relative path to the redirect page
+    # to   - the relative path or absolute URL to the redirect target
+    def set_paths(from, to)
+      @context ||= context
+      from = ensure_leading_slash(from)
+      data.merge!(
+        "permalink" => from,
+        "redirect"  => {
+          "from" => from,
+          "to"   => %r!^https?://!.match?(to) ? to : absolute_url(to),
+        }
+      )
+    end
+
+    def redirect_from
+      data["redirect"]["from"] if data["redirect"]
+      #puts data["redirect"]
+    end
+
+    def redirect_to
+      data["redirect"]["to"] if data["redirect"]
+    end
+
+    private
+
+    def context
+      JekyllRedirectFrom::Context.new(site)
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/redirect_page.rb
+++ b/_plugins/jekyll-redirect-from/redirect_page.rb
@@ -18,10 +18,29 @@ module JekyllRedirectFrom
     # to   - the relative path or URL which the page should redirect to
     def self.from_paths(site, from, to)
       page = RedirectPage.new(site, site.source, "", "redirect.html")
+      ##### BEGIN ArangoDB customization #####
+      if Jekyll.env != 'netlify'
+        to = RedirectPage.to_canonical(site.config, to)
+      end
+      ##### END ArangoDB customization #####
       page.set_paths(from, to)
       page
     end
 
+    ##### BEGIN ArangoDB customization #####
+    def self.to_canonical(config, url)
+      return url if url.start_with?('/stable/', '/devel/')
+      stable = config['versions']['stable']
+      devel = config['versions']['devel']
+      url
+        .sub(RedirectPage.version_regexp(stable), '/stable/')
+        .sub(RedirectPage.version_regexp(devel), '/devel/')
+    end
+
+    def self.version_regexp(version)
+      Regexp.new("^#{Regexp.escape("/#{version}/")}")
+    end
+    ##### END ArangoDB customization #####
 
     # Creates a new RedirectPage instance from the path to the given doc
     def self.redirect_from(doc, path)

--- a/_plugins/jekyll-redirect-from/redirectable.rb
+++ b/_plugins/jekyll-redirect-from/redirectable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  # Module which can be mixed in to documents (and pages) to provide
+  # redirect_to and redirect_from helpers
+  module Redirectable
+    # Returns a string representing the relative path or URL
+    # to which the document should be redirected
+    def redirect_to
+      if to_liquid["redirect_to"].is_a?(Array)
+        to_liquid["redirect_to"].compact.first
+      else
+        to_liquid["redirect_to"]
+      end
+    end
+
+    # Returns an array representing the relative paths to other
+    # documents which should be redirected to this document
+    def redirect_from
+      if to_liquid["redirect_from"].is_a?(Array)
+        to_liquid["redirect_from"].compact
+      else
+        [to_liquid["redirect_from"]].compact
+      end
+    end
+  end
+end

--- a/_plugins/jekyll-redirect-from/version.rb
+++ b/_plugins/jekyll-redirect-from/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module JekyllRedirectFrom
+  VERSION = "0.16.0"
+end

--- a/_plugins/versions.rb
+++ b/_plugins/versions.rb
@@ -29,7 +29,8 @@
 #         Non-versioned pages use the `STABLE_VERSION`'s sidebar data.
 #     `canonical` — the relative URL of the stable version of the page, if any
 
-Jekyll::External.require_with_graceful_fail('jekyll-redirect-from')
+#Jekyll::External.require_with_graceful_fail('jekyll-redirect-from')
+require_relative 'jekyll-redirect-from'
 
 require_relative 'versions/symlink'
 require_relative 'versions/version'


### PR DESCRIPTION
Before:
- `/3.7/ -> /3.7/` ✔️ 
- `/stable/ -> /3.7/` ❌ 

After:
- `/3.7/ -> /stable/` ❌ 
- `/stable/ -> /stable/` ✔️ 

Desired:
- `/3.7/ -> /3.7/` ✔️ 
- `/stable/ -> /stable/` ✔️ 

Problem: `/stable` is symlinked and can only forward to either `/3.7` or `/stable`. We would need to generate the files for stable and devel version separately (or at least the redirect files).