### PR TITLE
Thread default value updated in docs

### DIFF
--- a/3.10/programs-arangodump-examples.md
+++ b/3.10/programs-arangodump-examples.md
@@ -298,8 +298,7 @@ Threads
 Since v3.4.0, _arangodump_ can use multiple threads for dumping database data in 
 parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
-The number of threads can be controlled via the `--threads` option, which 
-defaults to `2`.
+The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
 
 _arangodump_ versions prior to v3.8.0 distribute dump jobs for individual
 collections to concurrent worker threads, which is optimal for dumping many

--- a/3.10/programs-arangodump-examples.md
+++ b/3.10/programs-arangodump-examples.md
@@ -300,6 +300,15 @@ parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
 The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
 
+The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
+
+```
+For example,
+If a system has 8 cores -> max(2,8) = 8, i.e. 8 threads will be used.
+And if it has 1 CPU core -> max(2,1) = 2, i.e. 2 threads will be used.
+```
+
+
 _arangodump_ versions prior to v3.8.0 distribute dump jobs for individual
 collections to concurrent worker threads, which is optimal for dumping many
 collections of approximately the same size, but does not help for dumping few

--- a/3.10/programs-arangodump-examples.md
+++ b/3.10/programs-arangodump-examples.md
@@ -298,7 +298,7 @@ Threads
 Since v3.4.0, _arangodump_ can use multiple threads for dumping database data in 
 parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
-The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
+The number of threads can be controlled via the `--threads` option. The default value was changed from `2` to the maximum of `2` and the number of available CPU cores.
 
 The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
 

--- a/3.9/programs-arangodump-examples.md
+++ b/3.9/programs-arangodump-examples.md
@@ -300,6 +300,14 @@ parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
 The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
 
+The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
+
+```
+For example,
+If a system has 8 cores -> max(2,8) = 8, i.e. 8 threads will be used.
+And if it has 1 CPU core -> max(2,1) = 2, i.e. 2 threads will be used.
+```
+
 _arangodump_ versions prior to v3.8.0 distribute dump jobs for individual
 collections to concurrent worker threads, which is optimal for dumping many
 collections of approximately the same size, but does not help for dumping few

--- a/3.9/programs-arangodump-examples.md
+++ b/3.9/programs-arangodump-examples.md
@@ -298,8 +298,7 @@ Threads
 Since v3.4.0, _arangodump_ can use multiple threads for dumping database data in 
 parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
-The number of threads can be controlled via the `--threads` option, which 
-defaults to `2`.
+The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
 
 _arangodump_ versions prior to v3.8.0 distribute dump jobs for individual
 collections to concurrent worker threads, which is optimal for dumping many

--- a/3.9/programs-arangodump-examples.md
+++ b/3.9/programs-arangodump-examples.md
@@ -298,7 +298,7 @@ Threads
 Since v3.4.0, _arangodump_ can use multiple threads for dumping database data in 
 parallel. To speed up the dump of a database with multiple collections, it is
 often beneficial to increase the number of _arangodump_ threads.
-The number of threads can be controlled via the `--threads` option. The default value changed from `2` to the maximum of `2` and the number of available CPU cores.
+The number of threads can be controlled via the `--threads` option. The default value was changed from `2` to the maximum of `2` and the number of available CPU cores.
 
 The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
 

--- a/3.9/release-notes-new-features39.md
+++ b/3.9/release-notes-new-features39.md
@@ -554,12 +554,6 @@ client tools:
 
 The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
 
-```
-For example,
-If a system has 8 cores -> max(2,8) = 8, i.e. 8 threads will be used.
-And if it has 1 CPU core -> max(2,1) = 2, i.e. 2 threads will be used.
-```
-
 This change can help to improve performance of imports, dumps or restore
 processes on machines with multiple cores in case the `--threads` parameter
 was not previously used. As a trade-off, the change may lead to an increased 

--- a/3.9/release-notes-new-features39.md
+++ b/3.9/release-notes-new-features39.md
@@ -552,6 +552,14 @@ client tools:
 - arangoimport
 - arangorestore
 
+The `--threads` option works dynamically, its value depends on the number of available CPU cores. If the amount of available CPU cores is less than `3`, a threads value of `2` is used. Otherwise the value of threads is set to the number of available CPU cores.
+
+```
+For example,
+If a system has 8 cores -> max(2,8) = 8, i.e. 8 threads will be used.
+And if it has 1 CPU core -> max(2,1) = 2, i.e. 2 threads will be used.
+```
+
 This change can help to improve performance of imports, dumps or restore
 processes on machines with multiple cores in case the `--threads` parameter
 was not previously used. As a trade-off, the change may lead to an increased 


### PR DESCRIPTION
Old: 
The number of threads can be controlled via the --threads option, which defaults to 2.

Change to: 
The number of threads can be controlled via the --threads option. The default value changed from 2 to the maximum of 2 and the number of available CPU cores.