### PR TITLE
adjust memory limit formula for small installations

### DIFF
--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -191,8 +191,9 @@ option `--query.memory-limit` from previously `0` (meaning: no limit) to a
 dynamically calculated value. The per-query memory limits defaults are now:
 
 ```
-Available memory:    134217728    (128MiB)  Limit:    134217728    (128MiB), %mem: 100.0
-Available memory:    268435456    (256MiB)  Limit:    268435456    (256MiB), %mem: 100.0
+Available memory:            0      (0MiB)  Limit:            0   unlimited, %mem:   n/a
+Available memory:    134217728    (128MiB)  Limit:     33554432     (32MiB), %mem:  25.0
+Available memory:    268435456    (256MiB)  Limit:     67108864     (64MiB), %mem:  25.0
 Available memory:    536870912    (512MiB)  Limit:    201326592    (192MiB), %mem:  37.5
 Available memory:    805306368    (768MiB)  Limit:    402653184    (384MiB), %mem:  50.0
 Available memory:   1073741824   (1024MiB)  Limit:    603979776    (576MiB), %mem:  56.2

--- a/3.8/release-notes-upgrading-changes38.md
+++ b/3.8/release-notes-upgrading-changes38.md
@@ -188,27 +188,27 @@ instance.
 
 The memory limit is introduced via changing the default value of the startup
 option `--query.memory-limit` from previously `0` (meaning: no limit) to a
-dynamically calculated value. The per-query memory limits defaults are now:
+dynamically calculated value. The per-query memory limit defaults are now:
 
 ```
-Available memory:            0      (0MiB)  Limit:            0   unlimited, %mem:   n/a
-Available memory:    134217728    (128MiB)  Limit:     33554432     (32MiB), %mem:  25.0
-Available memory:    268435456    (256MiB)  Limit:     67108864     (64MiB), %mem:  25.0
-Available memory:    536870912    (512MiB)  Limit:    201326592    (192MiB), %mem:  37.5
-Available memory:    805306368    (768MiB)  Limit:    402653184    (384MiB), %mem:  50.0
-Available memory:   1073741824   (1024MiB)  Limit:    603979776    (576MiB), %mem:  56.2
-Available memory:   2147483648   (2048MiB)  Limit:   1288490189   (1228MiB), %mem:  60.0
-Available memory:   4294967296   (4096MiB)  Limit:   2576980377   (2457MiB), %mem:  60.0
-Available memory:   8589934592   (8192MiB)  Limit:   5153960755   (4915MiB), %mem:  60.0
-Available memory:  17179869184  (16384MiB)  Limit:  10307921511   (9830MiB), %mem:  60.0
-Available memory:  25769803776  (24576MiB)  Limit:  15461882265  (14745MiB), %mem:  60.0
-Available memory:  34359738368  (32768MiB)  Limit:  20615843021  (19660MiB), %mem:  60.0
-Available memory:  42949672960  (40960MiB)  Limit:  25769803776  (24576MiB), %mem:  60.0
-Available memory:  68719476736  (65536MiB)  Limit:  41231686041  (39321MiB), %mem:  60.0
-Available memory: 103079215104  (98304MiB)  Limit:  61847529063  (58982MiB), %mem:  60.0
-Available memory: 137438953472 (131072MiB)  Limit:  82463372083  (78643MiB), %mem:  60.0
-Available memory: 274877906944 (262144MiB)  Limit: 164926744167 (157286MiB), %mem:  60.0
-Available memory: 549755813888 (524288MiB)  Limit: 329853488333 (314572MiB), %mem:  60.0
+Available memory:            0      (0MiB)  Limit:            0   unlimited, %mem:  n/a
+Available memory:    134217728    (128MiB)  Limit:     33554432     (32MiB), %mem: 25.0
+Available memory:    268435456    (256MiB)  Limit:     67108864     (64MiB), %mem: 25.0
+Available memory:    536870912    (512MiB)  Limit:    201326592    (192MiB), %mem: 37.5
+Available memory:    805306368    (768MiB)  Limit:    402653184    (384MiB), %mem: 50.0
+Available memory:   1073741824   (1024MiB)  Limit:    603979776    (576MiB), %mem: 56.2
+Available memory:   2147483648   (2048MiB)  Limit:   1288490189   (1228MiB), %mem: 60.0
+Available memory:   4294967296   (4096MiB)  Limit:   2576980377   (2457MiB), %mem: 60.0
+Available memory:   8589934592   (8192MiB)  Limit:   5153960755   (4915MiB), %mem: 60.0
+Available memory:  17179869184  (16384MiB)  Limit:  10307921511   (9830MiB), %mem: 60.0
+Available memory:  25769803776  (24576MiB)  Limit:  15461882265  (14745MiB), %mem: 60.0
+Available memory:  34359738368  (32768MiB)  Limit:  20615843021  (19660MiB), %mem: 60.0
+Available memory:  42949672960  (40960MiB)  Limit:  25769803776  (24576MiB), %mem: 60.0
+Available memory:  68719476736  (65536MiB)  Limit:  41231686041  (39321MiB), %mem: 60.0
+Available memory: 103079215104  (98304MiB)  Limit:  61847529063  (58982MiB), %mem: 60.0
+Available memory: 137438953472 (131072MiB)  Limit:  82463372083  (78643MiB), %mem: 60.0
+Available memory: 274877906944 (262144MiB)  Limit: 164926744167 (157286MiB), %mem: 60.0
+Available memory: 549755813888 (524288MiB)  Limit: 329853488333 (314572MiB), %mem: 60.0
 ```
 
 As previously, a memory limit value of `0` means no limitation.


### PR DESCRIPTION
@simran-b: as discussed, here is the adjustment for the memory usage limits.

This is the docs PR for https://github.com/arangodb/arangodb/pull/13595