### PR TITLE
deprecate load/unload functions for collections

### DIFF
--- a/3.8/appendix-deprecated.md
+++ b/3.8/appendix-deprecated.md
@@ -85,6 +85,15 @@ replace the old features with:
   Their usage in client applications can be replaced by the endpoints they 
   redirect to.
 
+- **Loading and unloading of collections**:
+  The JavaScript functions for explicitly loading and unloading collections, 
+  `db.<collection-name>.load()` and `db.<collection-name>.unload()` and their
+  REST API endpoints PUT `/_api/collection/<collection-name>/load` and PUT 
+  `/_api/collection/<collection-name>/unload` are deprecated in 3.8. 
+  There should be no need to explicitly load or unload a collection with the
+  RocksDB storage engine. The load/unload functionality was useful only with 
+  the MMFiles storage engine, which is not available anymore since 3.7.
+
 - **Actions**: Snippets of JavaScript code on the server-side for minimal
   custom endpoints. Since the Foxx revamp in 3.0, it became really easy to
   write [Foxx Microservices](foxx.html), which allow you to define

--- a/3.8/appendix-deprecated.md
+++ b/3.8/appendix-deprecated.md
@@ -86,12 +86,12 @@ replace the old features with:
   redirect to.
 
 - **Loading and unloading of collections**:
-  The JavaScript functions for explicitly loading and unloading collections, 
+  The JavaScript functions for explicitly loading and unloading collections,
   `db.<collection-name>.load()` and `db.<collection-name>.unload()` and their
-  REST API endpoints PUT `/_api/collection/<collection-name>/load` and PUT 
-  `/_api/collection/<collection-name>/unload` are deprecated in 3.8. 
+  REST API endpoints `PUT /_api/collection/<collection-name>/load` and
+  `PUT /_api/collection/<collection-name>/unload` are deprecated in 3.8.
   There should be no need to explicitly load or unload a collection with the
-  RocksDB storage engine. The load/unload functionality was useful only with 
+  RocksDB storage engine. The load/unload functionality was useful only with
   the MMFiles storage engine, which is not available anymore since 3.7.
 
 - **Actions**: Snippets of JavaScript code on the server-side for minimal

--- a/3.8/data-modeling-collections-collection-methods.md
+++ b/3.8/data-modeling-collections-collection-methods.md
@@ -212,9 +212,11 @@ Loads a collection into memory.
 Cluster collections are loaded at all times.
 {% endhint %}
 
-Note: the *load* function is **deprecated** as of ArangoDB 3.8.
+{% hint 'warning' %}
+The *load()* function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to load a collection with the RocksDB storage engine.
+{% endhint %}
 
 **Examples**
 
@@ -302,9 +304,11 @@ until all queries have finished.
 Cluster collections cannot be unloaded.
 {% endhint %}
 
-Note: the *unload* function is **deprecated** as of ArangoDB 3.8.
+{% hint 'warning' %}
+The *unload()* function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to unload a collection with the RocksDB storage engine.
+{% endhint %}
 
 **Examples**
 

--- a/3.8/data-modeling-collections-collection-methods.md
+++ b/3.8/data-modeling-collections-collection-methods.md
@@ -212,6 +212,10 @@ Loads a collection into memory.
 Cluster collections are loaded at all times.
 {% endhint %}
 
+Note: the *load* function is **deprecated** as of ArangoDB 3.8.
+The function may be removed in future versions of ArangoDB. There should not be
+any need to load a collection with the RocksDB storage engine.
+
 **Examples**
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
@@ -292,11 +296,15 @@ unloads a collection
 `collection.unload()`
 
 Starts unloading a collection from memory. Note that unloading is deferred
-until all query have finished.
+until all queries have finished.
 
 {% hint 'info' %}
 Cluster collections cannot be unloaded.
 {% endhint %}
+
+Note: the *unload* function is **deprecated** as of ArangoDB 3.8.
+The function may be removed in future versions of ArangoDB. There should not be
+any need to unload a collection with the RocksDB storage engine.
 
 **Examples**
 

--- a/3.9/appendix-deprecated.md
+++ b/3.9/appendix-deprecated.md
@@ -83,12 +83,12 @@ replace the old features with:
   - `/_admin/clusterStatistics`: redirects to `/_admin/cluster/statistics`
 
 - **Loading and unloading of collections**:
-  The JavaScript functions for explicitly loading and unloading collections, 
+  The JavaScript functions for explicitly loading and unloading collections,
   `db.<collection-name>.load()` and `db.<collection-name>.unload()` and their
-  REST API endpoints PUT `/_api/collection/<collection-name>/load` and PUT 
-  `/_api/collection/<collection-name>/unload` are deprecated in 3.8. 
+  REST API endpoints `PUT /_api/collection/<collection-name>/load` and
+  `PUT /_api/collection/<collection-name>/unload` are deprecated in 3.8.
   There should be no need to explicitly load or unload a collection with the
-  RocksDB storage engine. The load/unload functionality was useful only with 
+  RocksDB storage engine. The load/unload functionality was useful only with
   the MMFiles storage engine, which is not available anymore since 3.7.
 
 - **Actions**: Snippets of JavaScript code on the server-side for minimal

--- a/3.9/appendix-deprecated.md
+++ b/3.9/appendix-deprecated.md
@@ -82,6 +82,15 @@ replace the old features with:
   - `/_admin/clusterNodeStats`: redirects to `/_admin/cluster/nodeStatistics`
   - `/_admin/clusterStatistics`: redirects to `/_admin/cluster/statistics`
 
+- **Loading and unloading of collections**:
+  The JavaScript functions for explicitly loading and unloading collections, 
+  `db.<collection-name>.load()` and `db.<collection-name>.unload()` and their
+  REST API endpoints PUT `/_api/collection/<collection-name>/load` and PUT 
+  `/_api/collection/<collection-name>/unload` are deprecated in 3.8. 
+  There should be no need to explicitly load or unload a collection with the
+  RocksDB storage engine. The load/unload functionality was useful only with 
+  the MMFiles storage engine, which is not available anymore since 3.7.
+
 - **Actions**: Snippets of JavaScript code on the server-side for minimal
   custom endpoints. Since the Foxx revamp in 3.0, it became really easy to
   write [Foxx Microservices](foxx.html), which allow you to define

--- a/3.9/data-modeling-collections-collection-methods.md
+++ b/3.9/data-modeling-collections-collection-methods.md
@@ -212,9 +212,11 @@ Loads a collection into memory.
 Cluster collections are loaded at all times.
 {% endhint %}
 
-Note: the *load* function is **deprecated** as of ArangoDB 3.8.
+{% hint 'warning' %}
+The *load()* function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to load a collection with the RocksDB storage engine.
+{% endhint %}
 
 **Examples**
 
@@ -302,9 +304,11 @@ until all queries have finished.
 Cluster collections cannot be unloaded.
 {% endhint %}
 
-Note: the *unload* function is **deprecated** as of ArangoDB 3.8.
+{% hint 'warning' %}
+The *unload()* function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to unload a collection with the RocksDB storage engine.
+{% endhint %}
 
 **Examples**
 

--- a/3.9/data-modeling-collections-collection-methods.md
+++ b/3.9/data-modeling-collections-collection-methods.md
@@ -212,6 +212,10 @@ Loads a collection into memory.
 Cluster collections are loaded at all times.
 {% endhint %}
 
+Note: the *load* function is **deprecated** as of ArangoDB 3.8.
+The function may be removed in future versions of ArangoDB. There should not be
+any need to load a collection with the RocksDB storage engine.
+
 **Examples**
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
@@ -292,11 +296,15 @@ unloads a collection
 `collection.unload()`
 
 Starts unloading a collection from memory. Note that unloading is deferred
-until all query have finished.
+until all queries have finished.
 
 {% hint 'info' %}
 Cluster collections cannot be unloaded.
 {% endhint %}
+
+Note: the *unload* function is **deprecated** as of ArangoDB 3.8.
+The function may be removed in future versions of ArangoDB. There should not be
+any need to unload a collection with the RocksDB storage engine.
 
 **Examples**
 


### PR DESCRIPTION
Deprecate collection loading/unloading, as there is no sensible use case for it anymore with RocksDB.