### PR TITLE
Fix broken links

### DIFF
--- a/3.3/appendix-java-script-modules.md
+++ b/3.3/appendix-java-script-modules.md
@@ -113,7 +113,7 @@ The following [NPM modules](https://www.npmjs.com){:target="_blank"} are preinst
 
 <!-- * [extendible] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-* [graphql-sync](https://github.com/arangodb/graphql-sync){:target="_blank"}
+* [graphql-sync](https://www.npmjs.com/package/graphql-sync){:target="_blank"}
   is an ArangoDB-compatible GraphQL server/schema implementation.
 
 * [highlight.js](https://highlightjs.org){:target="_blank"}

--- a/3.3/foxx-graph-ql.md
+++ b/3.3/foxx-graph-ql.md
@@ -7,7 +7,7 @@ Using GraphQL in Foxx
 
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
-Foxx bundles version 0.6 of the [`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a synchronous wrapper for the official JavaScript GraphQL reference implementation, to allow writing GraphQL schemas directly inside Foxx.
+Foxx bundles version 0.6 of the [`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"}, which is a synchronous wrapper for the official JavaScript GraphQL reference implementation, to allow writing GraphQL schemas directly inside Foxx.
 
 Additionally the `@arangodb/foxx/graphql` lets you create routers for serving GraphQL requests, which closely mimics the behavior of the [`express-graphql` module](https://github.com/graphql/express-graphql){:target="_blank"}.
 

--- a/3.3/release-notes-new-features21.md
+++ b/3.3/release-notes-new-features21.md
@@ -241,8 +241,8 @@ Updated drivers
 ---------------
 
 Several drivers for ArangoDB have been checked for compatibility with 2.1.  The
-current list of drivers with compatibility notes can be found online
-[here](https://www.arangodb.org/driver){:target="_blank"}.
+current list of drivers with compatibility notes can be found at
+[arangodb.com/arangodb-drivers/](https://www.arangodb.com/arangodb-drivers/){:target="_blank"}.
 
 C++11 usage
 -----------

--- a/3.3/release-notes-new-features24.md
+++ b/3.3/release-notes-new-features24.md
@@ -64,9 +64,9 @@ The FoxxGenerator can create APIs based on a semantic description of entities
 and transitions. A blog series on the use cases and how to use the Foxx generator
 is here:
 
-* [part 1](https://www.arangodb.com/2014/11/26/building-hypermedia-api-json){:target="_blank"}
-* [part 2](https://www.arangodb.com/2014/12/02/building-hypermedia-apis-design){:target="_blank"}
-* [part 3](https://www.arangodb.com/2014/12/08/building-hypermedia-apis-foxxgenerator){:target="_blank"}
+* [Building Hypermedia APIs – Links and Forms in JSON](https://www.arangodb.com/2014/11/building-hypermedia-api-json/){:target="_blank"}
+* [Building Hypermedia APIs – a Design Approach using Statecharts](https://www.arangodb.com/2014/12/building-hypermedia-apis-design/){:target="_blank"}
+* [Building Hypermedia APIs – FoxxGenerator](https://www.arangodb.com/2014/12/building-hypermedia-apis-foxxgenerator/){:target="_blank"}
 
 AQL improvements
 ----------------

--- a/3.3/release-notes-new-features26.md
+++ b/3.3/release-notes-new-features26.md
@@ -231,7 +231,7 @@ documentation in your own Foxx apps. For more information see the
 Foxx documentation.
 
 Also see the blog post introducing this feature:
-[Document your Foxx apps with Swagger 2](https://www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/){:target="_blank"}
+[Document your Foxx apps with Swagger 2](https://www.arangodb.com/2015/05/foxx-swagger/){:target="_blank"}
 
 ### Custom Scripts and Foxx Queue
 

--- a/3.4/appendix-java-script-modules.md
+++ b/3.4/appendix-java-script-modules.md
@@ -112,7 +112,7 @@ The following [NPM modules](https://www.npmjs.com){:target="_blank"} are preinst
 
 <!-- * [extendible] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-* [graphql-sync](https://github.com/arangodb/graphql-sync){:target="_blank"}
+* [graphql-sync](https://www.npmjs.com/package/graphql-sync){:target="_blank"}
   is an ArangoDB-compatible GraphQL server/schema implementation.
 
 * [highlight.js](https://highlightjs.org){:target="_blank"}

--- a/3.4/foxx-reference-modules-graph-ql.md
+++ b/3.4/foxx-reference-modules-graph-ql.md
@@ -8,7 +8,7 @@ GraphQL integration
 `const createGraphQLRouter = require('@arangodb/foxx/graphql');`
 
 Foxx bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"}, which is a
+[`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"}, which is a
 synchronous wrapper for the official JavaScript GraphQL reference
 implementation, to allow writing GraphQL schemas directly inside Foxx.
 

--- a/3.4/release-notes-new-features21.md
+++ b/3.4/release-notes-new-features21.md
@@ -241,8 +241,8 @@ Updated drivers
 ---------------
 
 Several drivers for ArangoDB have been checked for compatibility with 2.1.  The
-current list of drivers with compatibility notes can be found online
-[here](https://www.arangodb.org/driver){:target="_blank"}.
+current list of drivers with compatibility notes can be found at
+[arangodb.com/arangodb-drivers/](https://www.arangodb.com/arangodb-drivers/){:target="_blank"}.
 
 C++11 usage
 -----------

--- a/3.4/release-notes-new-features24.md
+++ b/3.4/release-notes-new-features24.md
@@ -64,9 +64,9 @@ The FoxxGenerator can create APIs based on a semantic description of entities
 and transitions. A blog series on the use cases and how to use the Foxx generator
 is here:
 
-* [part 1](https://www.arangodb.com/2014/11/26/building-hypermedia-api-json){:target="_blank"}
-* [part 2](https://www.arangodb.com/2014/12/02/building-hypermedia-apis-design){:target="_blank"}
-* [part 3](https://www.arangodb.com/2014/12/08/building-hypermedia-apis-foxxgenerator){:target="_blank"}
+* [Building Hypermedia APIs – Links and Forms in JSON](https://www.arangodb.com/2014/11/building-hypermedia-api-json/){:target="_blank"}
+* [Building Hypermedia APIs – a Design Approach using Statecharts](https://www.arangodb.com/2014/12/building-hypermedia-apis-design/){:target="_blank"}
+* [Building Hypermedia APIs – FoxxGenerator](https://www.arangodb.com/2014/12/building-hypermedia-apis-foxxgenerator/){:target="_blank"}
 
 AQL improvements
 ----------------

--- a/3.4/release-notes-new-features26.md
+++ b/3.4/release-notes-new-features26.md
@@ -231,7 +231,7 @@ documentation in your own Foxx apps. For more information see the
 Foxx documentation.
 
 Also see the blog post introducing this feature:
-[Document your Foxx apps with Swagger 2](https://www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/){:target="_blank"}
+[Document your Foxx apps with Swagger 2](https://www.arangodb.com/2015/05/foxx-swagger/){:target="_blank"}
 
 ### Custom Scripts and Foxx Queue
 

--- a/3.5/appendix-java-script-modules.md
+++ b/3.5/appendix-java-script-modules.md
@@ -189,7 +189,7 @@ are preinstalled:
 
 <!-- - [**extendible**] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-- [**graphql-sync**](https://github.com/arangodb/graphql-sync){:target="_blank"}
+- [**graphql-sync**](https://www.npmjs.com/package/graphql-sync){:target="_blank"}
   is an ArangoDB-compatible GraphQL server/schema implementation.
 
 - [**highlight.js**](https://highlightjs.org){:target="_blank"}

--- a/3.5/foxx-reference-modules-graph-ql.md
+++ b/3.5/foxx-reference-modules-graph-ql.md
@@ -35,7 +35,7 @@ module.context.use(createGraphQLRouter({
 ```
 
 Foxx also bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+[`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"},
 which is a synchronous wrapper for the official JavaScript GraphQL reference
 implementation.
 

--- a/3.5/programs-arangobackup-examples.md
+++ b/3.5/programs-arangobackup-examples.md
@@ -228,7 +228,7 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+[Rclone](https://rclone.org/){:target="_blank"} is a versatile open-source
 remote file sync program that can deal with over 30 different remote file
 IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
@@ -285,7 +285,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
+[rclone.org/s3/](https://rclone.org/s3/){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -307,7 +307,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local){:target="_blank"}.
+[rclone.org/local/](https://rclone.org/local/){:target="_blank"}.
 
 ### WebDAV
 
@@ -330,4 +330,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.
+[rclone.org/webdav/](https://rclone.org/webdav/){:target="_blank"}.

--- a/3.6/appendix-java-script-modules.md
+++ b/3.6/appendix-java-script-modules.md
@@ -189,7 +189,7 @@ are preinstalled:
 
 <!-- - [**extendible**] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-- [**graphql-sync**](https://github.com/arangodb/graphql-sync){:target="_blank"}
+- [**graphql-sync**](https://www.npmjs.com/package/graphql-sync){:target="_blank"}
   is an ArangoDB-compatible GraphQL server/schema implementation.
 
 - [**highlight.js**](https://highlightjs.org){:target="_blank"}

--- a/3.6/foxx-reference-modules-graph-ql.md
+++ b/3.6/foxx-reference-modules-graph-ql.md
@@ -35,7 +35,7 @@ module.context.use(createGraphQLRouter({
 ```
 
 Foxx also bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+[`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"},
 which is a synchronous wrapper for the official JavaScript GraphQL reference
 implementation.
 

--- a/3.6/programs-arangobackup-examples.md
+++ b/3.6/programs-arangobackup-examples.md
@@ -234,7 +234,7 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+[Rclone](https://rclone.org/){:target="_blank"} is a versatile open-source
 remote file sync program that can deal with over 30 different remote file
 IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
@@ -291,7 +291,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
+[rclone.org/s3/](https://rclone.org/s3/){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -313,7 +313,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local){:target="_blank"}.
+[rclone.org/local/](https://rclone.org/local/){:target="_blank"}.
 
 ### WebDAV
 
@@ -336,4 +336,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.
+[rclone.org/webdav/](https://rclone.org/webdav/){:target="_blank"}.

--- a/3.7/appendix-java-script-modules.md
+++ b/3.7/appendix-java-script-modules.md
@@ -189,7 +189,7 @@ are preinstalled:
 
 <!-- - [**extendible**] (https://github.com/3rd-Eden/extendible) (only for legacy mode) -->
 
-- [**graphql-sync**](https://github.com/arangodb/graphql-sync){:target="_blank"}
+- [**graphql-sync**](https://www.npmjs.com/package/graphql-sync){:target="_blank"}
   is an ArangoDB-compatible GraphQL server/schema implementation.
 
 - [**highlight.js**](https://highlightjs.org){:target="_blank"}

--- a/3.7/foxx-reference-modules-graph-ql.md
+++ b/3.7/foxx-reference-modules-graph-ql.md
@@ -35,7 +35,7 @@ module.context.use(createGraphQLRouter({
 ```
 
 Foxx also bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+[`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"},
 which is a synchronous wrapper for the official JavaScript GraphQL reference
 implementation.
 

--- a/3.7/programs-arangobackup-examples.md
+++ b/3.7/programs-arangobackup-examples.md
@@ -234,7 +234,7 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+[Rclone](https://rclone.org/){:target="_blank"} is a versatile open-source
 remote file sync program that can deal with over 30 different remote file
 IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
@@ -291,7 +291,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
+[rclone.org/s3/](https://rclone.org/s3/){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -313,7 +313,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local){:target="_blank"}.
+[rclone.org/local/](https://rclone.org/local/){:target="_blank"}.
 
 ### WebDAV
 
@@ -336,4 +336,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.
+[rclone.org/webdav/](https://rclone.org/webdav/){:target="_blank"}.

--- a/3.7/release-notes-new-features21.md
+++ b/3.7/release-notes-new-features21.md
@@ -241,8 +241,8 @@ Updated drivers
 ---------------
 
 Several drivers for ArangoDB have been checked for compatibility with 2.1. The
-current list of drivers with compatibility notes can be found online
-[here](https://www.arangodb.org/driver){:target="_blank"}.
+current list of drivers with compatibility notes can be found on
+[Drivers Documentation page](drivers){:target="_blank"}.
 
 C++11 usage
 -----------

--- a/3.7/release-notes-new-features21.md
+++ b/3.7/release-notes-new-features21.md
@@ -241,8 +241,8 @@ Updated drivers
 ---------------
 
 Several drivers for ArangoDB have been checked for compatibility with 2.1. The
-current list of drivers with compatibility notes can be found on
-[Drivers Documentation page](drivers){:target="_blank"}.
+current list of drivers with compatibility notes can be found at
+[arangodb.com/arangodb-drivers/](https://www.arangodb.com/arangodb-drivers/){:target="_blank"}.
 
 C++11 usage
 -----------

--- a/3.7/release-notes-new-features24.md
+++ b/3.7/release-notes-new-features24.md
@@ -64,9 +64,9 @@ The FoxxGenerator can create APIs based on a semantic description of entities
 and transitions. A blog series on the use cases and how to use the Foxx generator
 is here:
 
-* [part 1](https://www.arangodb.com/2014/11/26/building-hypermedia-api-json){:target="_blank"}
-* [part 2](https://www.arangodb.com/2014/12/02/building-hypermedia-apis-design){:target="_blank"}
-* [part 3](https://www.arangodb.com/2014/12/08/building-hypermedia-apis-foxxgenerator){:target="_blank"}
+* [Building Hypermedia APIs – Links and Forms in JSON](https://www.arangodb.com/2014/11/building-hypermedia-api-json/){:target="_blank"}
+* [Building Hypermedia APIs – a Design Approach using Statecharts](https://www.arangodb.com/2014/12/building-hypermedia-apis-design/){:target="_blank"}
+* [Building Hypermedia APIs – FoxxGenerator](https://www.arangodb.com/2014/12/building-hypermedia-apis-foxxgenerator/){:target="_blank"}
 
 AQL improvements
 ----------------

--- a/3.7/release-notes-new-features26.md
+++ b/3.7/release-notes-new-features26.md
@@ -222,7 +222,7 @@ The API documentation has been updated to Swagger 2. You can now also mount API
 documentation in your own Foxx apps.
 
 Also see the blog post introducing this feature:
-[www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/](https://www.arangodb.com/2015/05/document-your-foxx-apps-with-swagger-2/){:target="_blank"}
+[Document your Foxx apps with Swagger 2](https://www.arangodb.com/2015/05/foxx-swagger/){:target="_blank"}
 
 ### Custom Scripts and Foxx Queue
 

--- a/3.8/foxx-reference-modules-graph-ql.md
+++ b/3.8/foxx-reference-modules-graph-ql.md
@@ -35,7 +35,7 @@ module.context.use(createGraphQLRouter({
 ```
 
 Foxx also bundles version 0.6 of the
-[`graphql-sync` module](https://github.com/arangodb/graphql-sync){:target="_blank"},
+[`graphql-sync` module](https://www.npmjs.com/package/graphql-sync){:target="_blank"},
 which is a synchronous wrapper for the official JavaScript GraphQL reference
 implementation.
 

--- a/3.8/programs-arangobackup-examples.md
+++ b/3.8/programs-arangobackup-examples.md
@@ -234,7 +234,7 @@ The output will look like this:
 Rclone Configuration
 --------------------
 
-[Rclone](https://rclone.org){:target="_blank"} is a versatile open-source
+[Rclone](https://rclone.org/){:target="_blank"} is a versatile open-source
 remote file sync program that can deal with over 30 different remote file
 IO protocols. Enterprise Editions of ArangoDB come with a bundled version
 of Rclone, which is distributed under the MIT license. It is used to
@@ -291,7 +291,7 @@ The file `my-s3.json` could look like this:
 ```
 
 More examples and details for S3 configurations can be found at
-[rclone.org/s3](https://rclone.org/s3){:target="_blank"}.
+[rclone.org/s3/](https://rclone.org/s3/){:target="_blank"}.
 
 ### Locally mounted local or remote volumes
 
@@ -313,7 +313,7 @@ The file `my-local.json` could look like this:
 ```
 
 More examples and details for local configurations can be found at
-[rclone.org/local](https://rclone.org/local){:target="_blank"}.
+[rclone.org/local/](https://rclone.org/local/){:target="_blank"}.
 
 ### WebDAV
 
@@ -336,4 +336,4 @@ Thie file `my-dav.json` could look like this:
 ```
 
 More examples and details on WebDAV configurations can be found
-[rclone.org/webdav](https://rclone.org/webdav){:target="_blank"}.
+[rclone.org/webdav/](https://rclone.org/webdav/){:target="_blank"}.


### PR DESCRIPTION
- Fix link to drivers page.
- Fix link to post "Document your Foxx apps with Swagger 2".
- Fix links to "Building Hypermedia APIs" blog series.
- Fix rclone.org links.
- Fix link to `graphql-sync` module (from [not exists github repository](https://github.com/arangodb/graphql-sync) to [NPM page](https://www.npmjs.com/package/graphql-sync).