### PR TITLE
Remove link to Arangosync changelog

### DIFF
--- a/3.4/release-notes.md
+++ b/3.4/release-notes.md
@@ -51,7 +51,8 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
-- [ArangoSync](https://github.com/arangodb/arangosync/blob/master/CHANGELOG){:target="_blank"}
+- [Foxx CLI](https://github.com/arangodb/foxx-cli/blob/main/CHANGELOG.md){:target="_blank"}
+- [kube-arangodb](https://github.com/arangodb/kube-arangodb/blob/master/CHANGELOG.md){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.5/release-notes.md
+++ b/3.5/release-notes.md
@@ -53,7 +53,8 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
-- [ArangoSync](https://github.com/arangodb/arangosync/blob/master/CHANGELOG){:target="_blank"}
+- [Foxx CLI](https://github.com/arangodb/foxx-cli/blob/main/CHANGELOG.md){:target="_blank"}
+- [kube-arangodb](https://github.com/arangodb/kube-arangodb/blob/master/CHANGELOG.md){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.6/release-notes.md
+++ b/3.6/release-notes.md
@@ -55,7 +55,8 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
-- [ArangoSync](https://github.com/arangodb/arangosync/blob/master/CHANGELOG){:target="_blank"}
+- [Foxx CLI](https://github.com/arangodb/foxx-cli/blob/main/CHANGELOG.md){:target="_blank"}
+- [kube-arangodb](https://github.com/arangodb/kube-arangodb/blob/master/CHANGELOG.md){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.7/release-notes.md
+++ b/3.7/release-notes.md
@@ -57,7 +57,6 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
-- [ArangoSync](https://github.com/arangodb/arangosync/blob/master/CHANGELOG){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.7/release-notes.md
+++ b/3.7/release-notes.md
@@ -57,6 +57,8 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
+- [Foxx CLI](https://github.com/arangodb/foxx-cli/blob/main/CHANGELOG.md){:target="_blank"}
+- [kube-arangodb](https://github.com/arangodb/kube-arangodb/blob/master/CHANGELOG.md){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.8/release-notes.md
+++ b/3.8/release-notes.md
@@ -59,6 +59,8 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
+- [Foxx CLI](https://github.com/arangodb/foxx-cli/blob/main/CHANGELOG.md){:target="_blank"}
+- [kube-arangodb](https://github.com/arangodb/kube-arangodb/blob/master/CHANGELOG.md){:target="_blank"}
 
 Incompatible changes
 --------------------

--- a/3.8/release-notes.md
+++ b/3.8/release-notes.md
@@ -59,7 +59,6 @@ please refer to the version specific changelogs:
 Additional changelogs for tools not included in the main repository:
 
 - [ArangoDB Starter](https://github.com/arangodb-helper/arangodb/blob/master/CHANGELOG.md){:target="_blank"}
-- [ArangoSync](https://github.com/arangodb/arangosync/blob/master/CHANGELOG){:target="_blank"}
 
 Incompatible changes
 --------------------


### PR DESCRIPTION
It's considered internal only and not shared with Enterprise customers.

Fixes #590