### PR TITLE
fix wrong version number for new options

### DIFF
--- a/3.6/data-modeling-databases-working-with.md
+++ b/3.6/data-modeling-databases-working-with.md
@@ -229,7 +229,7 @@ all clients have disconnected and references have been garbage-collected.
 
 ### Compact
 
-<small>Introduced in: v3.5.6, v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.5.6, v3.6.7, v3.7.3</small>
 
 compact the entire data, for all databases
 `db._compact(options)`

--- a/3.6/programs-arangod-query.md
+++ b/3.6/programs-arangod-query.md
@@ -6,7 +6,7 @@ description: ArangoDB Server Query Options
 
 ## Limiting query runtime
 
-<small>Introduced in: v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.6.7, v3.7.3</small>
 
 `--query.max-runtime value`
 

--- a/3.6/programs-arangodump-examples.md
+++ b/3.6/programs-arangodump-examples.md
@@ -197,7 +197,7 @@ engine, which does not have encryption-at-rest.
 Compression
 -----------
 
-<small>Introduced in: v3.4.6, v3.5.0</small>
+<small>Introduced in: v3.4.6</small>
 
 `--compress-output`
 

--- a/3.6/smartjoins.md
+++ b/3.6/smartjoins.md
@@ -8,7 +8,7 @@ redirect_from:
 SmartJoins
 ==========
 
-<small>Introduced in: v3.4.5, v3.5.0</small>
+<small>Introduced in: v3.4.5</small>
 
 {% include hint-ee-oasis.md feature="SmartJoins" plural=true %}
 

--- a/3.7/data-modeling-databases-working-with.md
+++ b/3.7/data-modeling-databases-working-with.md
@@ -229,7 +229,7 @@ all clients have disconnected and references have been garbage-collected.
 
 ### Compact
 
-<small>Introduced in: v3.5.6, v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.5.6, v3.6.7, v3.7.3</small>
 
 compact the entire data, for all databases
 `db._compact(options)`

--- a/3.7/programs-arangod-audit.md
+++ b/3.7/programs-arangod-audit.md
@@ -18,7 +18,7 @@ Audit destination(s).
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.9, v3.8.0</small>
+<small>Introduced in: v3.7.9</small>
 
 `--audit.max-entry-length value`
 

--- a/3.7/programs-arangod-audit.md
+++ b/3.7/programs-arangod-audit.md
@@ -18,7 +18,7 @@ Audit destination(s).
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.8</small>
+<small>Introduced in: v3.7.9, v3.8.0</small>
 
 `--audit.max-entry-length value`
 

--- a/3.7/programs-arangod-log.md
+++ b/3.7/programs-arangod-log.md
@@ -156,7 +156,7 @@ The default value for this option is `true`.
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.8</small>
+<small>Introduced in: v3.7.9, v3.8.0</small>
 
 `--log.max-entry-length value`
 

--- a/3.7/programs-arangod-log.md
+++ b/3.7/programs-arangod-log.md
@@ -156,7 +156,7 @@ The default value for this option is `true`.
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.9, v3.8.0</small>
+<small>Introduced in: v3.7.9</small>
 
 `--log.max-entry-length value`
 

--- a/3.7/programs-arangod-query.md
+++ b/3.7/programs-arangod-query.md
@@ -6,7 +6,7 @@ description: ArangoDB Server Query Options
 
 ## Limiting query runtime
 
-<small>Introduced in: v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.6.7, v3.7.3</small>
 
 `--query.max-runtime value`
 

--- a/3.7/programs-arangodump-examples.md
+++ b/3.7/programs-arangodump-examples.md
@@ -196,7 +196,7 @@ RocksDB encryption-at-rest feature.
 Compression
 -----------
 
-<small>Introduced in: v3.4.6, v3.5.0</small>
+<small>Introduced in: v3.4.6</small>
 
 `--compress-output`
 

--- a/3.7/smartjoins.md
+++ b/3.7/smartjoins.md
@@ -8,7 +8,7 @@ redirect_from:
 SmartJoins
 ==========
 
-<small>Introduced in: v3.4.5, v3.5.0</small>
+<small>Introduced in: v3.4.5</small>
 
 {% include hint-ee-oasis.md feature="SmartJoins" plural=true %}
 

--- a/3.8/data-modeling-databases-working-with.md
+++ b/3.8/data-modeling-databases-working-with.md
@@ -229,7 +229,7 @@ all clients have disconnected and references have been garbage-collected.
 
 ### Compact
 
-<small>Introduced in: v3.5.6, v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.5.6, v3.6.7, v3.7.3</small>
 
 compact the entire data, for all databases
 `db._compact(options)`

--- a/3.8/programs-arangod-audit.md
+++ b/3.8/programs-arangod-audit.md
@@ -18,7 +18,7 @@ Audit destination(s).
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.9, v3.8.0</small>
+<small>Introduced in: v3.7.9</small>
 
 `--audit.max-entry-length value`
 

--- a/3.8/programs-arangod-audit.md
+++ b/3.8/programs-arangod-audit.md
@@ -18,7 +18,7 @@ Audit destination(s).
 
 ## Maximum line length
 
-<small>Introduced in: v3.8.0</small>
+<small>Introduced in: v3.7.9, v3.8.0</small>
 
 `--audit.max-entry-length value`
 

--- a/3.8/programs-arangod-log.md
+++ b/3.8/programs-arangod-log.md
@@ -156,7 +156,7 @@ The default value for this option is `true`.
 
 ## Maximum line length
 
-<small>Introduced in: v3.7.9, v3.8.0</small>
+<small>Introduced in: v3.7.9</small>
 
 `--log.max-entry-length value`
 

--- a/3.8/programs-arangod-log.md
+++ b/3.8/programs-arangod-log.md
@@ -156,7 +156,7 @@ The default value for this option is `true`.
 
 ## Maximum line length
 
-<small>Introduced in: v3.8.0</small>
+<small>Introduced in: v3.7.9, v3.8.0</small>
 
 `--log.max-entry-length value`
 

--- a/3.8/programs-arangod-query.md
+++ b/3.8/programs-arangod-query.md
@@ -6,7 +6,7 @@ description: ArangoDB Server Query Options
 
 ## Limiting query runtime
 
-<small>Introduced in: v3.6.7, v3.7.3, v3.8.0</small>
+<small>Introduced in: v3.6.7, v3.7.3</small>
 
 `--query.max-runtime value`
 

--- a/3.8/programs-arangodump-examples.md
+++ b/3.8/programs-arangodump-examples.md
@@ -196,7 +196,7 @@ RocksDB encryption-at-rest feature.
 Compression
 -----------
 
-<small>Introduced in: v3.4.6, v3.5.0</small>
+<small>Introduced in: v3.4.6</small>
 
 `--compress-output`
 

--- a/3.8/smartjoins.md
+++ b/3.8/smartjoins.md
@@ -8,7 +8,7 @@ redirect_from:
 SmartJoins
 ==========
 
-<small>Introduced in: v3.4.5, v3.5.0</small>
+<small>Introduced in: v3.4.5</small>
 
 {% include hint-ee-oasis.md feature="SmartJoins" plural=true %}
 


### PR DESCRIPTION
Fix wrong version numbers introduced for backported logging options.
The docs say the options are available in 3.7.8, and that was also the idea.
However, 3.7.8 was built based on 3.7.7 with just a single commit on top, and that rendered all plans invalid.
This PR fixes the version number in the docs to 3.7.9, which will be the _real_ release these options become available.