### PR TITLE
removed skiplist index references from Spring Data documentation

### DIFF
--- a/drivers/spring-data-reference-mapping-indexes.md
+++ b/drivers/spring-data-reference-mapping-indexes.md
@@ -18,7 +18,6 @@ With the `@<IndexType>Indexed` annotations user defined indexes can be created a
 Possible `@<IndexType>Indexed` annotations are:
 
 - `@HashIndexed`
-- `@SkiplistIndexed`
 - `@PersistentIndexed`
 - `@GeoIndexed`
 - `@FulltextIndexed`
@@ -37,12 +36,12 @@ public class Person {
 
 With the `@<IndexType>Indexed` annotations different indexes can be created on the same field.
 
-The following example creates a hash index and also a skiplist index on the field `name`:
+The following example creates a hash index and also a persistent index on the field `name`:
 
 ```java
 public class Person {
   @HashIndexed
-  @SkiplistIndexed
+  @PersistentIndexed
   private String name;
 }
 ```
@@ -54,7 +53,6 @@ If the index should include multiple fields the `@<IndexType>Index` annotations 
 Possible `@<IndexType>Index` annotations are:
 
 - `@HashIndex`
-- `@SkiplistIndex`
 - `@PersistentIndex`
 - `@GeoIndex`
 - `@FulltextIndex`

--- a/drivers/spring-data-reference-mapping.md
+++ b/drivers/spring-data-reference-mapping.md
@@ -154,8 +154,6 @@ To deactivate the type mapping process, you can return `null` from the `typeKey(
 | @TypeAlias("alias")     | class                     | set a type alias for the class when persisted to the DB                                                                                             |
 | @HashIndex              | class                     | describes a hash index                                                                                                                              |
 | @HashIndexed            | field                     | describes how to index the field                                                                                                                    |
-| @SkiplistIndex          | class                     | describes a skiplist index                                                                                                                          |
-| @SkiplistIndexed        | field                     | describes how to index the field                                                                                                                    |
 | @PersistentIndex        | class                     | describes a persistent index                                                                                                                        |
 | @PersistentIndexed      | field                     | describes how to index the field                                                                                                                    |
 | @GeoIndex               | class                     | describes a geo index                                                                                                                               |

--- a/drivers/spring-data-reference-template-collection-manipulation.md
+++ b/drivers/spring-data-reference-template-collection-manipulation.md
@@ -161,44 +161,6 @@ IndexEntity index = collection.ensureHashIndex(Arrays.asList("a", "b.c"), new Ha
 // the index has been created with the handle `index.getId()`
 ```
 
-## CollectionOperations.ensureSkiplistIndex
-
-```
-CollectionOperations.ensureSkiplistIndex(Iterable<String> fields, SkiplistIndexOptions options) : IndexEntity
-```
-
-Creates a skip-list index for the collection if it does not already exist.
-
-**Arguments**
-
-- **fields**: `Iterable<String>`
-
-  A list of attribute paths
-
-- **options**: `SkiplistIndexOptions`
-
-  - **unique**: `Boolean`
-
-    If true, then create a unique index
-
-  - **sparse**: `Boolean`
-
-    If true, then create a sparse index
-
-  - **deduplicate**: `Boolean`
-
-    If false, the deduplication of array values is turned off.
-
-**Examples**
-
-```Java
-@Autowired ArangoOperations template;
-
-CollectionOperations collection = template.collection(MyObject.class);
-IndexEntity index = collection.ensureSkiplistIndex(Arrays.asList("a", "b.c"), new SkiplistIndexOptions());
-// the index has been created with the handle `index.getId()`
-```
-
 ## CollectionOperations.ensureGeoIndex
 
 ```


### PR DESCRIPTION
Follow-up of https://github.com/arangodb/docs/pull/805
