### PR TITLE
Fix small inaccuracies about threads

### DIFF
--- a/3.10/programs-arangod-server.md
+++ b/3.10/programs-arangod-server.md
@@ -386,7 +386,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a minimum of 32 threads.
+number of CPU cores but at least 32 threads.
 
 ## Toggling server statistics
 

--- a/3.10/programs-arangod-server.md
+++ b/3.10/programs-arangod-server.md
@@ -386,7 +386,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a maximum of 32 threads.
+number of CPU cores, capped to a minimum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.6/programs-arangod-server.md
+++ b/3.6/programs-arangod-server.md
@@ -272,8 +272,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is `max(64, 2 * available cores)`, so twice the
-number of CPU cores, capped to a minimum of 64 threads.
+handling. The default value is `max(32, 2 * available cores)`, so twice the
+number of CPU cores, capped to a maximum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.6/programs-arangod-server.md
+++ b/3.6/programs-arangod-server.md
@@ -272,8 +272,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a maximum of 32 threads.
+handling. The default value is `max(64, 2 * available cores)`, so twice the
+number of CPU cores, capped to a minimum of 64 threads.
 
 ## Toggling server statistics
 

--- a/3.7/programs-arangod-server.md
+++ b/3.7/programs-arangod-server.md
@@ -299,8 +299,8 @@ value is *2*.
 `--server.maximal-threads` determines the maximum number of request processing
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
-handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a maximum of 32 threads.
+handling. The default value is `max(64, 2 * available cores)`, so twice the
+number of CPU cores, capped to a minimum of 64 threads.
 
 ## Toggling server statistics
 

--- a/3.7/programs-arangod-server.md
+++ b/3.7/programs-arangod-server.md
@@ -300,7 +300,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(64, 2 * available cores)`, so twice the
-number of CPU cores, capped to a minimum of 64 threads.
+number of CPU cores but at least 64 threads.
 
 ## Toggling server statistics
 

--- a/3.8/programs-arangod-server.md
+++ b/3.8/programs-arangod-server.md
@@ -375,7 +375,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a maximum of 32 threads.
+number of CPU cores, capped to a minimum of 32 threads.
 
 ## Toggling server statistics
 

--- a/3.8/programs-arangod-server.md
+++ b/3.8/programs-arangod-server.md
@@ -375,7 +375,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a minimum of 32 threads.
+number of CPU cores but at least 32 threads.
 
 ## Toggling server statistics
 

--- a/3.9/programs-arangod-server.md
+++ b/3.9/programs-arangod-server.md
@@ -386,7 +386,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a minimum of 32 threads.
+number of CPU cores but at least 32 threads.
 
 ## Toggling server statistics
 

--- a/3.9/programs-arangod-server.md
+++ b/3.9/programs-arangod-server.md
@@ -386,7 +386,7 @@ value is *2*.
 threads the server is allowed to start for request handling. If that number of
 threads is already running, arangod will not start further threads for request
 handling. The default value is `max(32, 2 * available cores)`, so twice the
-number of CPU cores, capped to a maximum of 32 threads.
+number of CPU cores, capped to a minimum of 32 threads.
 
 ## Toggling server statistics
 


### PR DESCRIPTION
A customer noted that we have some small inconsistencies between
documentation and implementation. This fixes them.

This is around number of server threads.
