### PR TITLE
fix: correct documentation for 'null' that suggests empty arrays & objects are falsy

### DIFF
--- a/3.4/aql/fundamentals-data-types.md
+++ b/3.4/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.5/aql/fundamentals-data-types.md
+++ b/3.5/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.6/aql/fundamentals-data-types.md
+++ b/3.6/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.7/aql/fundamentals-data-types.md
+++ b/3.7/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.8/aql/fundamentals-data-types.md
+++ b/3.8/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example


### PR DESCRIPTION
closes https://github.com/arangodb/docs/issues/626

Signed-off-by: obataku <19821199+obataku@users.noreply.github.com>