### PR TITLE
Single server smart graphs

### DIFF
--- a/3.10/graphs-smart-graphs-management.md
+++ b/3.10/graphs-smart-graphs-management.md
@@ -30,8 +30,8 @@ Everything else works identical in both modules.
 Create a Graph
 --------------
 
-SmartGraphs also require edge relations to be created. The format of the
-relations is identical. The only difference is that all collections used within
+SmartGraphs require edge relations to be created. The format of the
+relations is identical to format used for General Graphs. The only difference is that all collections used within
 the relations to create a new SmartGraph must not exist yet. You have to let
 the SmartGraph module create the Graph collections for you, so that it can
 enforce the correct sharding.
@@ -51,7 +51,8 @@ enforce the correct sharding.
     the correct sharding all collections need an identical number of shards.
     This cannot be modified after creation of the graph.
   - `smartGraphAttribute` (string):
-    The attribute that will be used for sharding. All vertices are required to
+    The attribute that will be used for sharding: vertices with the same value of this attribute will be in the same 
+    shard. All vertices are required to
     have this attribute set and it has to be a string. Edges derive the
     attribute from their connected vertices.
   - `isDisjoint` (bool, optional):
@@ -72,7 +73,9 @@ known from the `general-graph` module, which is also available here.
 
 `orphanCollections` again is just a list of additional vertex collections which
 are not yet connected via edges but should follow the same sharding to be
-connected later on.
+connected later on. Note that these collections are not necessarily orphans in 
+the graph theoretic sense: it is possible to add edges having one end in a collection
+that has been declared as orphan. 
 
 All collections used within the creation process are newly created.
 The process will fail if one of them already exists, unless they have the
@@ -132,12 +135,12 @@ Modify a graph definition at runtime
 After you have created a SmartGraph its definition is not immutable. You can
 still add or remove relations. This is again identical to General Graphs.
 
-However there is one important difference: You can only add collections that
+However there is one important difference: you can only add collections that
 either *do not exist*, or that have been created by this graph earlier. The
-latter can be achieved if you for example remove an orphan collection from this
-graph, without dropping the collection itself. Than after some time you decide
-to add it again, it can be used. This is because the enforced sharding is still
-applied to this vertex collection, hence it is suitable to be added again.
+latter can be the case if you, for example, remove an orphan collection from this
+graph, without dropping the collection itself. When after some time you decide
+to add it to the graph again, you can do it. This is because the enforced sharding is still
+applied to this vertex collection.
 
 ### Remove a vertex collection
 
@@ -148,14 +151,14 @@ Remove a vertex collection from the graph:
 - `vertexCollectionName` (string):
   Name of vertex collection.
 - `dropCollection` (bool, _optional_):
-  If true the collection will be dropped if it is not used in any other graph.
+  If true, the collection will be dropped if it is not used in any other graph.
   Default: false.
 
 In most cases this function works identically to the General Graph one.
-But there is one special case: The first vertex collection added to the graph
+However there is one special case: The first vertex collection added to the graph
 (either orphan or within a relation) defines the sharding for all collections
-within the graph. They have their `distributeShardsLike` attribute set to the
-name of the initial collection. This collection can not be dropped as long as
+within the graph. Every other collection has its `distributeShardsLike` attribute set to the
+name of the initial collection. This collection cannot be dropped as long as
 other collections follow its sharding (i.e. they need to be dropped first).
 
 **Examples**
@@ -228,8 +231,8 @@ sharding for other collections (`edges`).
 
 You may drop the complete graph, but remember to drop collections that you
 might have removed from the graph beforehand, as they will not be part of the
-graph definition anymore and thus not be dropped for you. Alternatively, you
-can `truncate` the graph if you just want to get rid of the data.
+graph definition anymore and thus not be dropped automatically. Alternatively, you
+can `truncate` all collections from the graph if you just want to get rid of the data.
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline smartGraphModify5_cluster
@@ -277,7 +280,7 @@ Create a SmartGraph, then delete the edge definition and drop the edge collectio
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
 
-It is allowed to remove the vertex collection `vertices` if it's not used in
+It is allowed to remove the vertex collection `vertices` if it is not used in
 any relation (i.e. after the deletion of the edge definition):
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
@@ -296,7 +299,7 @@ any relation (i.e. after the deletion of the edge definition):
 {% endarangoshexample %}
 {% include arangoshexample.html id=examplevar script=script result=result %}
 
-Keep in mind that you can not drop the `vertices` collection until no other
+Keep in mind that you cannot drop the `vertices` collection until no other
 collection references it anymore (`distributeShardsLike` collection property).
 
 ### Remove a Graph

--- a/3.10/graphs-smart-graphs.md
+++ b/3.10/graphs-smart-graphs.md
@@ -12,7 +12,7 @@ This chapter describes the `smart-graph` module, which enables you to manage
 graphs at scale. It will give a vast performance benefit for all graphs sharded
 in an ArangoDB Cluster. On a single server this feature is pointless, however, it is possible to 
 create a SmartGraph also on a single server for testing and then to port it to a cluster, see 
-[SmartGraphs and SatelliteGraphs on a Single Server](LINK TO THE NEW DOCUMENT TODO).
+[SmartGraphs and SatelliteGraphs on a Single Server](smart-and-satellite-graphs-single-server.html).
 
 In terms of querying there is no difference between SmartGraphs and
 General Graphs. The former is a transparent replacement for the latter.

--- a/3.10/programs-arangorestore-examples.md
+++ b/3.10/programs-arangorestore-examples.md
@@ -137,12 +137,12 @@ It can be specified multiple times if required:
 
     arangorestore --collection myusers --collection myvalues --input-directory "dump"
 
-Collections will be processed by in alphabetical order by _arangorestore_, with all document
+Collections will be processed in alphabetical order by _arangorestore_, with all document
 collections being processed before all [edge collections](appendix-glossary.html#edge-collection).
 This remains valid also when multiple threads are in use (from v3.4.0 on).
 
 Note however that when restoring an edge collection no internal checks are made in order to validate that
-the documents that the edges connect exist or not. As a consequence, when restoring individual collections
+the documents that the edges connect exist. As a consequence, when restoring individual collections
 which are part of a graph you are not required to restore in a specific order. 
 
 {% hint 'warning' %}

--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -1,5 +1,6 @@
 ---
-layout: default description: ArangoDB v3.10 Release Notes New Features
+layout: default 
+description: ArangoDB v3.10 Release Notes New Features
 ---
 Features and Improvements in ArangoDB 3.10
 ==========================================

--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -1,13 +1,11 @@
 ---
-layout: default
-description: ArangoDB v3.10 Release Notes New Features
+layout: default description: ArangoDB v3.10 Release Notes New Features
 ---
 Features and Improvements in ArangoDB 3.10
 ==========================================
 
-The following list shows in detail which features have been added or improved in
-ArangoDB 3.10. ArangoDB 3.10 also contains several bug fixes that are not listed
-here.
+The following list shows in detail which features have been added or improved in ArangoDB 3.10. ArangoDB 3.10 also
+contains several bug fixes that are not listed here.
 
 ArangoSearch
 ------------
@@ -42,4 +40,15 @@ Client tools
 Internal changes
 ----------------
 
+### SmartGraphs and SatelliteGraphs on a single server
 
+Now it is possible to test [SmartGraphs](graphs-smart-graphs.html) and
+[SatelliteGraphs](graphs-satellite-graphs.html) on a single server and then to port them to a cluster with multiple
+servers. All existing types of SmartGraphs are eligible to this procedure: [SmartGraphs](graphs-smart-graphs.html)
+themselves, Disjoint SmartGraphs, [Hybrid SmartGraphs](graphs-smart-graphs.html#benefits-of-hybrid-smartgraphs) and
+[Hybrid Disjoint SmartGraphs](graphs-smart-graphs.html#benefits-of-hybrid-disjoint-smartgraphs). One can create a graph
+of any of those types in the usual way, e.g., using `arangosh`, but on a single server, then dump it, start a cluster
+(with multiple servers) and restore the graph in the cluster. The graph and the collections will keep all properties
+that are kept when the graph is already created in a cluster.
+
+This feature is only available in the Enterprise Edition.

--- a/3.10/smart-and-satellite-graphs-single-server.md
+++ b/3.10/smart-and-satellite-graphs-single-server.md
@@ -1,0 +1,32 @@
+---
+layout: default 
+description: Test SmartGraphs and SatelliteGraphs on a single server, port them to an ArangoDB Cluster  
+title: SmartGraphs and SatelliteGraphs on a Single Server
+---
+
+# General Idea
+
+Simulate a SmartGraph or a SatelliteGraph on a single server and then to port it to an ArangoDB
+Cluster
+{:class="lead"}
+
+The graphs are created in a single server instance and tested there. Internally, the graphs are, basically, General
+Graphs supplemented by formal properties as `isSmart` that, however, play no role in the behavior of the graphs. The
+same is true for vertex and edge collections: they have the corresponding properties, which are non-functional.
+
+After a test phase such a graph can be dumped and then restored in a cluster instance. The graph itself and the vertex
+and edge collections obtain now true SmartGraph or SatelliteGraph sharding properties as if they had been created in the
+cluster.
+
+# The Procedure
+
+[SmartGraphs](graphs-smart-graphs-management.html) or [SatelliteGraphs](graphs-satellite-graphs-management.html)
+graphs can be created in the usual way, e.g., using `arangosh`, just on a single server. Although not on a cluster, all
+cluster relevant properties of graphs and collections can be set: `numberOfShards`, `isSmart`,
+`isSatellite`, `replicationFactor`, `smartGraphAttribute`, `satellites` and `shardingStrategy`. Then the
+graphs are [dumped](programs-arangodump-examples.html) with `arangodump`, again in the usual way.
+
+Now a running instance of ArangoDB Cluster is used and the dumped data
+are [restored](programs-arangorestore-examples.html) into this instance. All cluster relevant properties are restored
+correctly and affect now the sharding and the performance.
+

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ algolia:
   index_name: dev_DOCS
   search_only_api_key: 1fc63d8ff5b71963f0354561b770b591
   files_to_exclude:
-    - 3.10/**/*
+#    - 3.10/**/*
     - 3.9/**/*
 #   - 3.8/**/*  # OUR STABLE VERSION
     - 3.7/**/*
@@ -87,7 +87,7 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
-  - 3.10/generated
+#  - 3.10/generated
   - 3.9/generated
   - 3.8/generated
   - 3.7/generated

--- a/_data/3.10-manual.yml
+++ b/_data/3.10-manual.yml
@@ -361,6 +361,8 @@
       children:
         - text: SmartGraph Management
           href: graphs-smart-graphs-management.html
+    - text: Testing Graphs on Single Server
+      href: smart-and-satellite-graphs-single-server.html
     - text: Traversals
       href: graphs-traversals.html
       children:


### PR DESCRIPTION
A new subsection "Testing Graphs on Single Server" within the "Graphs" is created. It describes the new feature of creating SmartGraphs (of different kinds: also Disjoint, Hybrid ans HybridDisjoint) and SatelliteGraphs on a single server instead of on a cluster. The graphs can be created with all properties related to sharding, however the properties do not affect anything. Then the graphs can be dumped and restored in a cluster with all sharding properties, which become functional now.

This is  3.10 feature which doesn't appear in earlier versions.

Also in related documents (about smart graphs and satellite graphs) minor changes and some reformulations of the existing text are made.