### PR TITLE
`server.authentication-system-only` disables authentication for Foxx endpoints only

### DIFF
--- a/3.6/administration-managing-users.md
+++ b/3.6/administration-managing-users.md
@@ -20,9 +20,10 @@ authentication = true
 ```
 
 This will make ArangoDB require authentication for every request (including
-requests to Foxx apps). If you want to run Foxx apps without HTTP
-authentication, but activate HTTP authentication for the built-in server APIs,
-you can add the following line in the `[server]` section of the configuration:
+requests to Foxx apps depending on the option below). If you want to run Foxx
+apps without HTTP authentication, but activate HTTP authentication for the built-in
+server APIs, you can add the following line in the `[server]` section of the 
+configuration:
 
 ```
 authentication-system-only = true

--- a/3.7/administration-managing-users.md
+++ b/3.7/administration-managing-users.md
@@ -20,9 +20,10 @@ authentication = true
 ```
 
 This will make ArangoDB require authentication for every request (including
-requests to Foxx apps). If you want to run Foxx apps without HTTP
-authentication, but activate HTTP authentication for the built-in server APIs,
-you can add the following line in the `[server]` section of the configuration:
+requests to Foxx apps depending on the option below). If you want to run Foxx
+apps without HTTP authentication, but activate HTTP authentication for the built-in
+server APIs, you can add the following line in the `[server]` section of the 
+configuration:
 
 ```
 authentication-system-only = true

--- a/3.8/administration-managing-users.md
+++ b/3.8/administration-managing-users.md
@@ -20,9 +20,10 @@ authentication = true
 ```
 
 This will make ArangoDB require authentication for every request (including
-requests to Foxx apps). If you want to run Foxx apps without HTTP
-authentication, but activate HTTP authentication for the built-in server APIs,
-you can add the following line in the `[server]` section of the configuration:
+requests to Foxx apps depending on the option below). If you want to run Foxx
+apps without HTTP authentication, but activate HTTP authentication for the built-in
+server APIs, you can add the following line in the `[server]` section of the 
+configuration:
 
 ```
 authentication-system-only = true

--- a/3.9/administration-managing-users.md
+++ b/3.9/administration-managing-users.md
@@ -20,9 +20,10 @@ authentication = true
 ```
 
 This will make ArangoDB require authentication for every request (including
-requests to Foxx apps). If you want to run Foxx apps without HTTP
-authentication, but activate HTTP authentication for the built-in server APIs,
-you can add the following line in the `[server]` section of the configuration:
+requests to Foxx apps depending on the option below). If you want to run Foxx
+apps without HTTP authentication, but activate HTTP authentication for the built-in
+server APIs, you can add the following line in the `[server]` section of the 
+configuration:
 
 ```
 authentication-system-only = true


### PR DESCRIPTION
Avoid any doubt