### PR TITLE
mention extra limitations for Stream Transactions

### DIFF
--- a/3.7/transactions-limitations.md
+++ b/3.7/transactions-limitations.md
@@ -168,3 +168,19 @@ attributes in the call to *db._query()*:
   commit is performed automatically
 - *intermediateCommitCount*: maximum number of operations after which an intermediate
   commit is performed automatically
+
+### Limits for Stream Transactions
+
+A maximum lifetime and transaction size for Stream Transactions is enforced
+on the Coordinator to ensure that abandoned transactions cannot block the
+cluster from operating properly:
+
+- Maximum idle timeout of **10 seconds** between operations
+- Maximum transaction size of **128 MB** per DB-Server
+
+These limits are also enforced for Stream Transactions on single servers.
+
+Enforcing the limits is useful to free up resources used by abandoned 
+transactions, for example from transactions that are abandoned by client 
+applications due to programming errors or that were left over because client 
+connections were interrupted.

--- a/3.8/transactions-limitations.md
+++ b/3.8/transactions-limitations.md
@@ -168,3 +168,25 @@ attributes in the call to *db._query()*:
   commit is performed automatically
 - *intermediateCommitCount*: maximum number of operations after which an intermediate
   commit is performed automatically
+
+### Limits for Stream Transactions
+
+A maximum lifetime and transaction size for Stream Transactions is enforced
+on the Coordinator to ensure that abandoned transactions cannot block the
+cluster from operating properly:
+
+- Maximum idle timeout of up to **120 seconds** between operations
+- Maximum transaction size of **128 MB** per DB-Server
+
+These limits are also enforced for Stream Transactions on single servers.
+
+The default maximum idle timeout is **60 seconds** between operations in a
+single Stream Transaction. The maximum value can be bumped up to at most 120
+seconds by setting the startup option `--transaction.streaming-idle-timeout`.
+Posting an operation into a non-expired Stream Transaction will reset the
+transaction's timeout to the configured idle timeout.
+
+Enforcing the limit is useful to free up resources used by abandoned
+transactions, for example from transactions that are abandoned by client
+applications due to programming errors or that were left over because client
+connections were interrupted.

--- a/3.9/transactions-limitations.md
+++ b/3.9/transactions-limitations.md
@@ -168,3 +168,25 @@ attributes in the call to *db._query()*:
   commit is performed automatically
 - *intermediateCommitCount*: maximum number of operations after which an intermediate
   commit is performed automatically
+
+### Limits for Stream transactions
+
+A maximum lifetime and transaction size for Stream Transactions is enforced
+on the Coordinator to ensure that abandoned transactions cannot block the
+cluster from operating properly:
+
+- Maximum idle timeout of up to **120 seconds** between operations
+- Maximum transaction size of **128 MB** per DB-Server
+
+These limits are also enforced for Stream Transactions on single servers.
+
+The default maximum idle timeout is **60 seconds** between operations in a
+single Stream Transaction. The maximum value can be bumped up to at most 120
+seconds by setting the startup option `--transaction.streaming-idle-timeout`.
+Posting an operation into a non-expired Stream Transaction will reset the
+transaction's timeout to the configured idle timeout.
+
+Enforcing the limit is useful to free up resources used by abandoned
+transactions, for example from transactions that are abandoned by client
+applications due to programming errors or that were left over because client
+connections were interrupted.


### PR DESCRIPTION
Currently we have mentioned limitations for Stream Transactions in our HTTP documentation, but not in the general "Limitations" section for transactions. 
I think the limitations should be mentioned in both places.
The PR copies the limitations paragraph from the HTTP API into the general space. This is redundant, so it is not ideal. Is there a way to write a paragraph once and use it from multiple places in the docs?