### PR TITLE
adjust default value for `--rocksdb.max-subcompactions`

### DIFF
--- a/3.9/release-notes-api-changes39.md
+++ b/3.9/release-notes-api-changes39.md
@@ -256,6 +256,8 @@ endpoint.
 
 ### Endpoints removed
 
+#### Redirects
+
 The following API redirect endpoints have been removed in ArangoDB 3.9.
 These endpoints have been only been redirections since ArangoDB 3.7. Any
 caller of these API endpoints should use the updated endpoints:

--- a/3.9/release-notes-upgrading-changes39.md
+++ b/3.9/release-notes-upgrading-changes39.md
@@ -74,7 +74,7 @@ Startup options
 
 ### RocksDB options
 
-The default value for the startup option `--rocksdb.max-subcompactions` was 
+The default value for the startup `--rocksdb.max-subcompactions` option  was 
 changed from `1` to `2`.
 This allows compactions jobs to be broken up into disjoint ranges which
 can be processed in parallel by multiple threads.
@@ -226,14 +226,14 @@ removed in a future version of ArangoDB, and its use is now highly discouraged.
 
 ### arangovpack
 
-The former options `--json` and `--pretty` of the *arangovpack* utility
-have been removed and have been replaced with separate options for specifying
+The former `--json` and `--pretty` options of the *arangovpack* utility
+were removed and replaced with separate options for specifying
 the input and output types:
 
 - `--input-type` (`json`, `json-hex`, `vpack`, `vpack-hex`)
 - `--output-type` (`json`, `json-pretty`, `vpack`, `vpack-hex`)
 
-The former option `--print-non-json` has been replaced with the new option
-`--fail-on-non-json` which makes arangovpack fail when trying to emit non-JSON
+The former `--print-non-json` option was replaced with the new
+`--fail-on-non-json` option, which makes arangovpack fail when trying to emit non-JSON
 types to JSON output.
 

--- a/3.9/release-notes-upgrading-changes39.md
+++ b/3.9/release-notes-upgrading-changes39.md
@@ -72,6 +72,13 @@ Also see [Known limitations for AQL queries](aql/fundamentals-limitations.html).
 Startup options
 ---------------
 
+### RocksDB options
+
+The default value for the startup option `--rocksdb.max-subcompactions` was 
+changed from `1` to `2`.
+This allows compactions jobs to be broken up into disjoint ranges which
+can be processed in parallel by multiple threads.
+
 ### Rebalance shards
 
 The `--cluster.max-number-of-move-shards` option limits the maximum number of 
@@ -136,60 +143,6 @@ In ArangoDB 3.9 the option `--database.old-system-collections` is now
 completely obsolete, and ArangoDB will never create these system collections
 for any new databases. The option can still be specified at startup, but it
 meaningless now.
-
-### Replaced arangovpack options
-
-The former options `--json` and `--pretty` of the *arangovpack* utility
-have been removed and have been replaced with separate options for specifying
-the input and output types:
-
-- `--input-type` (`json`, `json-hex`, `vpack`, `vpack-hex`)
-- `--output-type` (`json`, `json-pretty`, `vpack`, `vpack-hex`)
-
-The former option `--print-non-json` has been replaced with the new option
-`--fail-on-non-json` which makes arangovpack fail when trying to emit non-JSON
-types to JSON output.
-
-### Export API removed
-
-The REST API endpoint `/_api/export` has been removed in ArangoDB 3.9.
-This endpoint was previously only present in single server, but never
-supported in cluster deployments.
-
-The purpose of the endpoint was to provide the full data of a collection
-without holding collection locks for a long time, which was useful for
-the MMFile storage engine with its collection-level locks.
-
-The MMFiles engine is gone since ArangoDB 3.7, and the only remaining
-storage engine since then is RocksDB. For the RocksDB engine, the
-`/_api/export` endpoint internally used a streaming AQL query such as
-
-```js
-FOR doc IN @@collection RETURN doc
-```
-
-anyway. To remove API redundancy, the API endpoint has been deprecated
-in ArangoDB 3.8 and is now removed. If the functionality is still required
-by client applications, running a streaming AQL query can be used as a
-substitution.
-
-#### Redirects removed
-
-Since ArangoDB 3.7, some cluster APIs were made available under different
-paths. The old paths were left in place and simply redirected to the new
-address. These redirects have now been removed in ArangoDB 3.9.
-
-The following list shows the old, now dysfunctional paths and their
-replacements:
-
-- `/_admin/clusterNodeVersion`: replaced by `/_admin/cluster/nodeVersion`
-- `/_admin/clusterNodeEngine`: replaced by `/_admin/cluster/nodeEngine`
-- `/_admin/clusterNodeStats`: replaced by `/_admin/cluster/nodeStatistics`
-- `/_admin/clusterStatistics`: replaced by `/_admin/cluster/statistics`
-
-Using the replacements will work from ArangoDB 3.7 onwards already, so
-any client applications that still call the old addresses can be adjusted
-to call the new addresses from 3.7 onwards.
 
 Client tools
 ------------
@@ -270,3 +223,17 @@ the _arangoimp_ executable is now deprecated, and it is always favorable to use
 _arangoimport_ instead. 
 While the _arangoimport_ executable will remain, the _arangoimp_ alias will be 
 removed in a future version of ArangoDB, and its use is now highly discouraged.
+
+### arangovpack
+
+The former options `--json` and `--pretty` of the *arangovpack* utility
+have been removed and have been replaced with separate options for specifying
+the input and output types:
+
+- `--input-type` (`json`, `json-hex`, `vpack`, `vpack-hex`)
+- `--output-type` (`json`, `json-pretty`, `vpack`, `vpack-hex`)
+
+The former option `--print-non-json` has been replaced with the new option
+`--fail-on-non-json` which makes arangovpack fail when trying to emit non-JSON
+types to JSON output.
+


### PR DESCRIPTION
Docs PR for https://github.com/arangodb/arangodb/pull/15332 and https://github.com/arangodb/arangodb/pull/15333

This PR also moves some other things around in the release note, to potentially better suited locations.