### PR TITLE
Fix "Contribute" link for "Oasis" pages.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   {%- include head.html %}
 </head>
 <body>
-  {% include topnav.html %} 
+  {% include topnav.html %}
   <div class="book with-summary font-size-2 font-family-1">
     <div class="book-summary">
       {% include sidebar.html %}
@@ -28,7 +28,18 @@
       <div class="body-inner">
         <div class="book-header" role="navigation">
           <a class="btn pull-left js-toolbar-action hamburger" aria-label=""><i class="fa fa-align-justify"></i></a>
-          <a class="btn pull-left js-toolbar-action" aria-label="" href="https://github.com/arangodb/docs/edit/main/{{ page["path"] }}" target="_blank"><i class="fa fa-github"></i> Contribute</a>
+          {% assign pathChunks = page.path | split: '/' %}
+          {% if pathChunks[1] == 'oasis' %}
+                {% assign isOasis = true  %}
+            {% else %}
+                {% assign isOasis = false  %}
+            {% endif %}
+          {% if isOasis %}
+                {% assign realPagePath = page.path | slice: 4, 9999 %}
+            {% else %}
+                {% assign realPagePath = page.path %}
+           {% endif %}
+          <a class="btn pull-left js-toolbar-action" aria-label="" href="https://github.com/arangodb/docs/edit/main/{{ realPagePath }}" target="_blank"><i class="fa fa-github"></i> Contribute</a>
         </div>
         <div class="page-wrapper" tabindex="-1" role="main">
           <div class="page-inner">


### PR DESCRIPTION
`oasis` directory is symlinked to version directory (for example `3.7`). Therefore `page.path` starts with version directory, like `3.7/oasis/organizations.md` instead of real path `oasis/organizations.md` that should be used to generate link for "Contribute"-button.

I'm not sure that my fix implementation is the right way for this case. Seems, that it would be better to have custom filter to resolve symlink, but I don't not if it is possible with Jekyll.