### PR TITLE
Add missing description for --server.maximal-threads default value

### DIFF
--- a/3.10/programs-arangod-server.md
+++ b/3.10/programs-arangod-server.md
@@ -385,7 +385,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.6/programs-arangod-server.md
+++ b/3.6/programs-arangod-server.md
@@ -272,7 +272,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.7/programs-arangod-server.md
+++ b/3.7/programs-arangod-server.md
@@ -299,7 +299,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.8/programs-arangod-server.md
+++ b/3.8/programs-arangod-server.md
@@ -374,7 +374,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.9/programs-arangod-server.md
+++ b/3.9/programs-arangod-server.md
@@ -385,7 +385,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 


### PR DESCRIPTION
Apparently an oversight.