### PR TITLE
Correct statements about value comparisons

### DIFF
--- a/3.4/aql/fundamentals-data-types.md
+++ b/3.4/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or a zero-length string `""`).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.4/aql/operators.md
+++ b/3.4/aql/operators.md
@@ -31,13 +31,15 @@ The following comparison operators are supported:
 
 Each of the comparison operators returns a boolean value if the comparison can
 be evaluated and returns *true* if the comparison evaluates to true, and *false*
-otherwise. 
+otherwise.
 
-The comparison operators accept any data types for the first and second operands. 
-However, `IN` and `NOT IN` will only return a meaningful result if their right-hand 
-operand is an array, and `LIKE` will only execute if both operands are string values.
-The comparison operators will not perform any implicit type casts if the compared 
-operands have different or non-sensible types.
+The comparison operators accept any data types for the first and second
+operands. However, `IN` and `NOT IN` will only return a meaningful result if
+their right-hand operand is an array. `LIKE` and `NOT LIKE` will only execute
+if both operands are string values. All four operators will not perform
+implicit type casts if the compared operands have different types, i.e.
+they test for strict equality or inequality (`0` is different to `"0"`,
+`[0]`, `false` and `null` for example).
 
 Some examples for comparison operations in AQL:
 

--- a/3.5/aql/fundamentals-data-types.md
+++ b/3.5/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or a zero-length string `""`).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.5/aql/operators.md
+++ b/3.5/aql/operators.md
@@ -33,14 +33,15 @@ The following comparison operators are supported:
 
 Each of the comparison operators returns a boolean value if the comparison can
 be evaluated and returns *true* if the comparison evaluates to true, and *false*
-otherwise. 
+otherwise.
 
 The comparison operators accept any data types for the first and second
 operands. However, `IN` and `NOT IN` will only return a meaningful result if
 their right-hand operand is an array. `LIKE` and `NOT LIKE` will only execute
-if both operands are string values. The comparison operators will not perform
-any implicit type casts if the compared operands have different or non-sensible
-types.
+if both operands are string values. All four operators will not perform
+implicit type casts if the compared operands have different types, i.e.
+they test for strict equality or inequality (`0` is different to `"0"`,
+`[0]`, `false` and `null` for example).
 
 Some examples for comparison operations in AQL:
 

--- a/3.6/aql/fundamentals-data-types.md
+++ b/3.6/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or a zero-length string `""`).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.6/aql/operators.md
+++ b/3.6/aql/operators.md
@@ -33,14 +33,15 @@ The following comparison operators are supported:
 
 Each of the comparison operators returns a boolean value if the comparison can
 be evaluated and returns *true* if the comparison evaluates to true, and *false*
-otherwise. 
+otherwise.
 
 The comparison operators accept any data types for the first and second
 operands. However, `IN` and `NOT IN` will only return a meaningful result if
 their right-hand operand is an array. `LIKE` and `NOT LIKE` will only execute
-if both operands are string values. The comparison operators will not perform
-any implicit type casts if the compared operands have different or non-sensible
-types.
+if both operands are string values. All four operators will not perform
+implicit type casts if the compared operands have different types, i.e.
+they test for strict equality or inequality (`0` is different to `"0"`,
+`[0]`, `false` and `null` for example).
 
 Some examples for comparison operations in AQL:
 

--- a/3.7/aql/fundamentals-data-types.md
+++ b/3.7/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or a zero-length string `""`).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.7/aql/operators.md
+++ b/3.7/aql/operators.md
@@ -33,14 +33,15 @@ The following comparison operators are supported:
 
 Each of the comparison operators returns a boolean value if the comparison can
 be evaluated and returns *true* if the comparison evaluates to true, and *false*
-otherwise. 
+otherwise.
 
 The comparison operators accept any data types for the first and second
 operands. However, `IN` and `NOT IN` will only return a meaningful result if
 their right-hand operand is an array. `LIKE` and `NOT LIKE` will only execute
-if both operands are string values. The comparison operators will not perform
-any implicit type casts if the compared operands have different or non-sensible
-types.
+if both operands are string values. All four operators will not perform
+implicit type casts if the compared operands have different types, i.e.
+they test for strict equality or inequality (`0` is different to `"0"`,
+`[0]`, `false` and `null` for example).
 
 Some examples for comparison operations in AQL:
 

--- a/3.8/aql/fundamentals-data-types.md
+++ b/3.8/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false` or zero-length string).
+*falsy* values (`false` or a zero-length string `""`).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.8/aql/fundamentals-data-types.md
+++ b/3.8/aql/fundamentals-data-types.md
@@ -25,7 +25,7 @@ Primitive types
 
 A `null` value can be used to represent an empty or absent value.
 It is different from a numerical value of zero (`null != 0`) and other
-*falsy* values (`false`, zero-length string, empty array or object).
+*falsy* values (`false` or zero-length string).
 It is also known as *nil* or *None* in other languages.
 
 The system may return `null` in the absence of value, for example

--- a/3.8/aql/operators.md
+++ b/3.8/aql/operators.md
@@ -33,14 +33,15 @@ The following comparison operators are supported:
 
 Each of the comparison operators returns a boolean value if the comparison can
 be evaluated and returns *true* if the comparison evaluates to true, and *false*
-otherwise. 
+otherwise.
 
 The comparison operators accept any data types for the first and second
 operands. However, `IN` and `NOT IN` will only return a meaningful result if
 their right-hand operand is an array. `LIKE` and `NOT LIKE` will only execute
-if both operands are string values. The comparison operators will not perform
-any implicit type casts if the compared operands have different or non-sensible
-types.
+if both operands are string values. All four operators will not perform
+implicit type casts if the compared operands have different types, i.e.
+they test for strict equality or inequality (`0` is different to `"0"`,
+`[0]`, `false` and `null` for example).
 
 Some examples for comparison operations in AQL:
 


### PR DESCRIPTION
Fixes #626 and addresses the documentation-portion of https://github.com/arangodb/arangodb/issues/13655