### PR TITLE
Add page for --encryption.* startup option category to fix failing builds

### DIFF
--- a/3.10/programs-arangod-encryption.md
+++ b/3.10/programs-arangod-encryption.md
@@ -1,34 +1,24 @@
 ---
 layout: default
-description: arangodump Options
+description: ArangoDB Server Encryption Options
 ---
-_arangodump_ Options
+# ArangoDB Server Encryption Options
 
-Usage: `arangodump [<options>]`
+## Keyfile
 
-{% assign optionsFile = page.version.version | remove: "." | append: "-program-options-arangodump" -%}
-{% assign options = site.data[optionsFile] -%}
-{% include program-option.html options=options name="arangodump" %}
-
-Notes
------
-
-### Encryption Option Details
-
-{% include hint-ee-oasis.md feature="Dump encryption" %}
- 
-*\--encryption.keyfile path-of-keyfile*
+`--encryption.keyfile <path-of-keyfile>`
 
 The file `path-to-keyfile` must contain the encryption key. This file must be
-secured, so that only `arangodump`, `arangorestore`, and `arangod` can access it.
+secured, so that only `arangodump`, `arangorestore`, or `arangod` can access it.
 You should also ensure that in case someone steals your hardware, they will not be
 able to read the file. For example, by encrypting `/mytmpfs` or
 creating an in-memory file-system under `/mytmpfs`. The encryption keyfile must 
 contain 32 bytes of data.
 
-*\--encryption.key-generator path-to-my-generator*
+## Key Generator
+
+`--encryption.key-generator <path-to-my-generator>`
 
 This output is used if you want to use the program to generate your encryption key.
 The program `path-to-my-generator` must output the encryption on standard output
 and exit. The encryption keyfile must contain 32 bytes of data.
-

--- a/_config.yml
+++ b/_config.yml
@@ -95,7 +95,7 @@ exclude:
   - 3.5/generated
   - 3.4/generated
   - 3.3/generated
-# - 3.10/  
+# - 3.10/
 # - 3.9/
 # - 3.8/
 # - 3.7/

--- a/_data/3.10-manual.yml
+++ b/_data/3.10-manual.yml
@@ -65,6 +65,8 @@
               href: programs-arangod-cluster.html
             - text: Database
               href: programs-arangod-database.html
+            - text: Encryption
+              href: programs-arangod-encryption.html
             - text: Foxx
               href: programs-arangod-foxx.html
             - text: Frontend


### PR DESCRIPTION
A new startup option section `encryption` was added in 3.10 ([options diff](https://github.com/arangodb/docs/pull/883/files?file-filters%5B%5D=.json&show-viewed-files=true#diff-babd507fbcb16bf83576bf5d21870cc28bb06577521084a74f79ecb4d99bcb4b))

#883 and #878 fail after re-generating 3.10 examples

Text is taken from existing arangodump / arangorestore descriptions.