### PR TITLE
Clarifications around the WITH operation

### DIFF
--- a/3.6/aql/operations-with.md
+++ b/3.6/aql/operations-with.md
@@ -1,15 +1,64 @@
 ---
 layout: default
 description: An AQL query can optionally start with a WITH statement and the list of collections used by the query
+title: AQL WITH Operation
 ---
-
 WITH
 ====
 
-An AQL query can optionally start with a *WITH* statement and the list of 
-collections used by the query. All collections specified in *WITH* will be
-read-locked at query start, in addition to the other collections the query
-uses and that are detected by the AQL query parser.
+An AQL query can start with a `WITH` keyword followed by a list of collections
+that the query implicitly reads from. All collections specified in the `WITH`
+statement will be read-locked at query start, in addition to other collections
+that are explicitly used in the query and automatically detected by the AQL
+query parser.
+
+Syntax
+------
+
+<pre><code>WITH <em>collection1</em> [, <em>collection2</em> [, ... <em>collectionN</em> ] ]</code></pre>
+
+RocksDB
+-------
+
+With RocksDB as storage engine, the `WITH` operation is only required if you
+use a cluster deployment and only for AQL queries which dynamically access
+collections for reading.
+
+MMFiles
+-------
+
+The MMFiles storage engine uses collection-level locking. Collections need to
+be locked separately for both, reading and writing.
+
+With MMFiles as storage engine, the `WITH` operation is optional for single
+server instances, but it helps to avoid deadlocks caused by lazy locking of
+collections. There is a deadlock detection, which will abort queries that are
+stuck with the error `AQL: deadlock detected`.
+
+The `WITH` operation is required if you use a cluster deployment, but only for
+AQL queries which dynamically access collections for reading.
+
+### Deadlocks
+
+If you have two transactions (here: AQL queries), T<sub>a</sub> and
+T<sub>b</sub>, and both start at approximately the same time, then the
+following may happen:
+
+- T<sub>a</sub> successfully locks collection A in write mode
+- T<sub>b</sub> successfully locks collection B in write mode
+- T<sub>a</sub> lazily accesses and tries to lock collection B in read mode,
+  but needs to wait
+- T<sub>b</sub> lazily accesses and tries to lock collection A in read mode,
+  but needs to wait
+
+Neither of the transactions can make progress. It is a deadlock.
+
+To avoid deadlocks, all collections that will be implicitly used in a query or
+transaction in read mode need to be declared upfront, so that no lazy locking
+of collections will be necessary.
+
+Usage
+-----
 
 Specifying further collections in *WITH* can be useful for queries that 
 dynamically access collections (e.g. via traversals or via dynamic 

--- a/3.8/aql/operations-with.md
+++ b/3.8/aql/operations-with.md
@@ -1,15 +1,20 @@
 ---
 layout: default
-description: An AQL query can optionally start with a WITH statement and the list of collections used by the query
+description: Declare implicitly used collections to read-lock them at query start to avoid deadlocks
+title: AQL WITH Operation
 ---
-
 WITH
 ====
 
-An AQL query can optionally start with a `WITH` statement and the list of 
-collections used by the query. All collections specified in `WITH` will be
-read-locked at query start, in addition to the other collections the query
-uses and that are detected by the AQL query parser.
+An AQL query can start with a `WITH` keyword followed by a list of collections
+that the query implicitly reads from. All collections specified in the `WITH`
+statement will be read-locked at query start, in addition to other collections
+that are explicitly used in the query and automatically detected by the AQL
+query parser.
+
+With RocksDB as storage engine, the `WITH` operation is only required if you
+use a cluster deployment and only for AQL queries which dynamically access
+collections for reading.
 
 Syntax
 ------
@@ -19,11 +24,23 @@ Syntax
 Usage
 -----
 
-Specifying further collections in `WITH` can be useful for queries that 
-dynamically access collections (e.g. via traversals or via dynamic 
-document access functions such as `DOCUMENT()`). Such collections may be 
-invisible to the AQL query parser at query compile time, and thus will not
-be read-locked automatically at query start. In this case, the AQL execution 
+Specifying additional collections using the `WITH` operation is only needed for
+queries which dynamically access collections. This is the case if a query uses
+one of the following features:
+
+- **Traversals**: 
+
+- **Functions**: 
+
+ via traversals or via
+dynamic document access functions such as `DOCUMENT()`). Such collections are
+invisible to the AQL query parser at query compile time.
+
+
+
+
+They will thus not
+be read-locked automatically at query start. In this case, the AQL execution
 engine will lazily lock these collections whenever they are used, which can 
 lead to deadlock with other queries. In case such deadlock is detected, the 
 query will automatically be aborted and changes will be rolled back. In this


### PR DESCRIPTION
Distinguish between MMFiles and RocksDB, only the latter in 3.7+ docs. Explain how deadlocks can happen.