### PR TITLE
ArangoSearch clarifications

### DIFF
--- a/3.6/aql/functions-arangosearch.md
+++ b/3.6/aql/functions-arangosearch.md
@@ -437,6 +437,20 @@ It is the same as the following:
 FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, "fox", 0, "jumps", "text_en") RETURN doc
 ```
 
+Empty arrays are skipped:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, [], 1, "jumps", "text_en") RETURN doc
+```
+
+The query is equivalent to:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 2 "jumps", "text_en") RETURN doc
+```
+
+Providing only empty arrays is valid, but will yield no results.
+
 ### STARTS_WITH()
 
 `STARTS_WITH(path, prefix)`

--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -555,6 +555,20 @@ It is the same as the following:
 FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, "fox", 0, "jumps", "text_en") RETURN doc
 ```
 
+Empty arrays are skipped:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, [], 1, "jumps", "text_en") RETURN doc
+```
+
+The query is equivalent to:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 2 "jumps", "text_en") RETURN doc
+```
+
+Providing only empty arrays is valid, but will yield no results.
+
 Using object tokens `STARTS_WITH`, `WILDCARD`, `LEVENSHTEIN_MATCH`, `TERMS` and
 `IN_RANGE`:
 

--- a/3.7/aql/functions-arangosearch.md
+++ b/3.7/aql/functions-arangosearch.md
@@ -353,14 +353,16 @@ matching _n_-grams is, divided by the target's total _n_-gram count.
 Only fully matching _n_-grams are counted.
 
 The _n_-grams for both attribute and target are produced by the specified
-Analyzer. It is recommended to use an Analyzer of type `ngram` with
-`preserveOriginal: false` and `min` equal to `max`. Increasing the _n_-gram
-length will increase accuracy, but reduce error tolerance. In most cases a
-size of 2 or 3 will be a good choice. 
+Analyzer. Increasing the _n_-gram length will increase accuracy, but reduce
+error tolerance. In most cases a size of 2 or 3 will be a good choice.
 
 {% hint 'info' %}
-The selected Analyzer must have the `"position"` and `"frequency"` features
-enabled. The `NGRAM_MATCH()` function will otherwise not find anything.
+Use an Analyzer of type `ngram` with `preserveOriginal: false` and `min` equal
+to `max`. Otherwise, the similarity score calculated internally will be lower
+than expected.
+
+The Analyzer must have the `"position"` and `"frequency"` features enabled or
+the `NGRAM_MATCH()` function will not find anything.
 {% endhint %}
 
 Also see the String Functions

--- a/3.7/aql/functions-string.md
+++ b/3.7/aql/functions-string.md
@@ -920,7 +920,8 @@ SPLIT( "foo-bar-baz", "-", 1 ) // [ "foo" ]
 SPLIT( "foo, bar & baz", [ ", ", " & " ] ) // [ "foo", "bar", "baz" ]
 ```
 
-### STARTS_WITH()
+STARTS_WITH()
+-------------
 
 `STARTS_WITH(text, prefix) → startsWith`
 

--- a/3.7/aql/operations-search.md
+++ b/3.7/aql/operations-search.md
@@ -247,11 +247,12 @@ The `SEARCH` operation accepts an options object with the following attributes:
 - `collections` (array, _optional_): array of strings with collection names to
   restrict the search to certain source collections
 - `conditionOptimization` (string, _optional_): controls how search criteria
-  get optimized (introduced in v3.7.0). Possible values:
+  get optimized (introduced in v3.6.2). Possible values:
   - `"auto"` (default): convert conditions to disjunctive normal form (DNF) and
     apply optimizations. Removes redundant or overlapping conditions, but can
     take quite some time even for a low number of nested conditions.
   - `"none"`: search the index without optimizing the conditions.
+  <!-- Internal only: nodnf, noneg -->
 
 **Examples**
 

--- a/3.7/aql/operations-search.md
+++ b/3.7/aql/operations-search.md
@@ -252,14 +252,6 @@ The `SEARCH` operation accepts an options object with the following attributes:
     apply optimizations. Removes redundant or overlapping conditions, but can
     take quite some time even for a low number of nested conditions.
   - `"none"`: search the index without optimizing the conditions.
-- `countApproximate` (string, _optional_): controls how the total count of rows
-  is calculated if the `fullCount` option is enabled for a query or when
-  a `COLLECT WITH COUNT` clause is executed (introduced in v3.7.6)
-  - `"exact"` (default): rows are actually enumerated for a precise count.
-  - `"cost"`: a cost based approximation is used. Does not enumerate rows and
-    returns an approximate result with O(1) complexity. Gives a precise result
-    if the `SEARCH` condition is empty or if it contains a single term query
-    only (e.g. `SEARCH doc.field == "value"`).
 
 **Examples**
 

--- a/3.7/arangosearch-exact-value-matching.md
+++ b/3.7/arangosearch-exact-value-matching.md
@@ -183,8 +183,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~440ms) |
-|:----------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |
@@ -196,7 +196,9 @@ FOR doc IN imdb
 A better way to ignore documents without title attribute is to change the View
 property `storeValues` (not to be confused with `storedValues`!) from `"none"`
 to `"id"`. You can then use the [`EXISTS()` function](aql/functions-arangosearch.html#exists)
-to test whether there is a title field or not:
+to test whether there is a title field or not. On a single server with this
+particular dataset, the query is roughly five times faster than the previous
+one without `EXISTS()`:
 
 ```js
 FOR doc IN imdb
@@ -204,8 +206,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~90ms) |
-|:---------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |

--- a/3.7/arangosearch-performance.md
+++ b/3.7/arangosearch-performance.md
@@ -199,25 +199,4 @@ optimizations.
 
 Also see [SEARCH operation](aql/operations-search.html#search-options).
 
-## Count Approximation
-
-The `SEARCH` operation in AQL accepts an option `countApproximate` to control
-how the total count of rows is calculated if the `fullCount` option is enabled
-for a query or when a `COLLECT WITH COUNT` clause is executed.
-
-By default, rows are actually enumerated for a precise count. In some cases, an
-estimate might be good enough, however. You can set `countApproximate` to
-`"cost"` for a cost based approximation. It does not enumerate rows and returns
-an approximate result with O(1) complexity. It gives a precise result if the
-`SEARCH` condition is empty or if it contains a single term query only
-(e.g. `SEARCH doc.field == "value"`).
-
-```js
-FOR doc IN viewName
-  SEARCH doc.name == "Carol"
-  OPTIONS { countApproximate: "cost" }
-  COLLECT WITH COUNT INTO count
-  RETURN count
-```
-
 <!-- TODO: The Analyzer feature "norm" has some performance implications -->

--- a/3.7/arangosearch-wildcard-search.md
+++ b/3.7/arangosearch-wildcard-search.md
@@ -16,7 +16,7 @@ partial strings.
 
 The [ArangoSearch `LIKE()` function](aql/functions-arangosearch.html#like)
 is backed by View indexes. In contrast, the
-[String `LIKE()` function`](aql/functions-string.html#like) cannot utilize any
+[String `LIKE()` function](aql/functions-string.html#like) cannot utilize any
 sort of index. Another difference is that the ArangoSearch variant does not
 accept a third argument to make matching case-insensitive. You can control this
 via Analyzers instead, also see

--- a/3.7/highlights.md
+++ b/3.7/highlights.md
@@ -15,8 +15,7 @@ Version 3.7
   [Wildcard](aql/functions-arangosearch.html#like) and fuzzy search
   ([Levenshtein distance](aql/functions-arangosearch.html#levenshtein_match) and
   [_n_-gram based](aql/functions-arangosearch.html#ngram_match)),
-  [enhanced phrase](aql/functions-arangosearch.html#phrase) and
-  [proximity search](aql/functions-array.html#jaccard),
+  enhanced [phrase and proximity search](aql/functions-arangosearch.html#phrase),
   improved late document materialization and
   [Views covering queries](release-notes-new-features37.html#covering-indexes)
   using their indexes without touching the storage engine, as well as a new

--- a/3.8/aql/functions-arangosearch.md
+++ b/3.8/aql/functions-arangosearch.md
@@ -555,6 +555,20 @@ It is the same as the following:
 FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, "fox", 0, "jumps", "text_en") RETURN doc
 ```
 
+Empty arrays are skipped:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, [], 1, "jumps", "text_en") RETURN doc
+```
+
+The query is equivalent to:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 2 "jumps", "text_en") RETURN doc
+```
+
+Providing only empty arrays is valid, but will yield no results.
+
 Using object tokens `STARTS_WITH`, `WILDCARD`, `LEVENSHTEIN_MATCH`, `TERMS` and
 `IN_RANGE`:
 

--- a/3.8/aql/functions-arangosearch.md
+++ b/3.8/aql/functions-arangosearch.md
@@ -353,14 +353,16 @@ matching _n_-grams is, divided by the target's total _n_-gram count.
 Only fully matching _n_-grams are counted.
 
 The _n_-grams for both attribute and target are produced by the specified
-Analyzer. It is recommended to use an Analyzer of type `ngram` with
-`preserveOriginal: false` and `min` equal to `max`. Increasing the _n_-gram
-length will increase accuracy, but reduce error tolerance. In most cases a
-size of 2 or 3 will be a good choice. 
+Analyzer. Increasing the _n_-gram length will increase accuracy, but reduce
+error tolerance. In most cases a size of 2 or 3 will be a good choice.
 
 {% hint 'info' %}
-The selected Analyzer must have the `"position"` and `"frequency"` features
-enabled. The `NGRAM_MATCH()` function will otherwise not find anything.
+Use an Analyzer of type `ngram` with `preserveOriginal: false` and `min` equal
+to `max`. Otherwise, the similarity score calculated internally will be lower
+than expected.
+
+The Analyzer must have the `"position"` and `"frequency"` features enabled or
+the `NGRAM_MATCH()` function will not find anything.
 {% endhint %}
 
 Also see the String Functions

--- a/3.8/aql/functions-string.md
+++ b/3.8/aql/functions-string.md
@@ -920,7 +920,8 @@ SPLIT( "foo-bar-baz", "-", 1 ) // [ "foo" ]
 SPLIT( "foo, bar & baz", [ ", ", " & " ] ) // [ "foo", "bar", "baz" ]
 ```
 
-### STARTS_WITH()
+STARTS_WITH()
+-------------
 
 `STARTS_WITH(text, prefix) → startsWith`
 

--- a/3.8/aql/operations-search.md
+++ b/3.8/aql/operations-search.md
@@ -259,7 +259,8 @@ The `SEARCH` operation accepts an options object with the following attributes:
   - `"cost"`: a cost based approximation is used. Does not enumerate rows and
     returns an approximate result with O(1) complexity. Gives a precise result
     if the `SEARCH` condition is empty or if it contains a single term query
-    only (e.g. `SEARCH doc.field == "value"`).
+    only (e.g. `SEARCH doc.field == "value"`), the usual eventual consistency
+    of Views aside.
 
 **Examples**
 

--- a/3.8/aql/operations-search.md
+++ b/3.8/aql/operations-search.md
@@ -247,11 +247,12 @@ The `SEARCH` operation accepts an options object with the following attributes:
 - `collections` (array, _optional_): array of strings with collection names to
   restrict the search to certain source collections
 - `conditionOptimization` (string, _optional_): controls how search criteria
-  get optimized (introduced in v3.7.0). Possible values:
+  get optimized (introduced in v3.6.2). Possible values:
   - `"auto"` (default): convert conditions to disjunctive normal form (DNF) and
     apply optimizations. Removes redundant or overlapping conditions, but can
     take quite some time even for a low number of nested conditions.
   - `"none"`: search the index without optimizing the conditions.
+  <!-- Internal only: nodnf, noneg -->
 - `countApproximate` (string, _optional_): controls how the total count of rows
   is calculated if the `fullCount` option is enabled for a query or when
   a `COLLECT WITH COUNT` clause is executed (introduced in v3.7.6)

--- a/3.8/arangosearch-exact-value-matching.md
+++ b/3.8/arangosearch-exact-value-matching.md
@@ -183,8 +183,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~440ms) |
-|:----------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |
@@ -196,7 +196,9 @@ FOR doc IN imdb
 A better way to ignore documents without title attribute is to change the View
 property `storeValues` (not to be confused with `storedValues`!) from `"none"`
 to `"id"`. You can then use the [`EXISTS()` function](aql/functions-arangosearch.html#exists)
-to test whether there is a title field or not:
+to test whether there is a title field or not. On a single server with this
+particular dataset, the query is roughly five times faster than the previous
+one without `EXISTS()`:
 
 ```js
 FOR doc IN imdb
@@ -204,8 +206,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~90ms) |
-|:---------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |

--- a/3.8/arangosearch-performance.md
+++ b/3.8/arangosearch-performance.md
@@ -210,7 +210,8 @@ estimate might be good enough, however. You can set `countApproximate` to
 `"cost"` for a cost based approximation. It does not enumerate rows and returns
 an approximate result with O(1) complexity. It gives a precise result if the
 `SEARCH` condition is empty or if it contains a single term query only
-(e.g. `SEARCH doc.field == "value"`).
+(e.g. `SEARCH doc.field == "value"`), the usual eventual consistency
+of Views aside.
 
 ```js
 FOR doc IN viewName

--- a/3.8/arangosearch-wildcard-search.md
+++ b/3.8/arangosearch-wildcard-search.md
@@ -16,7 +16,7 @@ partial strings.
 
 The [ArangoSearch `LIKE()` function](aql/functions-arangosearch.html#like)
 is backed by View indexes. In contrast, the
-[String `LIKE()` function`](aql/functions-string.html#like) cannot utilize any
+[String `LIKE()` function](aql/functions-string.html#like) cannot utilize any
 sort of index. Another difference is that the ArangoSearch variant does not
 accept a third argument to make matching case-insensitive. You can control this
 via Analyzers instead, also see

--- a/3.8/highlights.md
+++ b/3.8/highlights.md
@@ -50,8 +50,7 @@ Version 3.7
   [Wildcard](aql/functions-arangosearch.html#like) and fuzzy search
   ([Levenshtein distance](aql/functions-arangosearch.html#levenshtein_match) and
   [_n_-gram based](aql/functions-arangosearch.html#ngram_match)),
-  [enhanced phrase](aql/functions-arangosearch.html#phrase) and
-  [proximity search](aql/functions-array.html#jaccard),
+  enhanced [phrase and proximity search](aql/functions-arangosearch.html#phrase),
   improved late document materialization and
   [Views covering queries](release-notes-new-features37.html#covering-indexes)
   using their indexes without touching the storage engine, as well as a new

--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -309,7 +309,8 @@ query or when a `COLLECT WITH COUNT` clause is executed:
 - `"cost"`: a cost based approximation is used. Does not enumerate rows and
   returns an approximate result with O(1) complexity. Gives a precise result
   if the `SEARCH` condition is empty or if it contains a single term query
-  only (e.g. `SEARCH doc.field == "value"`).
+  only (e.g. `SEARCH doc.field == "value"`), the usual eventual consistency
+  of Views aside.
 
 Also see: [AQL `SEARCH` Operation](aql/operations-search.html#search-options)
 

--- a/3.9/aql/functions-arangosearch.md
+++ b/3.9/aql/functions-arangosearch.md
@@ -555,6 +555,20 @@ It is the same as the following:
 FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, "fox", 0, "jumps", "text_en") RETURN doc
 ```
 
+Empty arrays are skipped:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 1, [], 1, "jumps", "text_en") RETURN doc
+```
+
+The query is equivalent to:
+
+```js
+FOR doc IN myView SEARCH PHRASE(doc.title, "quick", 2 "jumps", "text_en") RETURN doc
+```
+
+Providing only empty arrays is valid, but will yield no results.
+
 Using object tokens `STARTS_WITH`, `WILDCARD`, `LEVENSHTEIN_MATCH`, `TERMS` and
 `IN_RANGE`:
 

--- a/3.9/aql/functions-arangosearch.md
+++ b/3.9/aql/functions-arangosearch.md
@@ -353,14 +353,16 @@ matching _n_-grams is, divided by the target's total _n_-gram count.
 Only fully matching _n_-grams are counted.
 
 The _n_-grams for both attribute and target are produced by the specified
-Analyzer. It is recommended to use an Analyzer of type `ngram` with
-`preserveOriginal: false` and `min` equal to `max`. Increasing the _n_-gram
-length will increase accuracy, but reduce error tolerance. In most cases a
-size of 2 or 3 will be a good choice. 
+Analyzer. Increasing the _n_-gram length will increase accuracy, but reduce
+error tolerance. In most cases a size of 2 or 3 will be a good choice.
 
 {% hint 'info' %}
-The selected Analyzer must have the `"position"` and `"frequency"` features
-enabled. The `NGRAM_MATCH()` function will otherwise not find anything.
+Use an Analyzer of type `ngram` with `preserveOriginal: false` and `min` equal
+to `max`. Otherwise, the similarity score calculated internally will be lower
+than expected.
+
+The Analyzer must have the `"position"` and `"frequency"` features enabled or
+the `NGRAM_MATCH()` function will not find anything.
 {% endhint %}
 
 Also see the String Functions

--- a/3.9/aql/functions-string.md
+++ b/3.9/aql/functions-string.md
@@ -920,7 +920,8 @@ SPLIT( "foo-bar-baz", "-", 1 ) // [ "foo" ]
 SPLIT( "foo, bar & baz", [ ", ", " & " ] ) // [ "foo", "bar", "baz" ]
 ```
 
-### STARTS_WITH()
+STARTS_WITH()
+-------------
 
 `STARTS_WITH(text, prefix) → startsWith`
 

--- a/3.9/aql/operations-search.md
+++ b/3.9/aql/operations-search.md
@@ -256,10 +256,11 @@ The `SEARCH` operation accepts an options object with the following attributes:
   is calculated if the `fullCount` option is enabled for a query or when
   a `COLLECT WITH COUNT` clause is executed (introduced in v3.7.6)
   - `"exact"` (default): rows are actually enumerated for a precise count.
-  - `"cost"`: a cost based approximation is used. Does not enumerate rows and
+  - `"cost"`: a cost-based approximation is used. Does not enumerate rows and
     returns an approximate result with O(1) complexity. Gives a precise result
     if the `SEARCH` condition is empty or if it contains a single term query
-    only (e.g. `SEARCH doc.field == "value"`).
+    only (e.g. `SEARCH doc.field == "value"`), the usual eventual consistency
+    of Views aside.
 
 **Examples**
 

--- a/3.9/aql/operations-search.md
+++ b/3.9/aql/operations-search.md
@@ -247,11 +247,12 @@ The `SEARCH` operation accepts an options object with the following attributes:
 - `collections` (array, _optional_): array of strings with collection names to
   restrict the search to certain source collections
 - `conditionOptimization` (string, _optional_): controls how search criteria
-  get optimized (introduced in v3.7.0). Possible values:
+  get optimized (introduced in v3.6.2). Possible values:
   - `"auto"` (default): convert conditions to disjunctive normal form (DNF) and
     apply optimizations. Removes redundant or overlapping conditions, but can
     take quite some time even for a low number of nested conditions.
   - `"none"`: search the index without optimizing the conditions.
+  <!-- Internal only: nodnf, noneg -->
 - `countApproximate` (string, _optional_): controls how the total count of rows
   is calculated if the `fullCount` option is enabled for a query or when
   a `COLLECT WITH COUNT` clause is executed (introduced in v3.7.6)

--- a/3.9/arangosearch-exact-value-matching.md
+++ b/3.9/arangosearch-exact-value-matching.md
@@ -183,8 +183,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~440ms) |
-|:----------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |
@@ -196,7 +196,9 @@ FOR doc IN imdb
 A better way to ignore documents without title attribute is to change the View
 property `storeValues` (not to be confused with `storedValues`!) from `"none"`
 to `"id"`. You can then use the [`EXISTS()` function](aql/functions-arangosearch.html#exists)
-to test whether there is a title field or not:
+to test whether there is a title field or not. On a single server with this
+particular dataset, the query is roughly five times faster than the previous
+one without `EXISTS()`:
 
 ```js
 FOR doc IN imdb
@@ -204,8 +206,8 @@ FOR doc IN imdb
   RETURN doc.title
 ```
 
-| Result (~90ms) |
-|:---------------|
+| Result |
+|:-------|
 | Ploning |
 | Code Rush |
 | Ghost in the Shell 2.0 |

--- a/3.9/arangosearch-performance.md
+++ b/3.9/arangosearch-performance.md
@@ -210,7 +210,8 @@ estimate might be good enough, however. You can set `countApproximate` to
 `"cost"` for a cost based approximation. It does not enumerate rows and returns
 an approximate result with O(1) complexity. It gives a precise result if the
 `SEARCH` condition is empty or if it contains a single term query only
-(e.g. `SEARCH doc.field == "value"`).
+(e.g. `SEARCH doc.field == "value"`), the usual eventual consistency
+of Views aside.
 
 ```js
 FOR doc IN viewName

--- a/3.9/arangosearch-wildcard-search.md
+++ b/3.9/arangosearch-wildcard-search.md
@@ -16,7 +16,7 @@ partial strings.
 
 The [ArangoSearch `LIKE()` function](aql/functions-arangosearch.html#like)
 is backed by View indexes. In contrast, the
-[String `LIKE()` function`](aql/functions-string.html#like) cannot utilize any
+[String `LIKE()` function](aql/functions-string.html#like) cannot utilize any
 sort of index. Another difference is that the ArangoSearch variant does not
 accept a third argument to make matching case-insensitive. You can control this
 via Analyzers instead, also see

--- a/3.9/highlights.md
+++ b/3.9/highlights.md
@@ -59,8 +59,7 @@ Version 3.7
   [Wildcard](aql/functions-arangosearch.html#like) and fuzzy search
   ([Levenshtein distance](aql/functions-arangosearch.html#levenshtein_match) and
   [_n_-gram based](aql/functions-arangosearch.html#ngram_match)),
-  [enhanced phrase](aql/functions-arangosearch.html#phrase) and
-  [proximity search](aql/functions-array.html#jaccard),
+  enhanced [phrase and proximity search](aql/functions-arangosearch.html#phrase),
   improved late document materialization and
   [Views covering queries](release-notes-new-features37.html#covering-indexes)
   using their indexes without touching the storage engine, as well as a new


### PR DESCRIPTION
- BTS-399: An n-gram Analyzer with min == max is expected by NGRAM_MATCH(), it isn't just a recommendation (score will be lower than expected otherwise)
- Remove `countApproximate` option from 3.7 docs (added only in 3.8)
- Approximate count (`countApproximate: "cost"`) is affected by the eventually consistent nature of Views, i.e. it is not precise if documents were recently changed because everything View-related is lagging behind
- Remove erroneous link JACCARD() function . Proximity search is PHRASE() with skip tokens (wildcards)
- Fix headline level of STARTS_WITH()
- The SEARCH `conditionOptimization` option was introduced in 3.6.2, not 3.7.0
- Replace absolute with relative query execution time in `EXISTS()` example
- PHRASE() skips empty arrays since 3.6.1