### PR TITLE
Add resolve_symlink filter to get relative source file path

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
       <div class="body-inner">
         <div class="book-header" role="navigation">
           <a class="btn pull-left js-toolbar-action hamburger" aria-label=""><i class="fa fa-align-justify"></i></a>
-          <a class="btn pull-left js-toolbar-action" aria-label="" href="https://github.com/arangodb/docs/edit/main/{{ page["path"] }}" target="_blank"><i class="fa fa-github"></i> Contribute</a>
+          <a class="btn pull-left js-toolbar-action" aria-label="" href="https://github.com/arangodb/docs/edit/main/{{ page["path"] | resolve_symlink }}" target="_blank"><i class="fa fa-github"></i> Contribute</a>
         </div>
         <div class="page-wrapper" tabindex="-1" role="main">
           <div class="page-inner">

--- a/_plugins/ExtraFilters.rb
+++ b/_plugins/ExtraFilters.rb
@@ -58,6 +58,12 @@ module Jekyll
             *a, b = arr
             a.join(', ') + ' and ' + b
         end
+
+        def resolve_symlink(path)
+            site = @context.registers[:site]
+            source = site.source # base path
+            Pathname.new(File.realpath(path)).relative_path_from(source).to_s
+        end
     end
 end
 


### PR DESCRIPTION
More generic fix than #589, which also fixes the GitHub Contribute link for the release notes, drivers etc.

The path separator is apparently `/` on Windows as well, so it looks like no special processing is needed to go from `page['path']` to realpath to relative URL path.