### PR TITLE
New features 3.8 and cluster overwhelm

### DIFF
--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -924,3 +924,32 @@ used register are now discarded. Unused registers on the left hand side of the
 maximum used register id are not discarded, because we still need to guarantee
 that registers from depths above stay in the same slot when starting a new
 depth.
+
+### Better protection against overwhelm
+
+The cluster now protects itself better against being overwhelmed by too
+many concurrent requests.
+
+This is mostly achieved by limiting the total amount of requests from
+the low priority queue which are ongoing concurrently. There is a new option
+`--server.ongoing-low-priority-multiplier` (default is 4), which
+essentially says that only 4 times as many requests may be ongoing
+concurrently as there are worker threads. The default is chosen such
+that it is sensible for most workloads, but in special situations it
+can help to adjust the value.
+
+See [this section](programs-arangod-server.html#preventing-cluster-overwhelm) for details
+and hints for configuration.
+
+There have been further improvements, in particular to ensure that
+certain APIs to diagnose the situation in the cluster still work, even
+when a lot of normal requests are piling up. For example, the cluster
+health API will still be available in such a case.
+
+Furthermore, followers will now be dropped much later and only if they
+are actually failed, which leads to a lot fewer shard resynchronizations
+in case of very high load.
+
+Overall, these measures should all be below the surface and not be
+visible to the user at all (apart from preventing problems under high
+load).

--- a/3.8/tutorials-reduce-memory-footprint.md
+++ b/3.8/tutorials-reduce-memory-footprint.md
@@ -239,20 +239,19 @@ Concurrent operations
 ---------------------
 
 Starting with ArangoDB 3.8 one can limit the number of concurrent
-operations being executed on each coordinator. Reducing the amount of
-concurrent operations can lower the RAM usage on coordinators. The
-command line option for this is
+operations being executed on each Coordinator. Reducing the amount of
+concurrent operations can lower the RAM usage on Coordinators. The
+startup option for this is:
 
 ```
---server.ongoing-low-priority-multiplier 1
+--server.ongoing-low-priority-multiplier
 ```
 
-The default for this option is 4, which means that a coordinator with t
-scheduler threads can execute up to 4*t requests concurrently. The
+The default for this option is 4, which means that a Coordinator with `t`
+scheduler threads can execute up to `4 * t` requests concurrently. The
 minimal value for this option is 1.
 
-See [this page](programs-arangod-server.html#preventing-cluster-overwhelm)
-for details.
+Also see [Preventing cluster overwhelm](programs-arangod-server.html#preventing-cluster-overwhelm).
 
 CPU usage
 ---------

--- a/3.8/tutorials-reduce-memory-footprint.md
+++ b/3.8/tutorials-reduce-memory-footprint.md
@@ -235,6 +235,25 @@ cluster without these limitations. They apply to single server instances. They
 also apply to Coordinator nodes, but you should not disable V8 on Coordinators
 because certain cluster operations depend on it.
 
+Concurrent operations
+---------------------
+
+Starting with ArangoDB 3.8 one can limit the number of concurrent
+operations being executed on each coordinator. Reducing the amount of
+concurrent operations can lower the RAM usage on coordinators. The
+command line option for this is
+
+```
+--server.ongoing-low-priority-multiplier 1
+```
+
+The default for this option is 4, which means that a coordinator with t
+scheduler threads can execute up to 4*t requests concurrently. The
+minimal value for this option is 1.
+
+See [this page](programs-arangod-server.html#preventing-cluster-overwhelm)
+for details.
+
 CPU usage
 ---------
 


### PR DESCRIPTION
This PR adds a description of our cluster overwhelm measures in 3.8
to the new features for 3.8 document. It also explains the new command
line option `--server.ongoing-low-priority-multiplier` .
