### PR TITLE
license documentation after final pm decision

### DIFF
--- a/3.10/administration-license.md
+++ b/3.10/administration-license.md
@@ -49,21 +49,18 @@ At any point you may check the current state of your license in _arangosh_:
   "license": "JD4E ... dnDw==",
   "version": 1,
   "status": "good"
+  "hash" : "...."
 }
 ```
 
 The `status` attribute is the executive summary of your license and
 can have the following values:
 
-- `good`: Your license is valid for more than another 2 weeks.
+- `good`: Your license is valid for more than another 1 week.
 - `expiring`: Your license is about to expire shortly. Please contact
   your ArangoDB sales representative to acquire a new license or
   extend your old license.
-- `expired`: Your license has expired recently. All existing
-  Enterprise Edition features keep on functioning. However, no new Enterprise
-  Edition features can be used. This should prompt immediate contact with your
-  ArangoDB sales representative.
-- `read-only`: Your license has expired for over 2 weeks at which
+- `read-only`: Your license has expired at which
   point the deployment will be in read-only mode. All read operations to the
   instance will keep functioning. However, no data or data definition changes
   can be made. Please contact your ArangoDB sales representative immediately.

--- a/3.10/appendix-references-dbobject.md
+++ b/3.10/appendix-references-dbobject.md
@@ -69,3 +69,8 @@ The following methods exist on the *_db* object:
 * [db._engineStats()](data-modeling-databases-working-with.html#engine-statistics)
 * [db._executeTransaction()](transactions-transaction-invocation.html)
 * [db._version()](data-modeling-databases-working-with.html#get-the-version-of-arangodb)
+
+*License*
+
+* [db._getLicense()](administration-license.html#managing-your-license)]
+* [db._setLicense(data)](administration-license.html#initial-installation)]

--- a/3.9/administration-license.md
+++ b/3.9/administration-license.md
@@ -49,21 +49,18 @@ At any point you may check the current state of your license in _arangosh_:
   "license": "JD4E ... dnDw==",
   "version": 1,
   "status": "good"
+  "hash" : "...."
 }
 ```
 
 The `status` attribute is the executive summary of your license and
 can have the following values:
 
-- `good`: Your license is valid for more than another 2 weeks.
+- `good`: Your license is valid for more than another 1 week.
 - `expiring`: Your license is about to expire shortly. Please contact
   your ArangoDB sales representative to acquire a new license or
   extend your old license.
-- `expired`: Your license has expired recently. All existing
-  Enterprise Edition features keep on functioning. However, no new Enterprise
-  Edition features can be used. This should prompt immediate contact with your
-  ArangoDB sales representative.
-- `read-only`: Your license has expired for over 2 weeks at which
+- `read-only`: Your license has expired at which
   point the deployment will be in read-only mode. All read operations to the
   instance will keep functioning. However, no data or data definition changes
   can be made. Please contact your ArangoDB sales representative immediately.

--- a/3.9/appendix-references-dbobject.md
+++ b/3.9/appendix-references-dbobject.md
@@ -69,3 +69,8 @@ The following methods exist on the *_db* object:
 * [db._engineStats()](data-modeling-databases-working-with.html#engine-statistics)
 * [db._executeTransaction()](transactions-transaction-invocation.html)
 * [db._version()](data-modeling-databases-working-with.html#get-the-version-of-arangodb)
+
+*License*
+
+* [db._getLicense()](administration-license.html#managing-your-license)]
+* [db._setLicense(data)](administration-license.html#initial-installation)]


### PR DESCRIPTION
Updated license documentation to reflect the final PM decision:

* Time after installation without enforcement (currently 3 days): 1 hour
* Time before license expiration with daily warnings (currently 14 days): 7 days
* Time after expiration switch to Read-Only (currently 14 days): 0 days
