### PR TITLE
Add section about missing locale on Linux / language mismatch on startup

### DIFF
--- a/3.6/installation-linux-osconfiguration.md
+++ b/3.6/installation-linux-osconfiguration.md
@@ -13,6 +13,36 @@ easily applied by making use of a script. Please refer to the page
 ready-to-use examples.
 {% endhint %}
 
+System Locales
+--------------
+
+Some systems may miss the required locale to start the server, resulting in an
+error message like the following:
+
+```
+FATAL [7ef60] {config} specified language 'en_US' does not match previously used language ''
+```
+
+The locale can be generated with the following command:
+
+```
+sudo locale-gen "en_US.UTF-8"
+```
+
+Your distribution may also provide a frontend for doing so, for instance
+[`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
+
+If you don't set a [default language](programs-arangod-global.html#default-language)
+for the server explicitly, ArangoDB will use the default locale of your system.
+
+{% hint 'warning' %}
+The server language is stored in the `LANGUAGE` file in the database directory.
+This file should not be modified manually to bypass issues with the locale,
+because it may render indices invalid without raising a warning or error.
+Dumping the data and restoring it into an instance that has the correct
+language configured is advised.
+{% endhint %}
+
 File Systems
 ------------
 

--- a/3.7/installation-linux-osconfiguration.md
+++ b/3.7/installation-linux-osconfiguration.md
@@ -13,6 +13,36 @@ easily applied by making use of a script. Please refer to the page
 ready-to-use examples.
 {% endhint %}
 
+System Locales
+--------------
+
+Some systems may miss the required locale to start the server, resulting in an
+error message like the following:
+
+```
+FATAL [7ef60] {config} specified language 'en_US' does not match previously used language ''
+```
+
+The locale can be generated with the following command:
+
+```
+sudo locale-gen "en_US.UTF-8"
+```
+
+Your distribution may also provide a frontend for doing so, for instance
+[`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
+
+If you don't set a [default language](programs-arangod-global.html#default-language)
+for the server explicitly, ArangoDB will use the default locale of your system.
+
+{% hint 'warning' %}
+The server language is stored in the `LANGUAGE` file in the database directory.
+This file should not be modified manually to bypass issues with the locale,
+because it may render indices invalid without raising a warning or error.
+Dumping the data and restoring it into an instance that has the correct
+language configured is advised.
+{% endhint %}
+
 File Systems
 ------------
 

--- a/3.8/installation-linux-osconfiguration.md
+++ b/3.8/installation-linux-osconfiguration.md
@@ -32,6 +32,16 @@ sudo locale-gen "en_US.UTF-8"
 Your distribution may also provide a frontend for doing so, for instance
 [`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
 
+If you don't set a [default language](programs-arangod-global.html#default-language)
+for the server explicitly, ArangoDB will use the default locale of your system.
+
+{% hint 'warning' %}
+The server language is stored in the `LANGUAGE` file in the database directory.
+This file should not be changed, because it may render indices invalid.
+To change the language, dump the data and restore it into another instance
+which has the new language set.
+{% endhint %}
+
 File Systems
 ------------
 

--- a/3.8/installation-linux-osconfiguration.md
+++ b/3.8/installation-linux-osconfiguration.md
@@ -13,6 +13,25 @@ easily applied by making use of a script. Please refer to the page
 ready-to-use examples.
 {% endhint %}
 
+System Locales
+--------------
+
+Some systems may miss the required locale to start the server, resulting in an
+error message like the following:
+
+```
+FATAL [7ef60] {config} specified language 'en_US' does not match previously used language ''
+```
+
+The locale can be generated with the following command:
+
+```
+sudo locale-gen "en_US.UTF-8"
+```
+
+Your distribution may also provide a frontend for doing so, for instance
+[`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
+
 File Systems
 ------------
 

--- a/3.8/installation-linux-osconfiguration.md
+++ b/3.8/installation-linux-osconfiguration.md
@@ -37,9 +37,10 @@ for the server explicitly, ArangoDB will use the default locale of your system.
 
 {% hint 'warning' %}
 The server language is stored in the `LANGUAGE` file in the database directory.
-This file should not be changed, because it may render indices invalid.
-To change the language, dump the data and restore it into another instance
-which has the new language set.
+This file should not be modified manually to bypass issues with the locale,
+because it may render indices invalid without raising a warning or error.
+Dumping the data and restoring it into an instance that has the correct
+language configured is advised.
 {% endhint %}
 
 File Systems


### PR DESCRIPTION
Server fails to start on some systems:

```
FATAL [7ef60] {config} specified language 'en_US' does not match previously used language ''
```

Related issues:
- https://github.com/arangodb/arangodb/issues/12501
- https://github.com/arangodb/arangodb/issues/8332

It's unclear how it gets into this situation and whether starting the server initially with an explicit `default-language` would help in such cases. We should also add information about how to switch it (dump & restore) and potentially improve the server error message in cases where there is no system locale.