### PR TITLE
APM-217: deprecate the usage of fulltext indexes

### DIFF
--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -39,8 +39,8 @@ replace the old features with:
   prescribed by the [HTTP specification](https://tools.ietf.org/html/rfc7231#section-4.2){:target="_blank"}.
 
 - **Fulltext indexes**:
-  The "fulltext" index type is deprecated from version 3.10 onwards.
-  For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+  The fulltext index type is deprecated from version 3.10 onwards.
+  It's recommended to use [ArangoSearch](arangosearch.html) for advanced full-text search capabilities.
 
 - **Simple Queries**: Idiomatic interface in arangosh to perform trivial queries.
   They are superseded by [AQL queries](aql/index.html), which can also

--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -38,6 +38,10 @@ replace the old features with:
   equivalent to the PUT endpoint, but does not violate idempotency requirements
   prescribed by the [HTTP specification](https://tools.ietf.org/html/rfc7231#section-4.2){:target="_blank"}.
 
+- **Fulltext indexes**:
+  The "fulltext" index type is deprecated from version 3.10 onwards.
+  For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+
 - **Simple Queries**: Idiomatic interface in arangosh to perform trivial queries.
   They are superseded by [AQL queries](aql/index.html), which can also
   be run in arangosh. AQL is a language on its own and way more powerful than

--- a/3.10/appendix-glossary.md
+++ b/3.10/appendix-glossary.md
@@ -175,6 +175,10 @@ An edge index is automatically created for edge collections. It contains connect
 Fulltext Index
 --------------
 
+{% hint 'warning' %}
+The fulltext index type is deprecated from version 3.10 onwards.
+{% endhint %}
+
 A fulltext index can be used to find words, or prefixes of words inside documents. A fulltext index can be defined on one attribute only, and will include all words contained in documents that have a textual value in the index attribute. Since ArangoDB 2.6 the index will also include words from the index attribute if the index attribute is an array of strings, or an object with string value members.
 
 For example, given a fulltext index on the `translations` attribute and the following documents, then searching for `лиса` using the fulltext index would return only the first document. Searching for the index for the exact string `Fox` would return the first two documents, and searching for `prefix:Fox` would return all three documents:

--- a/3.10/http/indexes.md
+++ b/3.10/http/indexes.md
@@ -58,7 +58,7 @@ Documents which are expired are eventually removed by a background thread.
 
 {% hint 'warning' %}
 The fulltext index type is deprecated from version 3.10 onwards.
-For advanced full-text search capabilities consider [ArangoSearch](../arangosearch.html).
+It's recommended to use [ArangoSearch](../arangosearch.html) for advanced full-text search capabilities.
 {% endhint %}
 
 A fulltext index can be used to find words, or prefixes of words inside documents. A fulltext index can be set on one attribute only, and will index all words contained in documents that have a textual value in this attribute. Only words with a (specifiable) minimum length are indexed. Word tokenization is done using the word boundary analysis provided by libicu, which is taking into account the selected language provided at server start. Words are indexed in their lower-cased form. The index supports complete match queries (full words) and prefix queries.

--- a/3.10/http/indexes.md
+++ b/3.10/http/indexes.md
@@ -17,7 +17,7 @@ Indexes are used to allow fast access to documents. For each collection there is
 [document key](../appendix-glossary.html#document-key) (_key attribute). This index cannot be dropped or changed.
 [edge collections](../appendix-glossary.html#edge-collection) will also have an automatically created edges index, which cannot be modified. This index provides quick access to documents via the `_from` and `_to` attributes.
 
-Most user-land indexes can be created by defining the names of the attributes which should be indexed. Some index types allow indexing just one attribute (e.g. fulltext index) whereas other index types allow indexing multiple attributes.
+Most user-land indexes can be created by defining the names of the attributes which should be indexed. Some index types allow indexing just one attribute (e.g. ttl index) whereas other index types allow indexing multiple attributes.
 
 Using the system attribute `_id` in user-defined indexes is not supported by any index type.
 
@@ -55,6 +55,11 @@ The TTL index can be used for automatically removing expired documents from a co
 Documents which are expired are eventually removed by a background thread.
 
 ### Fulltext Index
+
+{% hint 'warning' %}
+The fulltext index type is deprecated from version 3.10 onwards.
+For advanced full-text search capabilities consider [ArangoSearch](../arangosearch.html).
+{% endhint %}
 
 A fulltext index can be used to find words, or prefixes of words inside documents. A fulltext index can be set on one attribute only, and will index all words contained in documents that have a textual value in this attribute. Only words with a (specifiable) minimum length are indexed. Word tokenization is done using the word boundary analysis provided by libicu, which is taking into account the selected language provided at server start. Words are indexed in their lower-cased form. The index supports complete match queries (full words) and prefix queries.
 

--- a/3.10/indexing-fulltext.md
+++ b/3.10/indexing-fulltext.md
@@ -7,7 +7,7 @@ Fulltext indexes
 
 {% hint 'warning' %}
 The fulltext index type is deprecated from version 3.10 onwards.
-For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+It's recommended to use [ArangoSearch](arangosearch.html) for advanced full-text search capabilities.
 {% endhint %}
 
 This is an introduction to ArangoDB's fulltext indexes.

--- a/3.10/indexing-fulltext.md
+++ b/3.10/indexing-fulltext.md
@@ -5,6 +5,11 @@ description: This is an introduction to ArangoDB's fulltext indexes
 Fulltext indexes
 ================
 
+{% hint 'warning' %}
+The fulltext index type is deprecated from version 3.10 onwards.
+For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+{% endhint %}
+
 This is an introduction to ArangoDB's fulltext indexes.
 
 Introduction to Fulltext Indexes

--- a/3.10/indexing-index-basics.md
+++ b/3.10/indexing-index-basics.md
@@ -384,7 +384,7 @@ Fulltext Index
 
 {% hint 'warning' %}
 The fulltext index type is deprecated from version 3.10 onwards.
-For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+It's recommended to use [ArangoSearch](arangosearch.html) for advanced full-text search capabilities.
 {% endhint %}
 
 A fulltext index can be used to find words, or prefixes of words inside documents. 

--- a/3.10/indexing-index-basics.md
+++ b/3.10/indexing-index-basics.md
@@ -12,7 +12,7 @@ of documents.
 
 User-defined indexes can be created on collection level. Most user-defined indexes 
 can be created by specifying the names of the index attributes.
-Some index types allow indexing just one attribute (e.g. *fulltext* index) whereas 
+Some index types allow indexing just one attribute (e.g. *ttl* index) whereas 
 other index types allow indexing multiple attributes at the same time.
 
 Learn how to use different indexes efficiently by going through the
@@ -382,6 +382,11 @@ or conditions.
 Fulltext Index
 --------------
 
+{% hint 'warning' %}
+The fulltext index type is deprecated from version 3.10 onwards.
+For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
+{% endhint %}
+
 A fulltext index can be used to find words, or prefixes of words inside documents. 
 A fulltext index can be created on a single attribute only, and will index all words 
 contained in documents that have a textual value in that attribute. Only words with a (specifiable) 
@@ -398,9 +403,6 @@ minimum length will be included in the index.
 The fulltext index is used via dedicated functions in AQL, but will
 not be enabled for other types of queries or conditions.
 
-{% hint 'tip' %}
-For advanced full-text search capabilities consider [ArangoSearch](arangosearch.html).
-{% endhint %}
 
 Indexing attributes and sub-attributes
 --------------------------------------

--- a/3.10/indexing-which-index.md
+++ b/3.10/indexing-which-index.md
@@ -137,6 +137,9 @@ different usage scenarios:
   The index supports complete match queries (full words) and prefix queries.
   Fulltext indexes will only be invoked via special functions.
 
+  Please note that the fulltext index type is deprecated from version 3.10 onwards
+  and is superseded by [ArangoSearch](arangosearch.html).
+
 - **View**: [ArangoSearch](arangosearch.html) is a sophisticated search engine
   for full-text, with text pre-processing, ranking capabilities and more.
   It offers more features and configuration options than a fulltext index.

--- a/3.10/indexing-working-with-indexes.md
+++ b/3.10/indexing-working-with-indexes.md
@@ -93,7 +93,7 @@ Other attributes may be necessary, depending on the index type.
 
 **type** can be one of the following values:
 - *persistent*: persistent index
-- *fulltext*: fulltext index
+- *fulltext*: fulltext index (deprecated from ArangoDB 3.10 onwards)
 - *geo*: geo index, with _one_ or _two_ attributes
 
 **name** can be a string. Index names are subject to the same character

--- a/3.10/release-notes-upgrading-changes310.md
+++ b/3.10/release-notes-upgrading-changes310.md
@@ -17,7 +17,7 @@ AQL
 Indexes
 -------
 
-The "fulltext" index type is now deprecated in favor of [ArangoSearch](arangosearch.html).
+The fulltext index type is now deprecated in favor of [ArangoSearch](arangosearch.html).
 Fulltext indexes are still usable in this version of ArangoDB, although their usage is
 now discouraged.
 

--- a/3.10/release-notes-upgrading-changes310.md
+++ b/3.10/release-notes-upgrading-changes310.md
@@ -14,6 +14,13 @@ AQL
 ---
 
 
+Indexes
+-------
+
+The "fulltext" index type is now deprecated in favor of [ArangoSearch](arangosearch.html).
+Fulltext indexes are still usable in this version of ArangoDB, although their usage is
+now discouraged.
+
 
 Startup options
 ---------------


### PR DESCRIPTION
arangodb/docs companion PR to arangodb/arangodb PR https://github.com/arangodb/arangodb/pull/15231

Context: https://arangodb.atlassian.net/browse/APM-217