### PR TITLE
Unquoted null, false and true are always converted in 3.6

### DIFF
--- a/3.3/administration-arangoimp.md
+++ b/3.3/administration-arangoimp.md
@@ -294,7 +294,7 @@ Other common cases are to rename columns in the input file to *_from* and *_to*:
 
     > arangoimp --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
+The *translate* option can be specified multiple times. The source attribute name
 and the target attribute must be separated with a *=*.
 
 

--- a/3.4/programs-arangoimport-examples-csv.md
+++ b/3.4/programs-arangoimport-examples-csv.md
@@ -145,7 +145,7 @@ Other common cases are to rename columns in the input file to *_from* and *_to*:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
+The *translate* option can be specified multiple times. The source attribute name
 and the target attribute must be separated with a *=*.
 
 Ignoring Attributes

--- a/3.5/programs-arangoimport-examples-csv.md
+++ b/3.5/programs-arangoimport-examples-csv.md
@@ -144,7 +144,7 @@ Other common cases are to rename columns in the input file to *_from* and *_to*:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
+The *translate* option can be specified multiple times. The source attribute name
 and the target attribute must be separated with a *=*.
 
 Ignoring Attributes

--- a/3.6/programs-arangoimport-examples-csv.md
+++ b/3.6/programs-arangoimport-examples-csv.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: arangoimport offers the possibility to import data from CSV files
+description: arangoimport can import data from comma and tab delimited files
 ---
 Arangoimport Examples: CSV / TSV
 ================================
@@ -20,7 +20,7 @@ The CSV import requires the data to have a homogeneous structure. All records
 must have exactly the same amount of columns as there are headers. By default,
 lines with a different number of values will not be imported and there will be 
 warnings for them. To still import lines with less values than in the header,
-there is the *--ignore-missing* option. If set to true, lines that have a
+there is the `--ignore-missing` option. If set to true, lines that have a
 different amount of fields will be imported. In this case only those attributes
 will be populated for which there are values. Attributes for which there are
 no values present will silently be discarded.
@@ -54,7 +54,7 @@ We will be using the following import for the CSV import:
 "Jim","O'Brady",19,,
 "Lisa","Jones",,,"1981-04-09"
 Hans,dos Santos,0123,,
-Wayne,Brewer,,false,
+Wayne,Brewer,null,false,
 ```
 
 The command line to execute the import is:
@@ -72,24 +72,32 @@ The above data will be imported into 5 documents which will look as follows:
 ```
 
 As can be seen, values left completely empty in the input file will be treated
-as absent. Numeric values not enclosed in quotes will be treated as numbers.
+as absent. This is also true for unquoted `null` literals.
+
+The literals `true` and `false` will be treated as booleans if they are not
+enclosed in quotes.
+
+Numeric values not enclosed in quotes will be treated as numbers.
 Note that leading zeros in numeric values will be removed. To import numbers
 with leading zeros, please use strings (e.g. `"012"` instead of `012`).
-The literals *true* and *false* will be treated as booleans if they are not
-enclosed in quotes. Other values not enclosed in quotes will be treated as
-strings. Any values enclosed in quotes will be treated as strings, too.
+
+You can set `--convert` to `false` if you want to treat all unquoted
+numbers as strings instead. `--convert` is enabled by default.
+
+Other values not enclosed in quotes will be treated as strings. Any values
+enclosed in quotes will be treated as strings, too.
 
 String values containing the quote character or the separator must be enclosed
 with quote characters. Within a string, the quote character itself must be
-escaped with another quote character (or with a backslash if the *--backslash-escape*
-option is used).
+escaped with another quote character (or with a backslash if the
+`--backslash-escape` option is used).
 
 Note that the quote and separator characters can be adjusted via the
-*--quote* and *--separator* arguments when invoking _arangoimport_. The quote
-character defaults to the double quote (*"*). To use a literal quote in a
-string, you can use two quote characters.
-To use backslash for escaping quote characters, please set the option
-*--backslash-escape* to *true*.
+`--quote` and `--separator` arguments when invoking _arangoimport_. The quote
+character defaults to the double quote mark (`"`). To use a literal quote in a
+string, you can use two quote characters (`""`).
+To use backslash for escaping quote characters (`\"`), please set the option
+`--backslash-escape` to `true`.
 
 The importer supports Windows (CRLF) and Unix (LF) line breaks. Line breaks might
 also occur inside values that are enclosed with the quote character.
@@ -121,7 +129,7 @@ As with CSV, the first line in the TSV file must contain the attribute names,
 and all lines must have an identical number of values.
 
 If a different separator character or string should be used, it can be specified
-with the *--separator* argument.
+with the `--separator` argument.
 
 An example command line to execute the TSV import is:
 
@@ -150,31 +158,31 @@ For the CSV and TSV input formats, attribute names can be translated automatical
 This is useful in case the import file has different attribute names than those
 that should be used in ArangoDB.
 
-A common use case is to rename an "id" column from the input file into "_key" as
+A common use case is to rename an `id` column from the input file into `_key` as
 it is expected by ArangoDB. To do this, specify the following translation when
 invoking arangoimport:
 
     arangoimport --file "data.csv" --type csv --translate "id=_key"
 
-Other common cases are to rename columns in the input file to *_from* and *_to*:
+Other common cases are to rename columns in the input file to `_from` and `_to`:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
-and the target attribute must be separated with a *=*.
+The `--translate` option can be specified multiple times. The source attribute name
+and the target attribute must be separated with a `=`.
 
 Ignoring Attributes
 -------------------
 
-For the CSV and TSV input formats, certain attribute names can be ignored on imports.
-In an ArangoDB cluster there are cases where this can come in handy,
-when your documents already contain a `_key` attribute
-and your collection has a sharding attribute other than `_key`: In the cluster this
-configuration is not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
-attribute in *all* shards of the collection.
+For the CSV and TSV input formats, certain attribute names can be ignored on
+imports. In an ArangoDB cluster there are cases where this can come in handy,
+when your documents already contain a `_key` attribute and your collection has
+a sharding attribute other than `_key`: In the cluster this configuration is
+not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
+attribute in **all** shards of the collection.
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_key"
 
-The same thing would apply if your data contains an *_id* attribute:
+The same thing would apply if your data contains an `_id` attribute:
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_id"

--- a/3.7/programs-arangoimport-examples-csv.md
+++ b/3.7/programs-arangoimport-examples-csv.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: arangoimport offers the possibility to import data from CSV files
+description: arangoimport can import data from comma and tab delimited files
 ---
 Arangoimport Examples: CSV / TSV
 ================================
@@ -20,7 +20,7 @@ The CSV import requires the data to have a homogeneous structure. All records
 must have exactly the same amount of columns as there are headers. By default,
 lines with a different number of values will not be imported and there will be 
 warnings for them. To still import lines with less values than in the header,
-there is the *--ignore-missing* option. If set to true, lines that have a
+there is the `--ignore-missing` option. If set to true, lines that have a
 different amount of fields will be imported. In this case only those attributes
 will be populated for which there are values. Attributes for which there are
 no values present will silently be discarded.
@@ -54,7 +54,7 @@ We will be using the following import for the CSV import:
 "Jim","O'Brady",19,,
 "Lisa","Jones",,,"1981-04-09"
 Hans,dos Santos,0123,,
-Wayne,Brewer,,false,
+Wayne,Brewer,null,false,
 ```
 
 The command line to execute the import is:
@@ -72,24 +72,32 @@ The above data will be imported into 5 documents which will look as follows:
 ```
 
 As can be seen, values left completely empty in the input file will be treated
-as absent. Numeric values not enclosed in quotes will be treated as numbers.
+as absent. This is also true for unquoted `null` literals.
+
+The literals `true` and `false` will be treated as booleans if they are not
+enclosed in quotes.
+
+Numeric values not enclosed in quotes will be treated as numbers.
 Note that leading zeros in numeric values will be removed. To import numbers
 with leading zeros, please use strings (e.g. `"012"` instead of `012`).
-The literals *true* and *false* will be treated as booleans if they are not
-enclosed in quotes. Other values not enclosed in quotes will be treated as
-strings. Any values enclosed in quotes will be treated as strings, too.
+
+You can set `--convert` to `false` if you want to treat all unquoted literals
+and numbers as strings instead. `--convert` is enabled by default.
+
+Other values not enclosed in quotes will be treated as strings. Any values
+enclosed in quotes will be treated as strings, too.
 
 String values containing the quote character or the separator must be enclosed
 with quote characters. Within a string, the quote character itself must be
-escaped with another quote character (or with a backslash if the *--backslash-escape*
-option is used).
+escaped with another quote character (or with a backslash if the
+`--backslash-escape` option is used).
 
 Note that the quote and separator characters can be adjusted via the
-*--quote* and *--separator* arguments when invoking _arangoimport_. The quote
-character defaults to the double quote (*"*). To use a literal quote in a
-string, you can use two quote characters.
-To use backslash for escaping quote characters, please set the option
-*--backslash-escape* to *true*.
+`--quote` and `--separator` arguments when invoking _arangoimport_. The quote
+character defaults to the double quote mark (`"`). To use a literal quote in a
+string, you can use two quote characters (`""`).
+To use backslash for escaping quote characters (`\"`), please set the option
+`--backslash-escape` to `true`.
 
 The importer supports Windows (CRLF) and Unix (LF) line breaks. Line breaks might
 also occur inside values that are enclosed with the quote character.
@@ -121,7 +129,7 @@ As with CSV, the first line in the TSV file must contain the attribute names,
 and all lines must have an identical number of values.
 
 If a different separator character or string should be used, it can be specified
-with the *--separator* argument.
+with the `--separator` argument.
 
 An example command line to execute the TSV import is:
 
@@ -150,31 +158,31 @@ For the CSV and TSV input formats, attribute names can be translated automatical
 This is useful in case the import file has different attribute names than those
 that should be used in ArangoDB.
 
-A common use case is to rename an "id" column from the input file into "_key" as
+A common use case is to rename an `id` column from the input file into `_key` as
 it is expected by ArangoDB. To do this, specify the following translation when
 invoking arangoimport:
 
     arangoimport --file "data.csv" --type csv --translate "id=_key"
 
-Other common cases are to rename columns in the input file to *_from* and *_to*:
+Other common cases are to rename columns in the input file to `_from` and `_to`:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
-and the target attribute must be separated with a *=*.
+The `--translate` option can be specified multiple times. The source attribute name
+and the target attribute must be separated with a `=`.
 
 Ignoring Attributes
 -------------------
 
-For the CSV and TSV input formats, certain attribute names can be ignored on imports.
-In an ArangoDB cluster there are cases where this can come in handy,
-when your documents already contain a `_key` attribute
-and your collection has a sharding attribute other than `_key`: In the cluster this
-configuration is not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
-attribute in *all* shards of the collection.
+For the CSV and TSV input formats, certain attribute names can be ignored on
+imports. In an ArangoDB cluster there are cases where this can come in handy,
+when your documents already contain a `_key` attribute and your collection has
+a sharding attribute other than `_key`: In the cluster this configuration is
+not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
+attribute in **all** shards of the collection.
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_key"
 
-The same thing would apply if your data contains an *_id* attribute:
+The same thing would apply if your data contains an `_id` attribute:
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_id"

--- a/3.8/programs-arangoimport-examples-csv.md
+++ b/3.8/programs-arangoimport-examples-csv.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: arangoimport offers the possibility to import data from CSV files
+description: arangoimport can import data from comma and tab delimited files
 ---
 Arangoimport Examples: CSV / TSV
 ================================
@@ -20,7 +20,7 @@ The CSV import requires the data to have a homogeneous structure. All records
 must have exactly the same amount of columns as there are headers. By default,
 lines with a different number of values will not be imported and there will be 
 warnings for them. To still import lines with less values than in the header,
-there is the *--ignore-missing* option. If set to true, lines that have a
+there is the `--ignore-missing` option. If set to true, lines that have a
 different amount of fields will be imported. In this case only those attributes
 will be populated for which there are values. Attributes for which there are
 no values present will silently be discarded.
@@ -54,7 +54,7 @@ We will be using the following import for the CSV import:
 "Jim","O'Brady",19,,
 "Lisa","Jones",,,"1981-04-09"
 Hans,dos Santos,0123,,
-Wayne,Brewer,,false,
+Wayne,Brewer,null,false,
 ```
 
 The command line to execute the import is:
@@ -72,24 +72,32 @@ The above data will be imported into 5 documents which will look as follows:
 ```
 
 As can be seen, values left completely empty in the input file will be treated
-as absent. Numeric values not enclosed in quotes will be treated as numbers.
+as absent. This is also true for unquoted `null` literals.
+
+The literals `true` and `false` will be treated as booleans if they are not
+enclosed in quotes.
+
+Numeric values not enclosed in quotes will be treated as numbers.
 Note that leading zeros in numeric values will be removed. To import numbers
 with leading zeros, please use strings (e.g. `"012"` instead of `012`).
-The literals *true* and *false* will be treated as booleans if they are not
-enclosed in quotes. Other values not enclosed in quotes will be treated as
-strings. Any values enclosed in quotes will be treated as strings, too.
+
+You can set `--convert` to `false` if you want to treat all unquoted literals
+and numbers as strings instead. `--convert` is enabled by default.
+
+Other values not enclosed in quotes will be treated as strings. Any values
+enclosed in quotes will be treated as strings, too.
 
 String values containing the quote character or the separator must be enclosed
 with quote characters. Within a string, the quote character itself must be
-escaped with another quote character (or with a backslash if the *--backslash-escape*
-option is used).
+escaped with another quote character (or with a backslash if the
+`--backslash-escape` option is used).
 
 Note that the quote and separator characters can be adjusted via the
-*--quote* and *--separator* arguments when invoking _arangoimport_. The quote
-character defaults to the double quote (*"*). To use a literal quote in a
-string, you can use two quote characters.
-To use backslash for escaping quote characters, please set the option
-*--backslash-escape* to *true*.
+`--quote` and `--separator` arguments when invoking _arangoimport_. The quote
+character defaults to the double quote mark (`"`). To use a literal quote in a
+string, you can use two quote characters (`""`).
+To use backslash for escaping quote characters (`\"`), please set the option
+`--backslash-escape` to `true`.
 
 The importer supports Windows (CRLF) and Unix (LF) line breaks. Line breaks might
 also occur inside values that are enclosed with the quote character.
@@ -121,7 +129,7 @@ As with CSV, the first line in the TSV file must contain the attribute names,
 and all lines must have an identical number of values.
 
 If a different separator character or string should be used, it can be specified
-with the *--separator* argument.
+with the `--separator` argument.
 
 An example command line to execute the TSV import is:
 
@@ -150,32 +158,32 @@ For the CSV and TSV input formats, attribute names can be translated automatical
 This is useful in case the import file has different attribute names than those
 that should be used in ArangoDB.
 
-A common use case is to rename an "id" column from the input file into "_key" as
+A common use case is to rename an `id` column from the input file into `_key` as
 it is expected by ArangoDB. To do this, specify the following translation when
 invoking arangoimport:
 
     arangoimport --file "data.csv" --type csv --translate "id=_key"
 
-Other common cases are to rename columns in the input file to *_from* and *_to*:
+Other common cases are to rename columns in the input file to `_from` and `_to`:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
-and the target attribute must be separated with a *=*.
+The `--translate` option can be specified multiple times. The source attribute name
+and the target attribute must be separated with a `=`.
 
 Ignoring Attributes
 -------------------
 
-For the CSV and TSV input formats, certain attribute names can be ignored on imports.
-In an ArangoDB cluster there are cases where this can come in handy,
-when your documents already contain a `_key` attribute
-and your collection has a sharding attribute other than `_key`: In the cluster this
-configuration is not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
-attribute in *all* shards of the collection.
+For the CSV and TSV input formats, certain attribute names can be ignored on
+imports. In an ArangoDB cluster there are cases where this can come in handy,
+when your documents already contain a `_key` attribute and your collection has
+a sharding attribute other than `_key`: In the cluster this configuration is
+not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
+attribute in **all** shards of the collection.
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_key"
 
-The same thing would apply if your data contains an *_id* attribute:
+The same thing would apply if your data contains an `_id` attribute:
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_id"
 

--- a/3.9/programs-arangoimport-examples-csv.md
+++ b/3.9/programs-arangoimport-examples-csv.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: arangoimport offers the possibility to import data from CSV files
+description: arangoimport can import data from comma and tab delimited files
 ---
 Arangoimport Examples: CSV / TSV
 ================================
@@ -20,7 +20,7 @@ The CSV import requires the data to have a homogeneous structure. All records
 must have exactly the same amount of columns as there are headers. By default,
 lines with a different number of values will not be imported and there will be 
 warnings for them. To still import lines with less values than in the header,
-there is the *--ignore-missing* option. If set to true, lines that have a
+there is the `--ignore-missing` option. If set to true, lines that have a
 different amount of fields will be imported. In this case only those attributes
 will be populated for which there are values. Attributes for which there are
 no values present will silently be discarded.
@@ -54,7 +54,7 @@ We will be using the following import for the CSV import:
 "Jim","O'Brady",19,,
 "Lisa","Jones",,,"1981-04-09"
 Hans,dos Santos,0123,,
-Wayne,Brewer,,false,
+Wayne,Brewer,null,false,
 ```
 
 The command line to execute the import is:
@@ -72,24 +72,32 @@ The above data will be imported into 5 documents which will look as follows:
 ```
 
 As can be seen, values left completely empty in the input file will be treated
-as absent. Numeric values not enclosed in quotes will be treated as numbers.
+as absent. This is also true for unquoted `null` literals.
+
+The literals `true` and `false` will be treated as booleans if they are not
+enclosed in quotes.
+
+Numeric values not enclosed in quotes will be treated as numbers.
 Note that leading zeros in numeric values will be removed. To import numbers
 with leading zeros, please use strings (e.g. `"012"` instead of `012`).
-The literals *true* and *false* will be treated as booleans if they are not
-enclosed in quotes. Other values not enclosed in quotes will be treated as
-strings. Any values enclosed in quotes will be treated as strings, too.
+
+You can set `--convert` to `false` if you want to treat all unquoted literals
+and numbers as strings instead. `--convert` is enabled by default.
+
+Other values not enclosed in quotes will be treated as strings. Any values
+enclosed in quotes will be treated as strings, too.
 
 String values containing the quote character or the separator must be enclosed
 with quote characters. Within a string, the quote character itself must be
-escaped with another quote character (or with a backslash if the *--backslash-escape*
-option is used).
+escaped with another quote character (or with a backslash if the
+`--backslash-escape` option is used).
 
 Note that the quote and separator characters can be adjusted via the
-*--quote* and *--separator* arguments when invoking _arangoimport_. The quote
-character defaults to the double quote (*"*). To use a literal quote in a
-string, you can use two quote characters.
-To use backslash for escaping quote characters, please set the option
-*--backslash-escape* to *true*.
+`--quote` and `--separator` arguments when invoking _arangoimport_. The quote
+character defaults to the double quote mark (`"`). To use a literal quote in a
+string, you can use two quote characters (`""`).
+To use backslash for escaping quote characters (`\"`), please set the option
+`--backslash-escape` to `true`.
 
 The importer supports Windows (CRLF) and Unix (LF) line breaks. Line breaks might
 also occur inside values that are enclosed with the quote character.
@@ -121,7 +129,7 @@ As with CSV, the first line in the TSV file must contain the attribute names,
 and all lines must have an identical number of values.
 
 If a different separator character or string should be used, it can be specified
-with the *--separator* argument.
+with the `--separator` argument.
 
 An example command line to execute the TSV import is:
 
@@ -150,32 +158,32 @@ For the CSV and TSV input formats, attribute names can be translated automatical
 This is useful in case the import file has different attribute names than those
 that should be used in ArangoDB.
 
-A common use case is to rename an "id" column from the input file into "_key" as
+A common use case is to rename an `id` column from the input file into `_key` as
 it is expected by ArangoDB. To do this, specify the following translation when
 invoking arangoimport:
 
     arangoimport --file "data.csv" --type csv --translate "id=_key"
 
-Other common cases are to rename columns in the input file to *_from* and *_to*:
+Other common cases are to rename columns in the input file to `_from` and `_to`:
 
     arangoimport --file "data.csv" --type csv --translate "from=_from" --translate "to=_to"
 
-The *translate* option can be specified multiple types. The source attribute name
-and the target attribute must be separated with a *=*.
+The `--translate` option can be specified multiple times. The source attribute name
+and the target attribute must be separated with a `=`.
 
 Ignoring Attributes
 -------------------
 
-For the CSV and TSV input formats, certain attribute names can be ignored on imports.
-In an ArangoDB cluster there are cases where this can come in handy,
-when your documents already contain a `_key` attribute
-and your collection has a sharding attribute other than `_key`: In the cluster this
-configuration is not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
-attribute in *all* shards of the collection.
+For the CSV and TSV input formats, certain attribute names can be ignored on
+imports. In an ArangoDB cluster there are cases where this can come in handy,
+when your documents already contain a `_key` attribute and your collection has
+a sharding attribute other than `_key`: In the cluster this configuration is
+not supported, because ArangoDB needs to guarantee the uniqueness of the `_key`
+attribute in **all** shards of the collection.
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_key"
 
-The same thing would apply if your data contains an *_id* attribute:
+The same thing would apply if your data contains an `_id` attribute:
 
     arangoimport --file "data.csv" --type csv --remove-attribute "_id"
 


### PR DESCRIPTION
In 3.7+ it depends on the --convert option

Related issues:
- arangodb/arangodb#13169
- arangodb/arangodb#13924
- arangodb/arangodb#13965