### PR TITLE
add warning

### DIFF
--- a/3.8/analyzers.md
+++ b/3.8/analyzers.md
@@ -687,12 +687,11 @@ attributes:
 - `pipeline` (array): an array of Analyzer definition-like objects with
   `type` and `properties` attributes
 
-{% hint 'warning' %}
-Analyzers of types `geopoint` and `geojson` could not be used as members of
-the pipeline. This analyzers require additional postprocessing and should be
-applied to the document fields only directly. Attempt to create a pipeline analyzer with
-at least one `geopoint` or `geojson` analyzer in the pipeline will fail.
-{% endhint %} 
+{% hint 'info' %}
+Analyzers of types `geopoint` and `geojson` cannot be used in pipelines and
+will make the creation fail. These Analyzers require additional postprocessing
+and can only be applied to document fields directly.
+{% endhint %}
 
 **Examples**
 

--- a/3.8/analyzers.md
+++ b/3.8/analyzers.md
@@ -687,6 +687,13 @@ attributes:
 - `pipeline` (array): an array of Analyzer definition-like objects with
   `type` and `properties` attributes
 
+{% hint 'warning' %}
+Analyzers of types `geopoint` and `geojson` could not be used as members of
+the pipeline. This analyzers require additional postprocessing and should be
+applied to the document fields only directly. Attempt to create a pipeline analyzer with
+at least one `geopoint` or `geojson` analyzer in the pipeline will fail.
+{% endhint %} 
+
 **Examples**
 
 Normalize to all uppercase and compute bigrams:

--- a/3.9/analyzers.md
+++ b/3.9/analyzers.md
@@ -686,6 +686,13 @@ attributes:
 
 - `pipeline` (array): an array of Analyzer definition-like objects with
   `type` and `properties` attributes
+  
+{% hint 'warning' %}
+Analyzers of types `geopoint` and `geojson` could not be used as members of
+the pipeline. This analyzers require additional postprocessing and should be
+applied to the document fields only directly. Attempt to create a pipeline analyzer with
+at least one `geopoint` or `geojson` analyzer in the pipeline will fail.
+{% endhint %}
 
 **Examples**
 

--- a/3.9/analyzers.md
+++ b/3.9/analyzers.md
@@ -687,11 +687,10 @@ attributes:
 - `pipeline` (array): an array of Analyzer definition-like objects with
   `type` and `properties` attributes
   
-{% hint 'warning' %}
-Analyzers of types `geopoint` and `geojson` could not be used as members of
-the pipeline. This analyzers require additional postprocessing and should be
-applied to the document fields only directly. Attempt to create a pipeline analyzer with
-at least one `geopoint` or `geojson` analyzer in the pipeline will fail.
+{% hint 'info' %}
+Analyzers of types `geopoint` and `geojson` cannot be used in pipelines and
+will make the creation fail. These Analyzers require additional postprocessing
+and can only be applied to document fields directly.
 {% endhint %}
 
 **Examples**


### PR DESCRIPTION
Added warning denoting limitation for pipeline analyzer: geo-related analyzers could not be used in pipeline.
See the issue https://arangodb.atlassian.net/browse/BTS-462