### PR TITLE
adjust docs for changed splice-subqueries optimizer rule behavior

### DIFF
--- a/3.8/aql/execution-and-performance-optimizer.md
+++ b/3.8/aql/execution-and-performance-optimizer.md
@@ -651,7 +651,7 @@ The following optimizer rules may appear in the `rules` attribute of a plan:
 
 - `splice-subqueries`:
   will appear when a subquery has been spliced into the surrounding query.
-  This will be performed on all subqueries unless explicitily switched off.
+  This will be performed on all subqueries and canot be switched off.
   This optimization is applied after all other optimizations, and reduces
   overhead for executing subqueries by inlining the execution. This mainly
   benefits queries which execute subqueries very often that only return a

--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -301,6 +301,18 @@ FOR status IN `Window`
   RETURN status.open
 ```
 
+## Subqueries
+
+The AQL optimizer rule `splice-subqueries` was introduced in ArangoDB 3.6 to
+optimize most subqueries, and it was extended in 3.7 to work with all types
+of subqueries. It was always turned on by default, but it still could be 
+deactivated manually using a startup option (`--query.optimizer-rules`).
+
+In ArangoDB 3.8, the optimizer rule `splice-subqueries` is now required for
+subquery execution, and cannot be turned off. Trying to disable it via the 
+mentioned startup option has no effect, as the optimizer rule will always 
+run for queries containing subqueries.
+
 ### UPDATE queries with `keepNull: false`
 
 AQL update queries using the `keepNull` option set to false had an inconsistent

--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -306,12 +306,13 @@ FOR status IN `Window`
 The AQL optimizer rule `splice-subqueries` was introduced in ArangoDB 3.6 to
 optimize most subqueries, and it was extended in 3.7 to work with all types
 of subqueries. It was always turned on by default, but it still could be 
-deactivated manually using a startup option (`--query.optimizer-rules`).
+deactivated manually using a startup option (`--query.optimizer-rules`) or
+for individual queries via the `optimizer.rules` query option.
 
 In ArangoDB 3.8, the optimizer rule `splice-subqueries` is now required for
 subquery execution, and cannot be turned off. Trying to disable it via the 
-mentioned startup option has no effect, as the optimizer rule will always 
-run for queries containing subqueries.
+mentioned startup option or query option has no effect, as the optimizer rule
+will always run for queries containing subqueries.
 
 ### UPDATE queries with `keepNull: false`
 


### PR DESCRIPTION
Adjust the docs for 3.8 so they mention the optimizer rule `splice-subqueries` cannot be turned off anymore.