### PR TITLE
discourage the use of arangoimp

### DIFF
--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -161,6 +161,15 @@ replace the old features with:
   discouraged. Their functionality is already removed, but they still exist to
   prevent unknown startup option errors.
 
+- **arangoimp** executable: ArangoDB release packages install an executable named
+  _arangoimp_ as an alias for the _arangoimport_ executable. This is done to 
+  provide compatibility with older releases, in which _arangoimport_ did not
+  yet exist and was named _arangoimp_. The renaming was actually carried out in
+  the codebase in December 2017. Using the _arangoimp_ executable is deprecated,
+  and it is always favorable to use _arangoimport_ instead. 
+  While the _arangoimport_ executable will remain, the _arangoimp_ alias will be 
+  removed in a future version of ArangoDB.
+
 - **HTTP and JavaScript traversal APIs**: The [HTTP traversal API](http/traversal.html)
   is deprecated since version 3.4.0. The JavaScript traversal module
   `@arangodb/graph/traversal` is also deprecated since then. The preferred way

--- a/3.9/appendix-deprecated.md
+++ b/3.9/appendix-deprecated.md
@@ -167,6 +167,15 @@ replace the old features with:
   removed in a future version of arangobench. Whenever a deprecated arangobench
   test case is invoked, there will be a warning message.
 
+- **arangoimp** executable: ArangoDB release packages install an executable named
+  _arangoimp_ as an alias for the _arangoimport_ executable. This is done to 
+  provide compatibility with older releases, in which _arangoimport_ did not
+  yet exist and was named _arangoimp_. The renaming was actually carried out in
+  the codebase in December 2017. Using the _arangoimp_ executable is deprecated,
+  and it is always favorable to use _arangoimport_ instead. 
+  While the _arangoimport_ executable will remain, the _arangoimp_ alias will be 
+  removed in a future version of ArangoDB.
+
 - **HTTP and JavaScript traversal APIs**: The [HTTP traversal API](http/traversal.html)
   is deprecated since version 3.4.0. The JavaScript traversal module
   `@arangodb/graph/traversal` is also deprecated since then. The preferred way

--- a/3.9/release-notes-upgrading-changes39.md
+++ b/3.9/release-notes-upgrading-changes39.md
@@ -247,3 +247,15 @@ requests.
 In this case it is advised to decrease the value of arangorestore's `--threads`
 option accordingly. The value of `--threads` will the determine the maximum
 parallelism used by arangorestore.
+
+### arangoimport
+
+ArangoDB release packages install an executable named _arangoimp_ as an alias 
+for the _arangoimport_ executable. This is done to provide compatibility with 
+older releases, in which _arangoimport_ did not yet exist and was named 
+_arangoimp_. 
+The renaming was actually carried out in the codebase in December 2017. Using 
+the _arangoimp_ executable is now deprecated, and it is always favorable to use 
+_arangoimport_ instead. 
+While the _arangoimport_ executable will remain, the _arangoimp_ alias will be 
+removed in a future version of ArangoDB, and its use is now highly discouraged.


### PR DESCRIPTION
Documentation for a deprecation discussed turing team lead sync meeting today:
* deprecate _arangoimp_ alias in 3.9: arangoimp is just an alias for arangoimp
* remove _arangoimp_ in some future version, and keep _arangoimport_ around