### PR TITLE
Mostly revert #409

### DIFF
--- a/3.4/administration-cluster.md
+++ b/3.4/administration-cluster.md
@@ -14,10 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}
-with full hosting, management, and monitoring.
-
 Please check the following talks as well:
 
 | # | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.4/administration-dc2-dc.md
+++ b/3.4/administration-dc2-dc.md
@@ -5,11 +5,7 @@ title: Administrating DC2DC Replication
 ---
 # Datacenter to datacenter replication administration
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 This section includes information related to the administration of the _datacenter
 to datacenter replication_.

--- a/3.4/administration-managing-users.md
+++ b/3.4/administration-managing-users.md
@@ -292,11 +292,7 @@ database. All changes to the access levels must be done using the
 
 ### LDAP Users
 
-{% hint 'info' %}
-LDAP authentication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="LDAP authentication" %}
 
 ArangoDB supports LDAP as an external authentication system. For detailed
 information please have look into the

--- a/3.4/architecture-deployment-modes-dc2-dc.md
+++ b/3.4/architecture-deployment-modes-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Replication
 ---
 # Datacenter to datacenter replication
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 This chapter introduces ArangoDB's _datacenter to datacenter replication_ (DC2DC).
 

--- a/3.4/deployment-cluster.md
+++ b/3.4/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.4/deployment-cluster.md
+++ b/3.4/deployment-cluster.md
@@ -10,17 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.4/deployment-dc2-dc.md
+++ b/3.4/deployment-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Replication Deployment
 ---
 # Datacenter to datacenter replication deployment
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 This chapter describes how to deploy all the components needed for
 _datacenter to datacenter replication_.

--- a/3.4/deployment-modes.md
+++ b/3.4/deployment-modes.md
@@ -5,11 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Master/Slave](deployment-master-slave.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.4/deployment-technology.md
+++ b/3.4/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.4/deployment-technology.md
+++ b/3.4/deployment-technology.md
@@ -4,12 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.4/deployment.md
+++ b/3.4/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.4/deployment.md
+++ b/3.4/deployment.md
@@ -8,11 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -42,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.4/graphs-smart-graphs.md
+++ b/3.4/graphs-smart-graphs.md
@@ -6,11 +6,7 @@ title: ArangoDB SmartGraphs
 SmartGraphs
 ===========
 
-{% hint 'info' %}
-SmartGraphs are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="SmartGraphs" plural=true %}
 
 This chapter describes the `smart-graph` module, which enables you to manage
 graphs at scale. It will give a vast performance benefit for all graphs sharded

--- a/3.4/monitoring-dc2-dc.md
+++ b/3.4/monitoring-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Replication Monitoring
 ---
 # Monitoring datacenter to datacenter replication
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 This section includes information related to the monitoring of the
 _datacenter to datacenter replication_.

--- a/3.4/programs-arangod-ldap.md
+++ b/3.4/programs-arangod-ldap.md
@@ -5,11 +5,7 @@ title: ArangoDB LDAP Configuration
 ---
 # ArangoDB Server LDAP Options
 
-{% hint 'info' %}
-LDAP authentication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="LDAP authentication" %}
 
 ## Basics Concepts
 

--- a/3.4/programs-arangod-ssl.md
+++ b/3.4/programs-arangod-ssl.md
@@ -114,11 +114,7 @@ Set to true if SSL session caching should be used.
 
 ### SSL peer certificate
 
-{% hint 'info' %}
-This feature is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="This option" %}
 
 `--ssl.require-peer-certificate`
 

--- a/3.4/programs-arangodump-examples.md
+++ b/3.4/programs-arangodump-examples.md
@@ -122,11 +122,7 @@ more details about restoring the collection.
 Encryption
 ----------
 
-{% hint 'info' %}
-Dump encryption is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Dump encryption" %}
 
 Starting from version 3.3 encryption of the dump is supported.
 

--- a/3.4/programs-arangodump-maskings.md
+++ b/3.4/programs-arangodump-maskings.md
@@ -289,11 +289,7 @@ or `.address`.
 Masking Functions
 -----------------
 
-{% hint 'info' %}
-The following masking functions are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="The following masking functions" plural=true %}
 
 - [Xify Front](#xify-front)
 - [Zip](#zip)

--- a/3.4/programs-arangodump-options.md
+++ b/3.4/programs-arangodump-options.md
@@ -14,11 +14,7 @@ Notes
 
 ### Encryption Option Details
 
-{% hint 'info' %}
-Dump encryption is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Dump encryption" %}
  
 *\--encryption.keyfile path-of-keyfile*
 

--- a/3.4/satellites.md
+++ b/3.4/satellites.md
@@ -6,11 +6,7 @@ title: ArangoDB SatelliteCollections
 SatelliteCollections
 ====================
 
-{% hint 'info' %}
-SatelliteCollections are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="SatelliteCollections" plural=true %}
 
 When doing joins in an ArangoDB cluster data has to be exchanged between different servers.
 

--- a/3.4/security-dc2-dc.md
+++ b/3.4/security-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Security
 ---
 # Datacenter to datacenter Security
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 This section includes information related to the _datacenter to datacenter replication_
 security.

--- a/3.4/security-encryption.md
+++ b/3.4/security-encryption.md
@@ -5,11 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% hint 'info' %}
-Encryption at rest is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want
 to protect that data under all circumstances.

--- a/3.4/smartjoins.md
+++ b/3.4/smartjoins.md
@@ -10,11 +10,7 @@ SmartJoins
 
 <small>Introduced in: v3.4.5, v3.5.0</small>
 
-{% hint 'info' %}
-SmartJoins are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="SmartJoins" plural=true %}
 
 SmartJoins allow to execute co-located join operations among identically sharded collections.
 

--- a/3.4/troubleshooting-dc2-dc.md
+++ b/3.4/troubleshooting-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Replication Troubleshooting
 ---
 # Troubleshooting datacenter to datacenter replication
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 The _datacenter to datacenter replication_ is a distributed system with a lot
 different components. As with any such system, it requires some, but not a lot,

--- a/3.4/tutorials-dc2-dc.md
+++ b/3.4/tutorials-dc2-dc.md
@@ -5,11 +5,7 @@ title: DC2DC Replication
 ---
 # Datacenter to datacenter Replication
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 ## About
 

--- a/3.4/tutorials-kubernetes-dc2-dc.md
+++ b/3.4/tutorials-kubernetes-dc2-dc.md
@@ -9,11 +9,7 @@ This tutorial guides you through the steps needed to configure
 an ArangoDB datacenter to datacenter replication between two ArangoDB
 clusters running in Kubernetes.
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 ## Requirements
 

--- a/3.4/tutorials-starter.md
+++ b/3.4/tutorials-starter.md
@@ -17,7 +17,7 @@ ArangoDB deployment.
 
 {% hint 'info %}
 ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
 {% endhint %}
 
 ## Installation
@@ -205,11 +205,7 @@ Note: When you restart the starter, it remembers the original `--starter.local` 
 
 ## Starting a cluster with datacenter to datacenter synchronization
 
-{% hint 'info' %}
-Datacenter to datacenter replication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="Datacenter to datacenter replication" %}
 
 Datacenter to datacenter replication (DC2DC) requires a normal ArangoDB cluster in both data centers
 and one or more (`arangosync`) syncmasters & syncworkers in both data centers.

--- a/3.4/tutorials.md
+++ b/3.4/tutorials.md
@@ -45,9 +45,6 @@ Deployment & Administration
 - [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}:
   Concepts, maintenance, resilience and troubleshooting
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/){:target="_blank"}:
-  Cloud service for cluster deployments of any size
-
 Graphs
 ------
 

--- a/3.5/administration-cluster.md
+++ b/3.5/administration-cluster.md
@@ -14,10 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}
-with full hosting, management, and monitoring.
-
 Please check the following talks as well:
 
 | # | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.5/administration-managing-users.md
+++ b/3.5/administration-managing-users.md
@@ -333,11 +333,7 @@ database. All changes to the access levels must be done using the
 
 ### LDAP Users
 
-{% hint 'info' %}
-LDAP authentication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="LDAP authentication" %}
 
 ArangoDB supports LDAP as an external authentication system. For detailed
 information please have look into the

--- a/3.5/backup-restore.md
+++ b/3.5/backup-restore.md
@@ -78,11 +78,7 @@ Hot backup and restore associated operations can be performed with the
 [_arangobackup_](programs-arangobackup.html) client tool and the
 [Hot Backup HTTP API](http/hot-backup.html).
 
-{% hint 'info' %}
-Arangobackup and the Hot Backup API are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="arangobackup and the Hot Backup API" plural=true %}
 
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.

--- a/3.5/deployment-cluster.md
+++ b/3.5/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.5/deployment-cluster.md
+++ b/3.5/deployment-cluster.md
@@ -10,17 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.5/deployment-modes.md
+++ b/3.5/deployment-modes.md
@@ -5,11 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Master/Slave](deployment-master-slave.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.5/deployment-technology.md
+++ b/3.5/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.5/deployment-technology.md
+++ b/3.5/deployment-technology.md
@@ -4,12 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.5/deployment.md
+++ b/3.5/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.5/deployment.md
+++ b/3.5/deployment.md
@@ -8,11 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -42,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.5/graphs-smart-graphs.md
+++ b/3.5/graphs-smart-graphs.md
@@ -6,11 +6,7 @@ title: ArangoDB SmartGraphs
 SmartGraphs
 ===========
 
-{% hint 'info' %}
-SmartGraphs are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="SmartGraphs" plural=true %}
 
 This chapter describes the `smart-graph` module, which enables you to manage
 graphs at scale. It will give a vast performance benefit for all graphs sharded

--- a/3.5/programs-arangod-ldap.md
+++ b/3.5/programs-arangod-ldap.md
@@ -5,11 +5,7 @@ title: ArangoDB LDAP Configuration
 ---
 # ArangoDB Server LDAP Options
 
-{% hint 'info' %}
-LDAP authentication is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="LDAP authentication" %}
 
 ## Basics Concepts
 

--- a/3.5/programs-arangod-ssl.md
+++ b/3.5/programs-arangod-ssl.md
@@ -115,11 +115,7 @@ Set to true if SSL session caching should be used.
 
 ### SSL peer certificate
 
-{% hint 'info' %}
-This feature is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="This option" %}
 
 `--ssl.require-peer-certificate`
 

--- a/3.5/programs-arangodump-examples.md
+++ b/3.5/programs-arangodump-examples.md
@@ -134,11 +134,7 @@ more details about restoring the collection.
 Encryption
 ----------
 
-{% hint 'info' %}
-Dump encryption is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Dump encryption" %}
 
 Starting from version 3.3 encryption of the dump is supported.
 

--- a/3.5/programs-arangodump-maskings.md
+++ b/3.5/programs-arangodump-maskings.md
@@ -470,11 +470,7 @@ processed by a single masking function, ignoring any other rules below it.
 Masking Functions
 -----------------
 
-{% hint 'info' %}
-The following masking functions are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="The following masking functions" plural=true %}
 
 - [Xify Front](#xify-front)
 - [Zip](#zip)

--- a/3.5/programs-arangodump-options.md
+++ b/3.5/programs-arangodump-options.md
@@ -14,11 +14,7 @@ Notes
 
 ### Encryption Option Details
 
-{% hint 'info' %}
-Dump encryption is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Dump encryption" %}
  
 *\--encryption.keyfile path-of-keyfile*
 

--- a/3.5/satellites.md
+++ b/3.5/satellites.md
@@ -6,11 +6,7 @@ title: ArangoDB SatelliteCollections
 SatelliteCollections
 ====================
 
-{% hint 'info' %}
-SatelliteCollections are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee.md feature="SatelliteCollections" plural=true %}
 
 When doing joins in an ArangoDB cluster data has to be exchanged between different servers.
 

--- a/3.5/security-encryption.md
+++ b/3.5/security-encryption.md
@@ -5,11 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% hint 'info' %}
-Encryption at rest is only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want
 to protect that data under all circumstances.

--- a/3.5/smartjoins.md
+++ b/3.5/smartjoins.md
@@ -10,11 +10,7 @@ SmartJoins
 
 <small>Introduced in: v3.4.5, v3.5.0</small>
 
-{% hint 'info' %}
-SmartJoins are only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
-also available in the [**ArangoDB Cloud**](https://cloud.arangodb.com/){:target="_blank"}.
-{% endhint %}
+{% include hint-ee-oasis.md feature="SmartJoins" plural=true %}
 
 SmartJoins allow to execute co-located join operations among identically sharded collections.
 

--- a/3.5/tutorials.md
+++ b/3.5/tutorials.md
@@ -48,9 +48,6 @@ Deployment & Administration
 - [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}:
   Concepts, maintenance, resilience and troubleshooting
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/){:target="_blank"}:
-  Cloud service for cluster deployments of any size
-
 Graphs
 ------
 

--- a/3.6/administration-cluster.md
+++ b/3.6/administration-cluster.md
@@ -14,12 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}
-with full hosting, management, and monitoring.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Please check the following talks as well:
 
 | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.6/aql/data-queries.md
+++ b/3.6/aql/data-queries.md
@@ -10,10 +10,6 @@ There are two fundamental types of AQL queries:
 - queries which access data (read documents)
 - queries which modify data (create, update, replace, delete documents)
 
-If you want to try out some of below AQL examples in just a few clicks, then
-[start a free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service for ArangoDB.
-
 Data Access Queries
 -------------------
 

--- a/3.6/aql/execution-and-performance.md
+++ b/3.6/aql/execution-and-performance.md
@@ -20,9 +20,3 @@ parts of the plan are responsible. The query-profiler can show you execution sta
 stage of the query execution.
 
 * [The AQL query result cache](execution-and-performance-query-cache.html): an optional query results cache can be used to avoid repeated calculation of the same query results.
-
-Be sure to check out the
-[ArangoDB Performance Course](https://www.arangodb.com/arangodb-performance-course/){:target="_blank"}
-for freshers as well and discover the power of AQL in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start a
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/aql/index.md
+++ b/3.6/aql/index.md
@@ -41,10 +41,6 @@ It is a pure data manipulation language (DML), not a data definition language
 The syntax of AQL queries is different to SQL, even if some keywords overlap.
 Nevertheless, AQL should be easy to understand for anyone with an SQL background.
 
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.
-
 For some example queries, please refer to the chapters
 [Data Queries](data-queries.html),
 [Usual query patterns](examples.html)

--- a/3.6/aql/operations.md
+++ b/3.6/aql/operations.md
@@ -50,7 +50,3 @@ The following high-level operations are described here after:
 
 - [**WITH**](operations-with.html):
   Specify collections used in a query (at query begin only).
-
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.

--- a/3.6/aql/operators.md
+++ b/3.6/aql/operators.md
@@ -379,7 +379,3 @@ The operator precedence in AQL is similar as in other familiar languages
 
 The parentheses `(` and `)` can be used to enforce a different operator
 evaluation order.
-
-Try out AQL in just a few clicks with ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/aql/tutorial-crud.md
+++ b/3.6/aql/tutorial-crud.md
@@ -10,10 +10,6 @@ CRUD
 - [**U**pdate documents](#update-documents)
 - [**D**elete documents](#delete-documents)
 
-You can go through this tutorial in ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Create documents
 ----------------
 

--- a/3.6/aql/tutorial.md
+++ b/3.6/aql/tutorial.md
@@ -17,9 +17,6 @@ of the AQL queries in this tutorial. You can interact with ArangoDB using its
 [web interface](../getting-started-web-interface.html) to manage
 collections and execute the queries.
 
-You can go through this tutorial in ArangoDB Oasis: the Cloud Service for
-ArangoDB. Start a [free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Chapters
 --------
 

--- a/3.6/architecture-deployment-modes-cluster-architecture.md
+++ b/3.6/architecture-deployment-modes-cluster-architecture.md
@@ -690,8 +690,6 @@ chapter for instructions.
 
 ArangoDB is also available as
 [cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
 
 Cluster ID
 ----------

--- a/3.6/architecture-deployment-modes-cluster.md
+++ b/3.6/architecture-deployment-modes-cluster.md
@@ -7,9 +7,6 @@ Cluster
 
 This chapter introduces ArangoDB's Cluster.
 
-Fire up your cluster in just a few clicks with a 14-day free trial of our
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 **Sections:**
 
 - [Cluster Architecture](architecture-deployment-modes-cluster-architecture.html)

--- a/3.6/deployment-cluster.md
+++ b/3.6/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.6/deployment-cluster.md
+++ b/3.6/deployment-cluster.md
@@ -10,18 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the [14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/deployment-modes.md
+++ b/3.6/deployment-modes.md
@@ -5,13 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Master/Slave](deployment-master-slave.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.6/deployment-technology.md
+++ b/3.6/deployment-technology.md
@@ -4,14 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/deployment-technology.md
+++ b/3.6/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.6/deployment.md
+++ b/3.6/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.6/deployment.md
+++ b/3.6/deployment.md
@@ -8,13 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -44,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/getting-started.md
+++ b/3.6/getting-started.md
@@ -13,7 +13,3 @@ We will introduce core concepts and cover how to
 - store example data in the database
 - query the database to retrieve the data again
 - edit and remove existing data
-
-You can also get started with ArangoDB directly in the Cloud in just a few
-clicks. Check out ArangoDB Oasis - the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.6/graphs.md
+++ b/3.6/graphs.md
@@ -31,10 +31,6 @@ Its common to have attributes attached to edges, i.e. a *label* naming this inte
 Edges have a direction, with their relations `_from` and `_to` pointing *from* one document *to* another document stored in vertex collections.
 In queries you can define in which directions the edge relations may be followed (`OUTBOUND`: `_from` → `_to`, `INBOUND`: `_from` ← `_to`, `ANY`: `_from` ↔ `_to`).
 
-Want to see the power of ArangoDB and graphs? Fire up your own ArangoDB in just
-a few clicks with ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Named Graphs
 ------------
 

--- a/3.6/index.md
+++ b/3.6/index.md
@@ -63,10 +63,6 @@ Key features include:
 - ArangoDB can be easily deployed as a [**fault-tolerant distributed state machine**](deployment-standalone-agency.html), which can serve as the animal brain of distributed appliances
 - It is **open source** (Apache License 2.0)
 
-Fire up your own ArangoDB and try it out in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Community
 ---------
  

--- a/3.6/security-encryption.md
+++ b/3.6/security-encryption.md
@@ -5,7 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% include hint-ee-oasis.md feature="Encryption at rest" %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want
 to protect that data under all circumstances.

--- a/3.6/tutorials.md
+++ b/3.6/tutorials.md
@@ -48,9 +48,6 @@ Deployment & Administration
 - [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}:
   Concepts, maintenance, resilience and troubleshooting
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}:
-  Cloud service for cluster deployments of any size
-
 Graphs
 ------
 

--- a/3.7/administration-cluster.md
+++ b/3.7/administration-cluster.md
@@ -14,12 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}
-with full hosting, management, and monitoring.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Please check the following talks as well:
 
 | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.7/aql/data-queries.md
+++ b/3.7/aql/data-queries.md
@@ -10,10 +10,6 @@ There are two fundamental types of AQL queries:
 - queries which access data (read documents)
 - queries which modify data (create, update, replace, delete documents)
 
-If you want to try out some of below AQL examples in just a few clicks, then
-[start a free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service for ArangoDB.
-
 Data Access Queries
 -------------------
 

--- a/3.7/aql/execution-and-performance.md
+++ b/3.7/aql/execution-and-performance.md
@@ -20,9 +20,3 @@ parts of the plan are responsible. The query-profiler can show you execution sta
 stage of the query execution.
 
 * [The AQL query result cache](execution-and-performance-query-cache.html): an optional query results cache can be used to avoid repeated calculation of the same query results.
-
-Be sure to check out the
-[ArangoDB Performance Course](https://www.arangodb.com/arangodb-performance-course/){:target="_blank"}
-for freshers as well and discover the power of AQL in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start a
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/aql/index.md
+++ b/3.7/aql/index.md
@@ -40,10 +40,6 @@ It is a pure data manipulation language (DML), not a data definition language
 The syntax of AQL queries is different to SQL, even if some keywords overlap.
 Nevertheless, AQL should be easy to understand for anyone with an SQL background.
 
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.
-
 For some example queries, please refer to the chapters
 [Data Queries](data-queries.html),
 [Usual query patterns](examples.html)

--- a/3.7/aql/operations.md
+++ b/3.7/aql/operations.md
@@ -50,7 +50,3 @@ The following high-level operations are described here after:
 
 - [**WITH**](operations-with.html):
   Specify collections used in a query (at query begin only).
-
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.

--- a/3.7/aql/operators.md
+++ b/3.7/aql/operators.md
@@ -397,7 +397,3 @@ The operator precedence in AQL is similar as in other familiar languages
 
 The parentheses `(` and `)` can be used to enforce a different operator
 evaluation order.
-
-Try out AQL in just a few clicks with ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/aql/tutorial-crud.md
+++ b/3.7/aql/tutorial-crud.md
@@ -10,10 +10,6 @@ CRUD
 - [**U**pdate documents](#update-documents)
 - [**D**elete documents](#delete-documents)
 
-You can go through this tutorial in ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Create documents
 ----------------
 

--- a/3.7/aql/tutorial.md
+++ b/3.7/aql/tutorial.md
@@ -17,9 +17,6 @@ of the AQL queries in this tutorial. You can interact with ArangoDB using its
 [web interface](../getting-started-web-interface.html) to manage
 collections and execute the queries.
 
-You can go through this tutorial in ArangoDB Oasis: the Cloud Service for
-ArangoDB. Start a [free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Chapters
 --------
 

--- a/3.7/architecture-deployment-modes-cluster-architecture.md
+++ b/3.7/architecture-deployment-modes-cluster-architecture.md
@@ -690,8 +690,6 @@ chapter for instructions.
 
 ArangoDB is also available as
 [cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
 
 Cluster ID
 ----------

--- a/3.7/architecture-deployment-modes-cluster.md
+++ b/3.7/architecture-deployment-modes-cluster.md
@@ -7,9 +7,6 @@ Cluster
 
 This chapter introduces ArangoDB's Cluster.
 
-Fire up your cluster in just a few clicks with a 14-day free trial of our
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 **Sections:**
 
 - [Cluster Architecture](architecture-deployment-modes-cluster-architecture.html)

--- a/3.7/deployment-cluster.md
+++ b/3.7/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.7/deployment-cluster.md
+++ b/3.7/deployment-cluster.md
@@ -10,18 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the [14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/deployment-modes.md
+++ b/3.7/deployment-modes.md
@@ -5,13 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Master/Slave](deployment-master-slave.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.7/deployment-technology.md
+++ b/3.7/deployment-technology.md
@@ -4,14 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/deployment-technology.md
+++ b/3.7/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.7/deployment.md
+++ b/3.7/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.7/deployment.md
+++ b/3.7/deployment.md
@@ -8,13 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -44,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/getting-started.md
+++ b/3.7/getting-started.md
@@ -13,7 +13,3 @@ We will introduce core concepts and cover how to
 - store example data in the database
 - query the database to retrieve the data again
 - edit and remove existing data
-
-You can also get started with ArangoDB directly in the Cloud in just a few
-clicks. Check out ArangoDB Oasis - the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.7/graphs.md
+++ b/3.7/graphs.md
@@ -31,10 +31,6 @@ Its common to have attributes attached to edges, i.e. a *label* naming this inte
 Edges have a direction, with their relations `_from` and `_to` pointing *from* one document *to* another document stored in vertex collections.
 In queries you can define in which directions the edge relations may be followed (`OUTBOUND`: `_from` → `_to`, `INBOUND`: `_from` ← `_to`, `ANY`: `_from` ↔ `_to`).
 
-Want to see the power of ArangoDB and graphs? Fire up your own ArangoDB in just
-a few clicks with ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Named Graphs
 ------------
 

--- a/3.7/index.md
+++ b/3.7/index.md
@@ -60,10 +60,6 @@ Key features include:
 - ArangoDB can be easily deployed as a [**fault-tolerant distributed state machine**](deployment-standalone-agency.html), which can serve as the animal brain of distributed appliances
 - It is **open source** (Apache License 2.0)
 
-Fire up your own ArangoDB and try it out in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 ## Community
 
 If you have questions regarding ArangoDB, Foxx, drivers, or this documentation don't hesitate to contact us on:

--- a/3.7/release-notes-new-features37.md
+++ b/3.7/release-notes-new-features37.md
@@ -202,8 +202,7 @@ This includes (k-)shortest path(s) computation and possibly joins with
 traversals and greatly improves performance for such queries.
 
 [SatelliteGraphs](graphs-satellite-graphs.html)
-are only available in the Enterprise Edition and the
-[ArangoDB Cloud](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic).
+are only available in the Enterprise Edition.
 
 Disjoint SmartGraphs
 --------------------
@@ -216,8 +215,7 @@ restriction allows the query optimizer to improve traversal execution times,
 because in many cases the execution can be pushed down to a single DB-Server.
 
 [Disjoint SmartGraphs](graphs-smart-graphs.html#benefits-of-disjoint-smartgraphs)
-are only available in the Enterprise Edition and the
-[ArangoDB Cloud](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic).
+are only available in the Enterprise Edition.
 
 AQL
 ---

--- a/3.7/security-encryption.md
+++ b/3.7/security-encryption.md
@@ -5,7 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% include hint-ee-oasis.md feature="Encryption at rest" %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL

--- a/3.7/tutorials.md
+++ b/3.7/tutorials.md
@@ -190,10 +190,6 @@ Administration
 
 - [Using The Linux Kernel and Cgroups to Simulate Starvation](https://www.arangodb.com/2019/01/using-the-linux-kernel-and-cgroups-to-simulate-starvation/){:target="_blank"}
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}:
-  Cloud service for cluster deployments of any size. Sign up, then click the
-  help icon in the top right corner and start the tour.
-
 - Oasisctl:
   - [Opening the ArangoDB Oasis API & Terraform Provider](https://www.arangodb.com/2020/03/opening-the-arangodb-oasis-api-terraform-provider/){:target="_blank"}
   - [Getting Started with the Oasis API and Oasisctl](oasis/oasisctl-getting-started.html)

--- a/3.8/administration-cluster.md
+++ b/3.8/administration-cluster.md
@@ -14,12 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}
-with full hosting, management, and monitoring.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Please check the following talks as well:
 
 | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.8/aql/data-queries.md
+++ b/3.8/aql/data-queries.md
@@ -10,10 +10,6 @@ There are two fundamental types of AQL queries:
 - queries which access data (read documents)
 - queries which modify data (create, update, replace, delete documents)
 
-If you want to try out some of below AQL examples in just a few clicks, then
-[start a free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service for ArangoDB.
-
 Data Access Queries
 -------------------
 

--- a/3.8/aql/execution-and-performance.md
+++ b/3.8/aql/execution-and-performance.md
@@ -20,9 +20,3 @@ parts of the plan are responsible. The query-profiler can show you execution sta
 stage of the query execution.
 
 * [The AQL query result cache](execution-and-performance-query-cache.html): an optional query results cache can be used to avoid repeated calculation of the same query results.
-
-Be sure to check out the
-[ArangoDB Performance Course](https://www.arangodb.com/arangodb-performance-course/){:target="_blank"}
-for freshers as well and discover the power of AQL in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start a
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/aql/index.md
+++ b/3.8/aql/index.md
@@ -40,10 +40,6 @@ It is a pure data manipulation language (DML), not a data definition language
 The syntax of AQL queries is different to SQL, even if some keywords overlap.
 Nevertheless, AQL should be easy to understand for anyone with an SQL background.
 
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.
-
 For some example queries, please refer to the chapters
 [Data Queries](data-queries.html),
 [Usual query patterns](examples.html)

--- a/3.8/aql/operations.md
+++ b/3.8/aql/operations.md
@@ -53,7 +53,3 @@ The following high-level operations are described here after:
 
 - [**WITH**](operations-with.html):
   Specify collections used in a query (at query begin only).
-
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.

--- a/3.8/aql/operators.md
+++ b/3.8/aql/operators.md
@@ -397,7 +397,3 @@ The operator precedence in AQL is similar as in other familiar languages
 
 The parentheses `(` and `)` can be used to enforce a different operator
 evaluation order.
-
-Try out AQL in just a few clicks with ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/aql/tutorial-crud.md
+++ b/3.8/aql/tutorial-crud.md
@@ -10,10 +10,6 @@ CRUD
 - [**U**pdate documents](#update-documents)
 - [**D**elete documents](#delete-documents)
 
-You can go through this tutorial in ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Create documents
 ----------------
 

--- a/3.8/aql/tutorial.md
+++ b/3.8/aql/tutorial.md
@@ -17,9 +17,6 @@ of the AQL queries in this tutorial. You can interact with ArangoDB using its
 [web interface](../getting-started-web-interface.html) to manage
 collections and execute the queries.
 
-You can go through this tutorial in ArangoDB Oasis: the Cloud Service for
-ArangoDB. Start a [free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Chapters
 --------
 

--- a/3.8/architecture-deployment-modes-cluster-architecture.md
+++ b/3.8/architecture-deployment-modes-cluster-architecture.md
@@ -689,8 +689,6 @@ chapter for instructions.
 
 ArangoDB is also available as
 [cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
 
 Cluster ID
 ----------

--- a/3.8/architecture-deployment-modes-cluster.md
+++ b/3.8/architecture-deployment-modes-cluster.md
@@ -7,9 +7,6 @@ Cluster
 
 This chapter introduces ArangoDB's Cluster.
 
-Fire up your cluster in just a few clicks with a 14-day free trial of our
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 **Sections:**
 
 - [Cluster Architecture](architecture-deployment-modes-cluster-architecture.html)

--- a/3.8/deployment-cluster.md
+++ b/3.8/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.8/deployment-cluster.md
+++ b/3.8/deployment-cluster.md
@@ -10,18 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the [14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/deployment-modes.md
+++ b/3.8/deployment-modes.md
@@ -5,13 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Leader/Follower](deployment-leader-follower.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.8/deployment-technology.md
+++ b/3.8/deployment-technology.md
@@ -4,14 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/deployment-technology.md
+++ b/3.8/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.8/deployment.md
+++ b/3.8/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.8/deployment.md
+++ b/3.8/deployment.md
@@ -8,13 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -44,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/getting-started.md
+++ b/3.8/getting-started.md
@@ -13,7 +13,3 @@ We will introduce core concepts and cover how to
 - store example data in the database
 - query the database to retrieve the data again
 - edit and remove existing data
-
-You can also get started with ArangoDB directly in the Cloud in just a few
-clicks. Check out ArangoDB Oasis - the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.8/graphs.md
+++ b/3.8/graphs.md
@@ -31,10 +31,6 @@ Its common to have attributes attached to edges, i.e. a *label* naming this inte
 Edges have a direction, with their relations `_from` and `_to` pointing *from* one document *to* another document stored in vertex collections.
 In queries you can define in which directions the edge relations may be followed (`OUTBOUND`: `_from` → `_to`, `INBOUND`: `_from` ← `_to`, `ANY`: `_from` ↔ `_to`).
 
-Want to see the power of ArangoDB and graphs? Fire up your own ArangoDB in just
-a few clicks with ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Named Graphs
 ------------
 

--- a/3.8/index.md
+++ b/3.8/index.md
@@ -60,10 +60,6 @@ Key features include:
 - ArangoDB can be easily deployed as a [**fault-tolerant distributed state machine**](deployment-standalone-agency.html), which can serve as the animal brain of distributed appliances
 - It is **open source** (Apache License 2.0)
 
-Fire up your own ArangoDB and try it out in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 ## Community
 
 If you have questions regarding ArangoDB, Foxx, drivers, or this documentation don't hesitate to contact us on:

--- a/3.8/security-encryption.md
+++ b/3.8/security-encryption.md
@@ -5,7 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% include hint-ee-oasis.md feature="Encryption at rest" %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL

--- a/3.8/tutorials.md
+++ b/3.8/tutorials.md
@@ -190,10 +190,6 @@ Administration
 
 - [Using The Linux Kernel and Cgroups to Simulate Starvation](https://www.arangodb.com/2019/01/using-the-linux-kernel-and-cgroups-to-simulate-starvation/){:target="_blank"}
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}:
-  Cloud service for cluster deployments of any size. Sign up, then click the
-  help icon in the top right corner and start the tour.
-
 - Oasisctl:
   - [Opening the ArangoDB Oasis API & Terraform Provider](https://www.arangodb.com/2020/03/opening-the-arangodb-oasis-api-terraform-provider/){:target="_blank"}
   - [Getting Started with the Oasis API and Oasisctl](oasis/oasisctl-getting-started.html)

--- a/3.9/administration-cluster.md
+++ b/3.9/administration-cluster.md
@@ -14,12 +14,6 @@ There is also a detailed
 [Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
 for download.
 
-Clusters can be easily deployed using the
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}
-with full hosting, management, and monitoring.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Please check the following talks as well:
 
 | Date            | Title                                                                       | Who                                     | Link                                                                                                            |

--- a/3.9/aql/data-queries.md
+++ b/3.9/aql/data-queries.md
@@ -10,10 +10,6 @@ There are two fundamental types of AQL queries:
 - queries which access data (read documents)
 - queries which modify data (create, update, replace, delete documents)
 
-If you want to try out some of below AQL examples in just a few clicks, then
-[start a free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service for ArangoDB.
-
 Data Access Queries
 -------------------
 

--- a/3.9/aql/execution-and-performance.md
+++ b/3.9/aql/execution-and-performance.md
@@ -20,9 +20,3 @@ parts of the plan are responsible. The query-profiler can show you execution sta
 stage of the query execution.
 
 * [The AQL query result cache](execution-and-performance-query-cache.html): an optional query results cache can be used to avoid repeated calculation of the same query results.
-
-Be sure to check out the
-[ArangoDB Performance Course](https://www.arangodb.com/arangodb-performance-course/){:target="_blank"}
-for freshers as well and discover the power of AQL in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start a
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/aql/index.md
+++ b/3.9/aql/index.md
@@ -40,10 +40,6 @@ It is a pure data manipulation language (DML), not a data definition language
 The syntax of AQL queries is different to SQL, even if some keywords overlap.
 Nevertheless, AQL should be easy to understand for anyone with an SQL background.
 
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.
-
 For some example queries, please refer to the chapters
 [Data Queries](data-queries.html),
 [Usual query patterns](examples.html)

--- a/3.9/aql/operations.md
+++ b/3.9/aql/operations.md
@@ -53,7 +53,3 @@ The following high-level operations are described here after:
 
 - [**WITH**](operations-with.html):
   Specify collections used in a query (at query begin only).
-
-To try out the power of AQL in just a few clicks, start a
-[free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}
-for ArangoDB Oasis: the Cloud Service.

--- a/3.9/aql/operators.md
+++ b/3.9/aql/operators.md
@@ -397,7 +397,3 @@ The operator precedence in AQL is similar as in other familiar languages
 
 The parentheses `(` and `)` can be used to enforce a different operator
 evaluation order.
-
-Try out AQL in just a few clicks with ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/aql/tutorial-crud.md
+++ b/3.9/aql/tutorial-crud.md
@@ -10,10 +10,6 @@ CRUD
 - [**U**pdate documents](#update-documents)
 - [**D**elete documents](#delete-documents)
 
-You can go through this tutorial in ArangoDB Oasis:
-the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Create documents
 ----------------
 

--- a/3.9/aql/tutorial.md
+++ b/3.9/aql/tutorial.md
@@ -17,9 +17,6 @@ of the AQL queries in this tutorial. You can interact with ArangoDB using its
 [web interface](../getting-started-web-interface.html) to manage
 collections and execute the queries.
 
-You can go through this tutorial in ArangoDB Oasis: the Cloud Service for
-ArangoDB. Start a [free 14-day trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Chapters
 --------
 

--- a/3.9/architecture-deployment-modes-cluster-architecture.md
+++ b/3.9/architecture-deployment-modes-cluster-architecture.md
@@ -689,8 +689,6 @@ chapter for instructions.
 
 ArangoDB is also available as
 [cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-You can fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
 
 Cluster ID
 ----------

--- a/3.9/architecture-deployment-modes-cluster.md
+++ b/3.9/architecture-deployment-modes-cluster.md
@@ -7,9 +7,6 @@ Cluster
 
 This chapter introduces ArangoDB's Cluster.
 
-Fire up your cluster in just a few clicks with a 14-day free trial of our
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 **Sections:**
 
 - [Cluster Architecture](architecture-deployment-modes-cluster-architecture.html)

--- a/3.9/deployment-cluster.md
+++ b/3.9/deployment-cluster.md
@@ -14,6 +14,5 @@ For a general introduction to the _ArangoDB Cluster_, please refer to the
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.9/deployment-cluster.md
+++ b/3.9/deployment-cluster.md
@@ -10,18 +10,10 @@ This chapter describes how to deploy an _ArangoDB Cluster_.
 For a general introduction to the _ArangoDB Cluster_, please refer to the
 [Cluster](architecture-deployment-modes-cluster.html) chapter.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the [14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Preliminary Information](deployment-cluster-preliminary-information.html)
 - [Using the ArangoDB Starter](deployment-cluster-using-the-starter.html)
 - [Manual Start](deployment-cluster-manual-start.html)
 - [Kubernetes](deployment-cluster-kubernetes.html)
 
-Go through the detailed
-[ArangoDB Cluster Administration Course](https://www.arangodb.com/learn/operations/cluster-course/){:target="_blank"}
-to dig deeper into maintenance, resilience and troubleshooting of your
-distributed environment.
+ArangoDB is also available as
+[cloud service **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/deployment-modes.md
+++ b/3.9/deployment-modes.md
@@ -5,13 +5,6 @@ description: Also see
 Deploying Options by ArangoDB _Deployment Mode_
 ===============================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Single instance](deployment-single-instance.html)
 - [Leader/Follower](deployment-leader-follower.html)
 - [Active Failover](deployment-active-failover.html)

--- a/3.9/deployment-technology.md
+++ b/3.9/deployment-technology.md
@@ -4,14 +4,10 @@ layout: default
 ArangoDB Deploying Options by _Technology_
 ==========================================
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 - [Manually](deployment-manually.html)
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/deployment-technology.md
+++ b/3.9/deployment-technology.md
@@ -8,6 +8,5 @@ ArangoDB Deploying Options by _Technology_
 - [ArangoDB Starter](deployment-arango-dbstarter.html)
 - [Docker](deployment-docker.html)
 - [Kubernetes](deployment-kubernetes.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.9/deployment.md
+++ b/3.9/deployment.md
@@ -37,6 +37,5 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
-
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
+- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"},
+  fully managed, available on AWS, Azure & GCP

--- a/3.9/deployment.md
+++ b/3.9/deployment.md
@@ -8,13 +8,6 @@ Deployment
 
 This chapter describes various possibilities to deploy ArangoDB.
 
-{% hint 'info %}
-ArangoDB is also available as
-[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Fire up your cluster in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.
-{% endhint %}
-
 For installation instructions, please refer to the [Installation](installation.html) _Chapter_.
 
 For _production_ deployments, please also carefully check the
@@ -44,3 +37,6 @@ In the _Cloud_:
 
 - [AWS](deployment-cloud-aws.html)
 - [Azure](deployment-cloud-azure.html)
+
+ArangoDB is also available as
+[cloud service - **ArangoDB Oasis**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/getting-started.md
+++ b/3.9/getting-started.md
@@ -13,7 +13,3 @@ We will introduce core concepts and cover how to
 - store example data in the database
 - query the database to retrieve the data again
 - edit and remove existing data
-
-You can also get started with ArangoDB directly in the Cloud in just a few
-clicks. Check out ArangoDB Oasis - the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.

--- a/3.9/graphs.md
+++ b/3.9/graphs.md
@@ -31,10 +31,6 @@ Its common to have attributes attached to edges, i.e. a *label* naming this inte
 Edges have a direction, with their relations `_from` and `_to` pointing *from* one document *to* another document stored in vertex collections.
 In queries you can define in which directions the edge relations may be followed (`OUTBOUND`: `_from` → `_to`, `INBOUND`: `_from` ← `_to`, `ANY`: `_from` ↔ `_to`).
 
-Want to see the power of ArangoDB and graphs? Fire up your own ArangoDB in just
-a few clicks with ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 Named Graphs
 ------------
 

--- a/3.9/index.md
+++ b/3.9/index.md
@@ -60,10 +60,6 @@ Key features include:
 - ArangoDB can be easily deployed as a [**fault-tolerant distributed state machine**](deployment-standalone-agency.html), which can serve as the animal brain of distributed appliances
 - It is **open source** (Apache License 2.0)
 
-Fire up your own ArangoDB and try it out in just a few clicks with
-ArangoDB Oasis: the Cloud Service for ArangoDB. Start your
-[free 14-day trial here](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=top_pages&utm_campaign=docs_traffic){:target="_blank"}.
-
 ## Community
 
 If you have questions regarding ArangoDB, Foxx, drivers, or this documentation don't hesitate to contact us on:

--- a/3.9/security-encryption.md
+++ b/3.9/security-encryption.md
@@ -5,7 +5,7 @@ title: Encryption at Rest
 ---
 # Encryption at Rest
 
-{% include hint-ee-oasis.md feature="Encryption at rest" %}
+{% include hint-ee-oasis.md feature="Encryption at Rest" %}
 
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL

--- a/3.9/tutorials.md
+++ b/3.9/tutorials.md
@@ -190,10 +190,6 @@ Administration
 
 - [Using The Linux Kernel and Cgroups to Simulate Starvation](https://www.arangodb.com/2019/01/using-the-linux-kernel-and-cgroups-to-simulate-starvation/){:target="_blank"}
 
-- [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=cluster_pages&utm_campaign=docs_traffic){:target="_blank"}:
-  Cloud service for cluster deployments of any size. Sign up, then click the
-  help icon in the top right corner and start the tour.
-
 - Oasisctl:
   - [Opening the ArangoDB Oasis API & Terraform Provider](https://www.arangodb.com/2020/03/opening-the-arangodb-oasis-api-terraform-provider/){:target="_blank"}
   - [Getting Started with the Oasis API and Oasisctl](oasis/oasisctl-getting-started.html)

--- a/README.md
+++ b/README.md
@@ -618,7 +618,8 @@ Useful hint
   - _Agent_, _Agency_ (uppercase A)
   - _Active Failover_
   - _Datacenter to Datacenter Replication_, _DC2DC_
-  - _Oasis_, _ArangoDB Oasis_, _ArangoDB Cloud_
+  - _Oasis_, _ArangoDB Oasis_ (_… the ArangoDB cloud_, but do not use
+    _ArangoDB Cloud_)
 
 - Do not capitalize the names of executables or code values, e.g. write
   _arangosh_ instead of _Arangosh_.

--- a/_includes/hint-ee-oasis.md
+++ b/_includes/hint-ee-oasis.md
@@ -1,7 +1,5 @@
 {% hint 'info' %}
 {{ include.feature }} {% if include.plural %}are{% else %}is{% endif %} only available in the
-[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"}
-and in the [**ArangoDB Cloud**](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=ee_pages&utm_campaign=docs_traffic){:target="_blank"}.
-Take this feature for a spin in just a few clicks with the
-[14-day free trial](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=ee_pages&utm_campaign=docs_traffic){:target="_blank"}. {{ include.extra }}
+[**Enterprise Edition**](https://www.arangodb.com/enterprise-server/){:target="_blank"},
+including [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=ee_pages&utm_campaign=docs_traffic){:target="_blank"}. {{ include.extra }}
 {% endhint %}


### PR DESCRIPTION
Current Enterprise Edition hint wording ([example](https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/security-encryption.html)):

> X is only available in the [**Enterprise Edition**](https://www.arangodb.com/enterprise-server/), including [ArangoDB Oasis](https://cloud.arangodb.com/home?utm_source=docs&utm_medium=ee_pages&utm_campaign=docs_traffic).

I would actually like to remove the mention of Oasis entirely in these EE remarks and advertise it on the Enterprise Server page instead (the _Enterprise Edition_ link). WDYT?

I left the following in (up for discussion):
- https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/tutorials-starter.html (hint box)
- https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/deployment.html (text at bottom)
- https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/deployment-cluster.html (text at bottom)
- https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/deployment-technology.html (text at bottom)
- https://deploy-preview-774--zealous-morse-14392b.netlify.app/docs/3.8/architecture-deployment-modes-cluster-architecture.html#deployment (text near the bottom)