### PR TITLE
Startup option section: global / general

### DIFF
--- a/3.4/programs-arangod-global.md
+++ b/3.4/programs-arangod-global.md
@@ -1,6 +1,8 @@
 ---
 layout: default
 description: ArangoDB Server Global Options
+redirect_from:
+  - programs-arangod-general.html # 3.9 -> 3.9
 ---
 # ArangoDB Server Global Options
 

--- a/3.5/programs-arangod-global.md
+++ b/3.5/programs-arangod-global.md
@@ -1,6 +1,8 @@
 ---
 layout: default
 description: ArangoDB Server Global Options
+redirect_from:
+  - programs-arangod-general.html # 3.9 -> 3.9
 ---
 # ArangoDB Server Global Options
 

--- a/3.6/administration-configuration.md
+++ b/3.6/administration-configuration.md
@@ -61,7 +61,7 @@ arangod --database.directory="my_data_dir"
 
 Many options belong to a section as in `‑‑section.param`, e.g.
 `‑‑server.database`, but there can also be options without any section.
-These options are referred to as _global options_.
+These options are referred to as _general options_.
 
 To list available options, you can run a binary with the `‑‑help` flag:
 

--- a/3.6/aql/fundamentals-type-value-order.md
+++ b/3.6/aql/fundamentals-type-value-order.md
@@ -78,7 +78,7 @@ result is defined as follows:
 - boolean: *false* is less than *true*
 - number: numeric values are ordered by their cardinal value
 - string: string values are ordered using a localized comparison, using the configured
-  [server language](../programs-arangod-global.html#default-language)
+  [server language](../programs-arangod-general.html#default-language)
   for sorting according to the alphabetical order rules of that language
 
 Note: unlike in SQL, *null* can be compared to any value, including *null*

--- a/3.6/indexing-persistent.md
+++ b/3.6/indexing-persistent.md
@@ -177,7 +177,7 @@ Persistent Indexes and Server Language
 --------------------------------------
 
 The order of index entries in persistent indexes adheres to the configured
-[server language](programs-arangod-global.html#default-language).
+[server language](programs-arangod-general.html#default-language).
 If, however, the server is restarted with a different language setting as when
 the persistent index was created, not all documents may be returned anymore and
 the sort order of those which are returned can be wrong (whenever the persistent

--- a/3.6/installation-linux-osconfiguration.md
+++ b/3.6/installation-linux-osconfiguration.md
@@ -32,7 +32,7 @@ sudo locale-gen "en_US.UTF-8"
 Your distribution may also provide a frontend for doing so, for instance
 [`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
 
-If you don't set a [default language](programs-arangod-global.html#default-language)
+If you don't set a [default language](programs-arangod-general.html#default-language)
 for the server explicitly, ArangoDB will use the default locale of your system.
 
 {% hint 'warning' %}

--- a/3.6/programs-arangod-general.md
+++ b/3.6/programs-arangod-general.md
@@ -1,10 +1,12 @@
 ---
 layout: default
-description: ArangoDB Server Global Options
+description: ArangoDB Server General Options
+redirect_from:
+  - programs-arangod-global.html # 3.9 -> 3.9
 ---
-# ArangoDB Server Global Options
+# ArangoDB Server General Options
 
-## General help
+## Help
 
 `--help`
 

--- a/3.7/administration-configuration.md
+++ b/3.7/administration-configuration.md
@@ -61,7 +61,7 @@ arangod --database.directory="my_data_dir"
 
 Many options belong to a section as in `‑‑section.param`, e.g.
 `‑‑server.database`, but there can also be options without any section.
-These options are referred to as _global options_.
+These options are referred to as _general options_.
 
 To list available options, you can run a binary with the `‑‑help` flag:
 

--- a/3.7/aql/fundamentals-type-value-order.md
+++ b/3.7/aql/fundamentals-type-value-order.md
@@ -78,7 +78,7 @@ result is defined as follows:
 - boolean: *false* is less than *true*
 - number: numeric values are ordered by their cardinal value
 - string: string values are ordered using a localized comparison, using the configured
-  [server language](../programs-arangod-global.html#default-language)
+  [server language](../programs-arangod-general.html#default-language)
   for sorting according to the alphabetical order rules of that language
 
 Note: unlike in SQL, *null* can be compared to any value, including *null*

--- a/3.7/indexing-persistent.md
+++ b/3.7/indexing-persistent.md
@@ -177,7 +177,7 @@ Persistent Indexes and Server Language
 --------------------------------------
 
 The order of index entries in persistent indexes adheres to the configured
-[server language](programs-arangod-global.html#default-language).
+[server language](programs-arangod-general.html#default-language).
 If, however, the server is restarted with a different language setting as when
 the persistent index was created, not all documents may be returned anymore and
 the sort order of those which are returned can be wrong (whenever the persistent

--- a/3.7/installation-linux-osconfiguration.md
+++ b/3.7/installation-linux-osconfiguration.md
@@ -32,7 +32,7 @@ sudo locale-gen "en_US.UTF-8"
 Your distribution may also provide a frontend for doing so, for instance
 [`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
 
-If you don't set a [default language](programs-arangod-global.html#default-language)
+If you don't set a [default language](programs-arangod-general.html#default-language)
 for the server explicitly, ArangoDB will use the default locale of your system.
 
 {% hint 'warning' %}

--- a/3.7/programs-arangod-general.md
+++ b/3.7/programs-arangod-general.md
@@ -1,10 +1,12 @@
 ---
 layout: default
-description: ArangoDB Server Global Options
+description: ArangoDB Server General Options
+redirect_from:
+  - programs-arangod-global.html # 3.9 -> 3.9
 ---
-# ArangoDB Server Global Options
+# ArangoDB Server General Options
 
-## General help
+## Help
 
 `--help`
 

--- a/3.8/administration-configuration.md
+++ b/3.8/administration-configuration.md
@@ -61,7 +61,7 @@ arangod --database.directory="my_data_dir"
 
 Many options belong to a section as in `‑‑section.param`, e.g.
 `‑‑server.database`, but there can also be options without any section.
-These options are referred to as _global options_.
+These options are referred to as _general options_.
 
 To list available options, you can run a binary with the `‑‑help` flag:
 

--- a/3.8/aql/fundamentals-type-value-order.md
+++ b/3.8/aql/fundamentals-type-value-order.md
@@ -78,7 +78,7 @@ result is defined as follows:
 - boolean: *false* is less than *true*
 - number: numeric values are ordered by their cardinal value
 - string: string values are ordered using a localized comparison, using the configured
-  [server language](../programs-arangod-global.html#default-language)
+  [server language](../programs-arangod-general.html#default-language)
   for sorting according to the alphabetical order rules of that language
 
 Note: unlike in SQL, *null* can be compared to any value, including *null*

--- a/3.8/indexing-persistent.md
+++ b/3.8/indexing-persistent.md
@@ -177,7 +177,7 @@ Persistent Indexes and Server Language
 --------------------------------------
 
 The order of index entries in persistent indexes adheres to the configured
-[server language](programs-arangod-global.html#default-language).
+[server language](programs-arangod-general.html#default-language).
 If, however, the server is restarted with a different language setting as when
 the persistent index was created, not all documents may be returned anymore and
 the sort order of those which are returned can be wrong (whenever the persistent

--- a/3.8/installation-linux-osconfiguration.md
+++ b/3.8/installation-linux-osconfiguration.md
@@ -32,7 +32,7 @@ sudo locale-gen "en_US.UTF-8"
 Your distribution may also provide a frontend for doing so, for instance
 [`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
 
-If you don't set a [default language](programs-arangod-global.html#default-language)
+If you don't set a [default language](programs-arangod-general.html#default-language)
 for the server explicitly, ArangoDB will use the default locale of your system.
 
 {% hint 'warning' %}

--- a/3.8/programs-arangod-general.md
+++ b/3.8/programs-arangod-general.md
@@ -1,10 +1,12 @@
 ---
 layout: default
-description: ArangoDB Server Global Options
+description: ArangoDB Server General Options
+redirect_from:
+  - programs-arangod-global.html # 3.9 -> 3.9
 ---
-# ArangoDB Server Global Options
+# ArangoDB Server General Options
 
-## General help
+## Help
 
 `--help`
 

--- a/3.9/administration-configuration.md
+++ b/3.9/administration-configuration.md
@@ -61,7 +61,7 @@ arangod --database.directory="my_data_dir"
 
 Many options belong to a section as in `‑‑section.param`, e.g.
 `‑‑server.database`, but there can also be options without any section.
-These options are referred to as _global options_.
+These options are referred to as _general options_.
 
 To list available options, you can run a binary with the `‑‑help` flag:
 

--- a/3.9/aql/fundamentals-type-value-order.md
+++ b/3.9/aql/fundamentals-type-value-order.md
@@ -78,7 +78,7 @@ result is defined as follows:
 - boolean: *false* is less than *true*
 - number: numeric values are ordered by their cardinal value
 - string: string values are ordered using a localized comparison, using the configured
-  [server language](../programs-arangod-global.html#default-language)
+  [server language](../programs-arangod-general.html#default-language)
   for sorting according to the alphabetical order rules of that language
 
 Note: unlike in SQL, *null* can be compared to any value, including *null*

--- a/3.9/indexing-persistent.md
+++ b/3.9/indexing-persistent.md
@@ -177,7 +177,7 @@ Persistent Indexes and Server Language
 --------------------------------------
 
 The order of index entries in persistent indexes adheres to the configured
-[server language](programs-arangod-global.html#default-language).
+[server language](programs-arangod-general.html#default-language).
 If, however, the server is restarted with a different language setting as when
 the persistent index was created, not all documents may be returned anymore and
 the sort order of those which are returned can be wrong (whenever the persistent

--- a/3.9/installation-linux-osconfiguration.md
+++ b/3.9/installation-linux-osconfiguration.md
@@ -32,7 +32,7 @@ sudo locale-gen "en_US.UTF-8"
 Your distribution may also provide a frontend for doing so, for instance
 [`dpkg-reconfigure locales` on Debian](https://wiki.debian.org/Locale){:target="_blank"}.
 
-If you don't set a [default language](programs-arangod-global.html#default-language)
+If you don't set a [default language](programs-arangod-general.html#default-language)
 for the server explicitly, ArangoDB will use the default locale of your system.
 
 {% hint 'warning' %}

--- a/3.9/programs-arangod-general.md
+++ b/3.9/programs-arangod-general.md
@@ -1,10 +1,12 @@
 ---
 layout: default
-description: ArangoDB Server Global Options
+description: ArangoDB Server General Options
+redirect_from:
+  - programs-arangod-global.html # 3.9 -> 3.9
 ---
-# ArangoDB Server Global Options
+# ArangoDB Server General Options
 
-## General help
+## Help
 
 `--help`
 

--- a/_data/3.6-manual.yml
+++ b/_data/3.6-manual.yml
@@ -49,8 +49,8 @@
         - text: Options
           href: programs-arangod-options.html
           children:
-            - text: Global
-              href: programs-arangod-global.html
+            - text: General
+              href: programs-arangod-general.html
             - text: Agency
               href: programs-arangod-agency.html
             - text: ArangoSearch

--- a/_data/3.7-manual.yml
+++ b/_data/3.7-manual.yml
@@ -49,8 +49,8 @@
         - text: Options
           href: programs-arangod-options.html
           children:
-            - text: Global
-              href: programs-arangod-global.html
+            - text: General
+              href: programs-arangod-general.html
             - text: Agency
               href: programs-arangod-agency.html
             - text: ArangoSearch

--- a/_data/3.8-manual.yml
+++ b/_data/3.8-manual.yml
@@ -49,8 +49,8 @@
         - text: Options
           href: programs-arangod-options.html
           children:
-            - text: Global
-              href: programs-arangod-global.html
+            - text: General
+              href: programs-arangod-general.html
             - text: Agency
               href: programs-arangod-agency.html
             - text: ArangoSearch

--- a/_data/3.9-manual.yml
+++ b/_data/3.9-manual.yml
@@ -49,8 +49,8 @@
         - text: Options
           href: programs-arangod-options.html
           children:
-            - text: Global
-              href: programs-arangod-global.html
+            - text: General
+              href: programs-arangod-general.html
             - text: Agency
               href: programs-arangod-agency.html
             - text: ArangoSearch

--- a/_includes/program-option.html
+++ b/_includes/program-option.html
@@ -33,7 +33,7 @@ Also see [{{ section[0] | capitalize_section }} details](programs-arangod-{{ sec
 {%- if option[1].dynamic -%}
 Default: *dynamic* (e.g. `{{ option[1].default | jsonify }}`)
 {%- else -%}
-Default: `{{ option[1].default | jsonify }}`
+Default: <code>{{ option[1].default | jsonify }}</code>
 {%- endif -%}
 {%- endif -%}
 {%- if option[1].values %}<br>{{ option[1].values }}{% endif -%}

--- a/_plugins/OptionsBySectionFilter.rb
+++ b/_plugins/OptionsBySectionFilter.rb
@@ -28,7 +28,7 @@ module OptionsBySectionFilter
             by_section[section] = Hash.new if !by_section[section]
             by_section[section][k] = v
         }
-        by_section.sort.map {|k, v| [k == "" ? "global" : k, v] }.to_h
+        by_section.sort.map {|k, v| [k == "" ? "general" : k, v] }.to_h
     end
 end
   


### PR DESCRIPTION
Rename global to general options

Could restrict this to 3.9+ but doesn't have any side effects. Older binaries call it global, that's it.

  https://github.com/arangodb/arangodb/pull/13982/commits/3956da173731178184fc0a20fbfdb0a75f8249b0

Fixes https://github.com/arangodb/planning/issues/3318

Depends on #683 to get a preview build.