### PR TITLE
remove usages of "skiplist"

### DIFF
--- a/3.10/administration-cluster.md
+++ b/3.10/administration-cluster.md
@@ -122,9 +122,8 @@ for a new document, but must let the server generated one automatically. This
 restriction comes from the fact that ensuring uniqueness of the primary key
 would be very inefficient if the user could specify the document key.
 
-Unique indexes (hash, skiplist, persistent) on sharded collections are
-only allowed if the fields used to determine the shard key are also
-included in the list of attribute paths for the index:
+Unique indexes on sharded collections are only allowed if the fields used to 
+determine the shard key are also included in the list of attribute paths for the index:
 
 | shardKeys | indexKeys |             |
 |----------:|----------:|------------:|

--- a/3.10/appendix-glossary.md
+++ b/3.10/appendix-glossary.md
@@ -167,10 +167,10 @@ Most user-land indexes can be created by defining the names of the attributes wh
 
 Indexing the system attribute `_id` in user-defined indexes is not supported by any index type.
 
-Edges Index
+Edge Index
 -----------
 
-An edges index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edges indexes.
+An edge index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edge indexes.
 
 Fulltext Index
 --------------
@@ -197,21 +197,23 @@ Index Handle
 
 An index handle uniquely identifies an index in the database. It is a string and consists of a collection name and an index identifier separated by /.
 
+Persistent Index
+----------------
+
+A persistent index is a sorted index type that can be used to find individual documents by a lookup value,
+or multiple documents in a given lookup value range. It can also be used for retrieving documents in a
+sorted order.
+
 Hash Index
 ----------
 
-A hash index is used to find documents based on examples. A hash index can be created for one or multiple document attributes.
+A hash index is now an alias for a persistent index.
 
-A hash index will only be used by queries if all indexed attributes are present in the example or search query, and if all attributes are compared using the equality (== operator). That means the hash index does not support range queries.
-
-A unique hash index has an amortized complexity of O(1) for lookup, insert, update, and remove operations.
-The non-unique hash index is similar, but amortized lookup performance is O(n), with n being the number of
-index entries with the same lookup value.
 
 Skiplist Index
 --------------
 
-A skiplist is a sorted index type that can be used to find ranges of documents.
+A skiplist index is now an alias for a persistent index.
 
 
 Anonymous Graphs

--- a/3.10/aql/examples-actors-and-movies.md
+++ b/3.10/aql/examples-actors-and-movies.md
@@ -720,11 +720,11 @@ db._query(`
 ### The number of movies acted in between two years by actor
 
 This query is where a multi-model database actually shines.
-First of all we want to use it in production, so we set a skiplist index on year.
+First of all we want to use it in production, so we set a persistent index on year.
 This allows as to execute fast range queries like between 1990 and 1995.
 
 ```js
-db.actsIn.ensureIndex({ type: "skiplist", fields: ["year"] });
+db.actsIn.ensureIndex({ type: "persistent", fields: ["year"] });
 ```
 
 Now we slightly modify our movies by actor query.

--- a/3.10/aql/execution-and-performance-optimizer.md
+++ b/3.10/aql/execution-and-performance-optimizer.md
@@ -39,7 +39,7 @@ You may use it like this: (we disable syntax highlighting here)
     ~db._drop("test");
     db._create("test");
     for (i = 0; i < 100; ++i) { db.test.save({ value: i }); }
-    db.test.ensureIndex({ type: "skiplist", fields: [ "value" ] });
+    db.test.ensureIndex({ type: "persistent", fields: [ "value" ] });
     var explain = require("@arangodb/aql/explainer").explain;
     explain("FOR i IN test FILTER i.value > 97 SORT i.value RETURN i.value", {colors:false});
     @END_EXAMPLE_ARANGOSH_OUTPUT
@@ -116,7 +116,7 @@ Here is a summary:
 #### Optimizer rules
 
 Note that in the example, the optimizer has optimized the `SORT` statement away.
-It can do it safely because there is a sorted skiplist index on `i.value`, which it has
+It can do it safely because there is a sorted persistent index on `i.value`, which it has
 picked in the *IndexNode*. As the index values are iterated over in sorted order
 anyway, the extra *SortNode* would have been redundant and was removed.
 
@@ -807,7 +807,7 @@ from the document, and only if the rest of the document data is not used later
 on in the query.
 
 The optimization is currently available for the RocksDB engine for the index types
-primary, edge, hash, skiplist and persistent.
+primary, edge, persistent (and its aliases hash and skiplist).
 
 If the optimization is applied, it will show up as "index only" in an AQL
 query's execution plan for an *IndexNode*.

--- a/3.10/aql/execution-and-performance-query-profiler.md
+++ b/3.10/aql/execution-and-performance-query-profiler.md
@@ -72,17 +72,17 @@ internal batch size of 1000 these blocks were also called 100 times each.
 The _FilterNode_ as well as the _ReturnNode_ however only ever returned 10 rows
 and only had to be called once, because the result size fits within a single batch.
 
-Let us add a skiplist index on `value` to speed up the query:
+Let us add a persistent index on `value` to speed up the query:
 
 ```js
-db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ```
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
 @startDocuBlockInline 02_workWithAQL_profileQuerySimpleIndex
 @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_profileQuerySimpleIndex}
 ~db._create('acollection');
-~db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+~db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ~for (let i=0; i < 10000; i++) { db.acollection.insert({value:i}); }
 |db._profileQuery(`
 |FOR doc IN acollection
@@ -109,7 +109,7 @@ Let us consider a query containing a subquery:
 @startDocuBlockInline 03_workWithAQL_profileQuerySubquery
 @EXAMPLE_ARANGOSH_OUTPUT{03_workWithAQL_profileQuerySubquery}
 ~db._create('acollection');
-~db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+~db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ~for (let i=0; i < 10000;i++) { db.acollection.insert({value:i}); }
 |db._profileQuery(`
 |LET list = (FOR doc in acollection FILTER doc.value > 90 RETURN doc)

--- a/3.10/arangosearch-performance.md
+++ b/3.10/arangosearch-performance.md
@@ -97,7 +97,7 @@ The optimization can be applied to View queries which sort by both fields as
 defined (`SORT doc.date DESC, doc.name`), but also if they sort in descending
 order by the `date` attribute only (`SORT doc.date DESC`). Queries which sort
 by `text` alone (`SORT doc.name`) are not eligible, because the View is sorted
-by `date` first. This is similar to skiplist indexes, but inverted sorting
+by `date` first. This is similar to persistent indexes, but inverted sorting
 directions are not covered by the View index
 (e.g. `SORT doc.date, doc.name DESC`).
 

--- a/3.10/architecture-deployment-modes-cluster-sharding.md
+++ b/3.10/architecture-deployment-modes-cluster-sharding.md
@@ -151,9 +151,8 @@ a look in the [Cluster Administration](administration-cluster.html) section.
 
 ### Indexes On Shards
 
-Unique indexes (hash, skiplist, persistent) on sharded collections are only
-allowed if the fields used to determine the shard key are also included in the
-list of attribute paths for the index:
+Unique indexes on sharded collections are only allowed if the fields used to 
+determine the shard key are also included in the list of attribute paths for the index:
 
 | shardKeys | indexKeys |             |
 |----------:|----------:|------------:|

--- a/3.10/http/indexes-skiplist.md
+++ b/3.10/http/indexes-skiplist.md
@@ -5,7 +5,7 @@ description: Working with Skiplist Indexes
 Working with Skiplist Indexes
 =============================
 
-If a suitable skip-list index exists, then `/_api/simple/range` and other operations
+If a suitable skiplist index exists, then `/_api/simple/range` and other operations
 will use this index to execute queries.
 
 <!-- js/actions/api-index.js -->

--- a/3.10/http/indexes.md
+++ b/3.10/http/indexes.md
@@ -36,18 +36,18 @@ There is no way to explicitly create or delete primary indexes.
 An edge index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edge indexes.
 The edge index is non-unique.
 
-### Hash Index
-
-A hash index is an unsorted index that can be used to find individual documents by equality lookups.
-
-### Skiplist Index
-
-A skiplist is a sorted index that can be used to find individual documents or ranges of documents.
-
 ### Persistent Index
 
 A persistent index is a sorted index that can be used for finding individual documents or ranges of documents.
 In contrast to the other indexes, the contents of a persistent index are stored on disk and thus do not need to be rebuilt in memory from the documents when the collection is loaded.
+
+### Hash Index
+
+A hash index is now an alias for a persistent index.
+
+### Skiplist Index
+
+A skiplist index is now an alias for a persistent index.
 
 ### TTL (time-to-live) index
 

--- a/3.10/http/replications-walaccess.md
+++ b/3.10/http/replications-walaccess.md
@@ -168,7 +168,7 @@ definition.
     "id": "260",
     "selectivityEstimate": 1,
     "sparse": false,
-    "type": "skiplist",
+    "type": "persistent",
     "unique": false
   }
 }

--- a/3.10/indexing-working-with-indexes.md
+++ b/3.10/indexing-working-with-indexes.md
@@ -286,7 +286,7 @@ You can use explain to verify that a certain index is used:
     @EXAMPLE_ARANGOSH_OUTPUT{IndexVerify}
     ~db._create("example");
     var explain = require("@arangodb/aql/explainer").explain;
-    db.example.ensureIndex({ type: "skiplist", fields: [ "a", "b" ] });
+    db.example.ensureIndex({ type: "persistent", fields: [ "a", "b" ] });
     explain("FOR doc IN example FILTER doc.a < 23 RETURN doc", {colors: false});
     ~db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT

--- a/3.10/security-auditing-audit-events.md
+++ b/3.10/security-auditing-audit-events.md
@@ -133,16 +133,16 @@ successful, the status will read `ok`, otherwise `failed`.
 Indexes
 -------
 
-### Create a index
+### Create an index
 
 ```
-2016-10-05 18:19:40 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52467 | http basic | create index in 'collection1' | ok | {"fields":["a"],"sparse":false,"type":"skiplist","unique":false} | /_api/index?collection=collection1
+2016-10-05 18:19:40 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52467 | http basic | create index in 'collection1' | ok | {"fields":["a"],"sparse":false,"type":"persistent","unique":false} | /_api/index?collection=collection1
 ```
 
 This message will occur whenever a user attempts to create an index. If
 successful, the status will read `ok`, otherwise `failed`.
 
-### Drop a index
+### Drop an index
 
 ```
 2016-10-05 18:18:28 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52464 | http basic | drop index 'collection1/44051' | ok | /_api/index/collection1/44051

--- a/3.9/administration-cluster.md
+++ b/3.9/administration-cluster.md
@@ -122,9 +122,8 @@ for a new document, but must let the server generated one automatically. This
 restriction comes from the fact that ensuring uniqueness of the primary key
 would be very inefficient if the user could specify the document key.
 
-Unique indexes (hash, skiplist, persistent) on sharded collections are
-only allowed if the fields used to determine the shard key are also
-included in the list of attribute paths for the index:
+Unique indexes on sharded collections are only allowed if the fields used to 
+determine the shard key are also included in the list of attribute paths for the index:
 
 | shardKeys | indexKeys |             |
 |----------:|----------:|------------:|

--- a/3.9/appendix-glossary.md
+++ b/3.9/appendix-glossary.md
@@ -167,10 +167,10 @@ Most user-land indexes can be created by defining the names of the attributes wh
 
 Indexing the system attribute `_id` in user-defined indexes is not supported by any index type.
 
-Edges Index
+Edge Index
 -----------
 
-An edges index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edges indexes.
+An edge index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edge indexes.
 
 Fulltext Index
 --------------
@@ -197,21 +197,23 @@ Index Handle
 
 An index handle uniquely identifies an index in the database. It is a string and consists of a collection name and an index identifier separated by /.
 
+Persistent Index
+----------------
+
+A persistent index is a sorted index type that can be used to find individual documents by a lookup value,
+or multiple documents in a given lookup value range. It can also be used for retrieving documents in a
+sorted order.
+
 Hash Index
 ----------
 
-A hash index is used to find documents based on examples. A hash index can be created for one or multiple document attributes.
+A hash index is now an alias for a persistent index.
 
-A hash index will only be used by queries if all indexed attributes are present in the example or search query, and if all attributes are compared using the equality (== operator). That means the hash index does not support range queries.
-
-A unique hash index has an amortized complexity of O(1) for lookup, insert, update, and remove operations.
-The non-unique hash index is similar, but amortized lookup performance is O(n), with n being the number of
-index entries with the same lookup value.
 
 Skiplist Index
 --------------
 
-A skiplist is a sorted index type that can be used to find ranges of documents.
+A skiplist index is now an alias for a persistent index.
 
 
 Anonymous Graphs

--- a/3.9/aql/examples-actors-and-movies.md
+++ b/3.9/aql/examples-actors-and-movies.md
@@ -720,11 +720,11 @@ db._query(`
 ### The number of movies acted in between two years by actor
 
 This query is where a multi-model database actually shines.
-First of all we want to use it in production, so we set a skiplist index on year.
+First of all we want to use it in production, so we set a persistent index on year.
 This allows as to execute fast range queries like between 1990 and 1995.
 
 ```js
-db.actsIn.ensureIndex({ type: "skiplist", fields: ["year"] });
+db.actsIn.ensureIndex({ type: "persistent", fields: ["year"] });
 ```
 
 Now we slightly modify our movies by actor query.

--- a/3.9/aql/execution-and-performance-optimizer.md
+++ b/3.9/aql/execution-and-performance-optimizer.md
@@ -39,7 +39,7 @@ You may use it like this: (we disable syntax highlighting here)
     ~db._drop("test");
     db._create("test");
     for (i = 0; i < 100; ++i) { db.test.save({ value: i }); }
-    db.test.ensureIndex({ type: "skiplist", fields: [ "value" ] });
+    db.test.ensureIndex({ type: "persistent", fields: [ "value" ] });
     var explain = require("@arangodb/aql/explainer").explain;
     explain("FOR i IN test FILTER i.value > 97 SORT i.value RETURN i.value", {colors:false});
     @END_EXAMPLE_ARANGOSH_OUTPUT
@@ -116,7 +116,7 @@ Here is a summary:
 #### Optimizer rules
 
 Note that in the example, the optimizer has optimized the `SORT` statement away.
-It can do it safely because there is a sorted skiplist index on `i.value`, which it has
+It can do it safely because there is a sorted persistent index on `i.value`, which it has
 picked in the *IndexNode*. As the index values are iterated over in sorted order
 anyway, the extra *SortNode* would have been redundant and was removed.
 
@@ -807,7 +807,7 @@ from the document, and only if the rest of the document data is not used later
 on in the query.
 
 The optimization is currently available for the RocksDB engine for the index types
-primary, edge, hash, skiplist and persistent.
+primary, edge, persistent (and its aliases hash and skiplist).
 
 If the optimization is applied, it will show up as "index only" in an AQL
 query's execution plan for an *IndexNode*.

--- a/3.9/aql/execution-and-performance-query-profiler.md
+++ b/3.9/aql/execution-and-performance-query-profiler.md
@@ -72,17 +72,17 @@ internal batch size of 1000 these blocks were also called 100 times each.
 The _FilterNode_ as well as the _ReturnNode_ however only ever returned 10 rows
 and only had to be called once, because the result size fits within a single batch.
 
-Let us add a skiplist index on `value` to speed up the query:
+Let us add a persistent index on `value` to speed up the query:
 
 ```js
-db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ```
 
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
 @startDocuBlockInline 02_workWithAQL_profileQuerySimpleIndex
 @EXAMPLE_ARANGOSH_OUTPUT{02_workWithAQL_profileQuerySimpleIndex}
 ~db._create('acollection');
-~db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+~db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ~for (let i=0; i < 10000; i++) { db.acollection.insert({value:i}); }
 |db._profileQuery(`
 |FOR doc IN acollection
@@ -109,7 +109,7 @@ Let us consider a query containing a subquery:
 @startDocuBlockInline 03_workWithAQL_profileQuerySubquery
 @EXAMPLE_ARANGOSH_OUTPUT{03_workWithAQL_profileQuerySubquery}
 ~db._create('acollection');
-~db.acollection.ensureIndex({type:"skiplist", fields:["value"]});
+~db.acollection.ensureIndex({type:"persistent", fields:["value"]});
 ~for (let i=0; i < 10000;i++) { db.acollection.insert({value:i}); }
 |db._profileQuery(`
 |LET list = (FOR doc in acollection FILTER doc.value > 90 RETURN doc)

--- a/3.9/arangosearch-performance.md
+++ b/3.9/arangosearch-performance.md
@@ -97,7 +97,7 @@ The optimization can be applied to View queries which sort by both fields as
 defined (`SORT doc.date DESC, doc.name`), but also if they sort in descending
 order by the `date` attribute only (`SORT doc.date DESC`). Queries which sort
 by `text` alone (`SORT doc.name`) are not eligible, because the View is sorted
-by `date` first. This is similar to skiplist indexes, but inverted sorting
+by `date` first. This is similar to persistent indexes, but inverted sorting
 directions are not covered by the View index
 (e.g. `SORT doc.date, doc.name DESC`).
 

--- a/3.9/architecture-deployment-modes-cluster-sharding.md
+++ b/3.9/architecture-deployment-modes-cluster-sharding.md
@@ -151,9 +151,8 @@ a look in the [Cluster Administration](administration-cluster.html) section.
 
 ### Indexes On Shards
 
-Unique indexes (hash, skiplist, persistent) on sharded collections are only
-allowed if the fields used to determine the shard key are also included in the
-list of attribute paths for the index:
+Unique indexes on sharded collections are only allowed if the fields used to 
+determine the shard key are also included in the list of attribute paths for the index:
 
 | shardKeys | indexKeys |             |
 |----------:|----------:|------------:|

--- a/3.9/http/indexes-skiplist.md
+++ b/3.9/http/indexes-skiplist.md
@@ -5,7 +5,7 @@ description: Working with Skiplist Indexes
 Working with Skiplist Indexes
 =============================
 
-If a suitable skip-list index exists, then `/_api/simple/range` and other operations
+If a suitable skiplist index exists, then `/_api/simple/range` and other operations
 will use this index to execute queries.
 
 <!-- js/actions/api-index.js -->

--- a/3.9/http/indexes.md
+++ b/3.9/http/indexes.md
@@ -36,18 +36,18 @@ There is no way to explicitly create or delete primary indexes.
 An edge index is automatically created for edge collections. It contains connections between vertex documents and is invoked when the connecting edges of a vertex are queried. There is no way to explicitly create or delete edge indexes.
 The edge index is non-unique.
 
-### Hash Index
-
-A hash index is an unsorted index that can be used to find individual documents by equality lookups.
-
-### Skiplist Index
-
-A skiplist is a sorted index that can be used to find individual documents or ranges of documents.
-
 ### Persistent Index
 
 A persistent index is a sorted index that can be used for finding individual documents or ranges of documents.
 In contrast to the other indexes, the contents of a persistent index are stored on disk and thus do not need to be rebuilt in memory from the documents when the collection is loaded.
+
+### Hash Index
+
+A hash index is now an alias for a persistent index.
+
+### Skiplist Index
+
+A skiplist index is now an alias for a persistent index.
 
 ### TTL (time-to-live) index
 

--- a/3.9/http/replications-walaccess.md
+++ b/3.9/http/replications-walaccess.md
@@ -168,7 +168,7 @@ definition.
     "id": "260",
     "selectivityEstimate": 1,
     "sparse": false,
-    "type": "skiplist",
+    "type": "persistent",
     "unique": false
   }
 }

--- a/3.9/indexing-working-with-indexes.md
+++ b/3.9/indexing-working-with-indexes.md
@@ -286,7 +286,7 @@ You can use explain to verify that a certain index is used:
     @EXAMPLE_ARANGOSH_OUTPUT{IndexVerify}
     ~db._create("example");
     var explain = require("@arangodb/aql/explainer").explain;
-    db.example.ensureIndex({ type: "skiplist", fields: [ "a", "b" ] });
+    db.example.ensureIndex({ type: "persistent", fields: [ "a", "b" ] });
     explain("FOR doc IN example FILTER doc.a < 23 RETURN doc", {colors: false});
     ~db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT

--- a/3.9/security-auditing-audit-events.md
+++ b/3.9/security-auditing-audit-events.md
@@ -133,16 +133,16 @@ successful, the status will read `ok`, otherwise `failed`.
 Indexes
 -------
 
-### Create a index
+### Create an index
 
 ```
-2016-10-05 18:19:40 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52467 | http basic | create index in 'collection1' | ok | {"fields":["a"],"sparse":false,"type":"skiplist","unique":false} | /_api/index?collection=collection1
+2016-10-05 18:19:40 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52467 | http basic | create index in 'collection1' | ok | {"fields":["a"],"sparse":false,"type":"persistent","unique":false} | /_api/index?collection=collection1
 ```
 
 This message will occur whenever a user attempts to create an index. If
 successful, the status will read `ok`, otherwise `failed`.
 
-### Drop a index
+### Drop an index
 
 ```
 2016-10-05 18:18:28 | server1 | audit-collection | user1 | database1 | 127.0.0.1:52464 | http basic | drop index 'collection1/44051' | ok | /_api/index/collection1/44051


### PR DESCRIPTION
in the RocksDB engine, a skiplist index is the same as a persistent
index. it is just an alias and there for compatibility reasons. we
should discourage the usage of "skiplist" indexes and instead use and
recommend "persistent" indexes.