### PR TITLE
RocksDB 6.26

### DIFF
--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -42,4 +42,6 @@ Client tools
 Internal changes
 ----------------
 
+### Upgraded bundled RocksDB library version
 
+The bundled version of the RocksDB library has been upgraded from 6.8 to 6.26.

--- a/3.9/release-notes-new-features39.md
+++ b/3.9/release-notes-new-features39.md
@@ -661,6 +661,8 @@ source.
 The bundled version of the Snappy compression library was upgraded from
 version 1.1.8 to version 1.1.9.
 
+The bundled version of the RocksDB library has been upgraded from 6.8 to 6.26.
+
 The minimum architecture requirements have been raised from the Westmere
 architecture to the Sandy Bridge architecture. 256-bit AVX instructions are
 now expected to be present on all targets that run ArangoDB 3.9 executables.


### PR DESCRIPTION
(in contrast to the branch name, the upgrade is actually to 6.26, not 6.25 - this is due to 6.26 being released after the upgrade branch was created)