### PR TITLE
Add commas

### DIFF
--- a/3.10/foxx-guides-browser.md
+++ b/3.10/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically allow all response headers as they are used.
+As of 3.2, Foxx will then automatically allow all response headers as they are used.
 
 If you want more control over what is exposed or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.4/foxx-guides-browser.md
+++ b/3.4/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically whitelist all response headers as they are used.
+As of 3.2, Foxx will then automatically whitelist all response headers as they are used.
 
 If you want more control over the whitelist or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.5/foxx-guides-browser.md
+++ b/3.5/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically whitelist all response headers as they are used.
+As of 3.2, Foxx will then automatically whitelist all response headers as they are used.
 
 If you want more control over the whitelist or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.6/foxx-guides-browser.md
+++ b/3.6/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically whitelist all response headers as they are used.
+As of 3.2, Foxx will then automatically whitelist all response headers as they are used.
 
 If you want more control over the whitelist or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.7/foxx-guides-browser.md
+++ b/3.7/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically whitelist all response headers as they are used.
+As of 3.2, Foxx will then automatically whitelist all response headers as they are used.
 
 If you want more control over the whitelist or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.8/foxx-guides-browser.md
+++ b/3.8/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically allow all response headers as they are used.
+As of 3.2, Foxx will then automatically allow all response headers as they are used.
 
 If you want more control over what is exposed or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).

--- a/3.9/foxx-guides-browser.md
+++ b/3.9/foxx-guides-browser.md
@@ -135,10 +135,10 @@ you will need to enable CORS in ArangoDB.
 
 First you need to
 [configure ArangoDB for CORS](http/general.html#cross-origin-resource-sharing-cors-requests).
-As of 3.2 Foxx will then automatically allow all response headers as they are used.
+As of 3.2, Foxx will then automatically allow all response headers as they are used.
 
 If you want more control over what is exposed or are using an older version of
-ArangoDB you can set the following response headers in your request handler:
+ArangoDB, you can set the following response headers in your request handler:
 
 - `access-control-expose-headers`: a comma-separated list of response headers.
   This defaults to a list of all headers the response is actually using
@@ -151,5 +151,5 @@ ArangoDB you can set the following response headers in your request handler:
 
 Note that it is not possible to override these headers for the CORS preflight
 response. It is therefore not possible to accept credentials or cookies only
-for individual routes, services or databases. The origin needs to be trusted
+for individual routes, services, or databases. The origin needs to be trusted
 according to the general ArangoDB configuration (see above).


### PR DESCRIPTION
- Add commas to introductory clauses.
- Add oxford comma. [^1]

[^1]: [Strippers, JFK, Stalin, and the Oxford Comma](https://www.verbicidemagazine.com/2011/09/20/strippers-jfk-and-stalin-illustrate-why-you-should-use-the-serial-comma/)
