### PR TITLE
Deprecate old metrics API

### DIFF
--- a/3.8/appendix-deprecated.md
+++ b/3.8/appendix-deprecated.md
@@ -49,6 +49,13 @@ replace the old features with:
   against the database in recent versions, because of better performance and
   reduced maintenance complexity.
 
+- **Old metrics API**:
+  The old metrics API under `/_admin/metrics` is deprecated and we offer
+  a new V2 one under `/_admin/metrics/v2` from 3.8 on. This step was
+  necessary because the old API did not follow quite a few Prometheus
+  guidelines for metrics. We offer new dashboards with 3.8, too.
+  Furthermore, beginning with 3.8 all metrics are documented.
+
 - **Actions**: Snippets of JavaScript code on the server-side for minimal
   custom endpoints. Since the Foxx revamp in 3.0, it became really easy to
   write [Foxx Microservices](foxx.html), which allow you to define

--- a/3.8/appendix-deprecated.md
+++ b/3.8/appendix-deprecated.md
@@ -50,11 +50,10 @@ replace the old features with:
   reduced maintenance complexity.
 
 - **Old metrics API**:
-  The old metrics API under `/_admin/metrics` is deprecated and we offer
-  a new V2 one under `/_admin/metrics/v2` from 3.8 on. This step was
+  The old metrics API under `/_admin/metrics` is deprecated and replaced by
+  a new one under `/_admin/metrics/v2` from version 3.8.0 on. This step was
   necessary because the old API did not follow quite a few Prometheus
-  guidelines for metrics. We offer new dashboards with 3.8, too.
-  Furthermore, beginning with 3.8 all metrics are documented.
+  guidelines for metrics.
 
 - **Actions**: Snippets of JavaScript code on the server-side for minimal
   custom endpoints. Since the Foxx revamp in 3.0, it became really easy to


### PR DESCRIPTION
Add deprecation notice to 3.8 appendix for old metrics API.
