### PR TITLE
Fix for analyzer creation function call examples

### DIFF
--- a/3.10/arangosearch-fuzzy-search.md
+++ b/3.10/arangosearch-fuzzy-search.md
@@ -193,7 +193,7 @@ also relevant.
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["frequency", "norm"]);
+analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**
@@ -260,7 +260,7 @@ not including the original string:
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["frequency", "norm"]);
+analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**

--- a/3.10/arangosearch-fuzzy-search.md
+++ b/3.10/arangosearch-fuzzy-search.md
@@ -190,11 +190,15 @@ into account accurately. With stemming enabled, it would be less accurate with
 respect to the original strings, but potentially find more matches that are
 also relevant.
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline levenshtein_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{levenshtein_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock levenshtein_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 
 **View definition:**
 
@@ -257,11 +261,18 @@ FOR doc IN imdb
 trigram Analyzer in arangosh with a minimum and maximum _n_-gram size of 3,
 not including the original string:
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline ngram_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{ngram_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock ngram_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
+
+
+
 
 **View definition:**
 

--- a/3.7/arangosearch-fuzzy-search.md
+++ b/3.7/arangosearch-fuzzy-search.md
@@ -193,7 +193,7 @@ also relevant.
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["frequency", "norm"]);
+analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**
@@ -260,7 +260,7 @@ not including the original string:
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["frequency", "norm"]);
+analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**

--- a/3.7/arangosearch-fuzzy-search.md
+++ b/3.7/arangosearch-fuzzy-search.md
@@ -190,11 +190,15 @@ into account accurately. With stemming enabled, it would be less accurate with
 respect to the original strings, but potentially find more matches that are
 also relevant.
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline levenshtein_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{levenshtein_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock levenshtein_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 
 **View definition:**
 
@@ -257,10 +261,15 @@ FOR doc IN imdb
 trigram Analyzer in arangosh with a minimum and maximum _n_-gram size of 3,
 not including the original string:
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline ngram_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{ngram_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock ngram_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}zers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**

--- a/3.8/arangosearch-fuzzy-search.md
+++ b/3.8/arangosearch-fuzzy-search.md
@@ -193,7 +193,7 @@ also relevant.
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["frequency", "norm"]);
+analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**
@@ -260,7 +260,7 @@ not including the original string:
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["frequency", "norm"]);
+analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**

--- a/3.8/arangosearch-fuzzy-search.md
+++ b/3.8/arangosearch-fuzzy-search.md
@@ -190,12 +190,15 @@ into account accurately. With stemming enabled, it would be less accurate with
 respect to the original strings, but potentially find more matches that are
 also relevant.
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
-```
-
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline levenshtein_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{levenshtein_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock levenshtein_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 **View definition:**
 
 ```json
@@ -257,11 +260,15 @@ FOR doc IN imdb
 trigram Analyzer in arangosh with a minimum and maximum _n_-gram size of 3,
 not including the original string:
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline ngram_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{ngram_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock ngram_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 
 **View definition:**
 

--- a/3.9/arangosearch-fuzzy-search.md
+++ b/3.9/arangosearch-fuzzy-search.md
@@ -193,7 +193,7 @@ also relevant.
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["frequency", "norm"]);
+analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**
@@ -260,7 +260,7 @@ not including the original string:
 ```js
 //db._useDatabase("your_database"); // Analyzer will be created in current database
 var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["frequency", "norm"]);
+analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
 ```
 
 **View definition:**

--- a/3.9/arangosearch-fuzzy-search.md
+++ b/3.9/arangosearch-fuzzy-search.md
@@ -190,11 +190,15 @@ into account accurately. With stemming enabled, it would be less accurate with
 respect to the original strings, but potentially find more matches that are
 also relevant.
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline levenshtein_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{levenshtein_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("text_en_no_stem", "text", { locale: "en.utf-8", accent: false, case: "lower", stemming: false, stopwords: [] }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock levenshtein_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 
 **View definition:**
 
@@ -257,11 +261,15 @@ FOR doc IN imdb
 trigram Analyzer in arangosh with a minimum and maximum _n_-gram size of 3,
 not including the original string:
 
-```js
-//db._useDatabase("your_database"); // Analyzer will be created in current database
-var analyzers = require("@arangodb/analyzers");
-analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
-```
+{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    @startDocuBlockInline ngram_match_sample
+    @EXAMPLE_ARANGOSH_OUTPUT{ngram_match_sample}
+    var analyzers = require("@arangodb/analyzers");
+    analyzers.save("trigram", "ngram", { min: 3, max: 3, preserveOriginal: false, streamType: "utf8" }, ["position", "frequency", "norm"]);
+    @END_EXAMPLE_ARANGOSH_OUTPUT
+    @endDocuBlock ngram_match_sample
+{% endarangoshexample %}
+{% include arangoshexample.html id=examplevar script=script result=result %}
 
 **View definition:**
 


### PR DESCRIPTION
Hi,
According to [NGRAM_MATCH()](https://www.arangodb.com/docs/3.7/aql/functions-arangosearch.html#ngram_match) and [PHRASE()](https://www.arangodb.com/docs/3.7/aql/functions-arangosearch.html#phrase) documentation, analyzers must have "position" feature in order to work correctly. At the same time "Fuzzy search" branch of documentation has incorrect and misleading examples for [NGRAM_MATCH()](https://www.arangodb.com/docs/stable/arangosearch-fuzzy-search.html#searching-with-ngram_match) and [LEVENSHTEIN_MATCH()](https://www.arangodb.com/docs/stable/arangosearch-fuzzy-search.html#searching-with-levenshtein_match) sections.
This PR proposes a fix.
This has been discussed with the Search team and has their approval.
// Alex. 