### PR TITLE
Oasis: Update permissions, pre-defined roles, and oasisctl docs

### DIFF
--- a/_data/oasis.yml
+++ b/_data/oasis.yml
@@ -268,6 +268,8 @@
           href: oasisctl-list-cpusizes.html
         - text: List Deployments
           href: oasisctl-list-deployments.html
+        - text: List Disk Performances
+          href: oasisctl-list-diskperformances.html
         - text: List Effective
           href: oasisctl-list-effective.html
         - text: List Effective Permissions

--- a/oasis/access-control.md
+++ b/oasis/access-control.md
@@ -108,6 +108,43 @@ The roles below are described following this pattern:
 - `Permission`
 {% endhint %}
 
+**Audit Log Admin** (`auditlog-admin`):
+- `audit.auditlog.list`
+- `audit.auditlog.get`
+- `audit.auditlog.create`
+- `audit.auditlog.delete`
+- `audit.auditlog.set-default`
+- `audit.auditlog.test-https-post-destination`
+- `audit.auditlog.update`
+
+**Audit Log Archive Admin** (`auditlog-archive-admin`):
+- `audit.auditlogarchive.list`
+- `audit.auditlogarchive.get`
+- `audit.auditlogarchive.delete`
+
+**Audit Log Archive Viewer** (`auditlog-archive-viewer`):
+- `audit.auditlogarchive.list`
+- `audit.auditlogarchive.get`
+
+**Audit Log Attachment Admin** (`auditlog-attachment-admin`):
+- `audit.auditlogattachment.get`
+- `audit.auditlogattachment.create`
+- `audit.auditlogattachment.delete`
+
+**Audit Log Attachment Viewer** (`auditlog-attachment-viewer`):
+- `audit.auditlogattachment.get`
+
+**Audit Log Event Admin** (`auditlog-event-admin`):
+- `audit.auditlogevents.get`
+- `audit.auditlogevent.delete`
+
+**Audit Log Event Viewer** (`auditlog-event-viewer`):
+- `audit.auditlogevents.get`
+
+**Audit Log Viewer** (`auditlog-viewer`):
+- `audit.auditlog.list`
+- `audit.auditlog.get`
+
 **Backup Administrator** (`backup-admin`):
 - `backup.backup.create`
 - `backup.backup.delete`
@@ -139,6 +176,7 @@ The roles below are described following this pattern:
 - `billing.config.get`
 - `billing.config.set`
 - `billing.invoice.get`
+- `billing.invoice.get-preliminary`
 - `billing.invoice.get-statistics`
 - `billing.invoice.list`
 - `billing.organization.get`
@@ -154,6 +192,7 @@ The roles below are described following this pattern:
 **Billing Viewer** (`billing-viewer`):
 - `billing.config.get`
 - `billing.invoice.get`
+- `billing.invoice.get-preliminary`
 - `billing.invoice.get-statistics`
 - `billing.invoice.list`
 - `billing.organization.get`
@@ -179,9 +218,11 @@ The roles below are described following this pattern:
 - `data.deployment.create`
 - `data.deployment.create-test-database`
 - `data.deployment.delete`
-- `data.deployment.resume`
 - `data.deployment.get`
 - `data.deployment.list`
+- `data.deployment.resume`
+- `data.deployment.rebalance-shards`
+- `data.deployment.rotate-server`
 - `data.deployment.update`
 - `data.deploymentfeatures.get`
 - `data.deploymentprice.calculate`
@@ -189,6 +230,9 @@ The roles below are described following this pattern:
 - `data.nodesize.list`
 - `data.presets.list`
 - `monitoring.logs.get`
+- `notification.deployment-notification.list`
+- `notification.deployment-notification.mark-as-read`
+- `notification.deployment-notification.mark-as-unread`
 
 **Deployment Content Administrator** (`deployment-content-admin`):
 - `data.cpusize.list`
@@ -197,19 +241,32 @@ The roles below are described following this pattern:
 - `data.deployment.list`
 - `data.deploymentcredentials.get`
 - `data.deploymentfeatures.get`
+- `data.deploymentprice.calculate`
 - `data.limits.get`
 - `data.nodesize.list`
 - `data.presets.list`
 - `monitoring.logs.get`
+
+**Deployment Content Viewer** (`deployment-content-viewer`):
+- `data.deployment.get`
+- `data.deployment.list`
+- `data.deploymentcredentials.get`
+- `data.limits.get`
+- `data.presets.list`
 
 **Deployment Viewer** (`deployment-viewer`):
 - `data.cpusize.list`
 - `data.deployment.get`
 - `data.deployment.list`
 - `data.deploymentfeatures.get`
+- `data.deploymentprice.calculate`
+- `data.diskperformance.list`
 - `data.limits.get`
 - `data.nodesize.list`
 - `data.presets.list`
+- `notification.deployment-notification.list`
+- `notification.deployment-notification.mark-as-read`
+- `notification.deployment-notification.mark-as-unread`
 
 **Example Datasets Viewer** (`exampledataset-viewer`):
 - `example.exampledataset.list`
@@ -249,23 +306,25 @@ The roles below are described following this pattern:
 - `security.iamprovider.get`
 - `security.iamprovider.list`
 
-**IP allowlist Administrator** (`ipallowlist-admin`):
-- `security.ipallowlist.create`
-- `security.ipallowlist.delete`
-- `security.ipallowlist.get`
-- `security.ipallowlist.list`
-- `security.ipallowlist.update`
+**IP allowlist Administrator** (`ipwhitelist-admin`):
 - `security.ipallowlist.create`
 - `security.ipallowlist.delete`
 - `security.ipallowlist.get`
 - `security.ipallowlist.list`
 - `security.ipallowlist.update`
 
-**IP allowlist Viewer** (`ipallowlist-viewer`):
+**IP allowlist Viewer** (`ipwhitelist-viewer`):
 - `security.ipallowlist.get`
 - `security.ipallowlist.list`
-- `security.ipallowlist.get`
-- `security.ipallowlist.list`
+
+**Metrics Administrator** (`metrics-admin`):
+- `metrics.endpoint.get`
+- `metrics.token.create`
+- `metrics.token.delete`
+- `metrics.token.get`
+- `metrics.token.list`
+- `metrics.token.revoke`
+- `metrics.token.update`
 
 **Organization Administrator** (`organization-admin`):
 - `billing.organization.get`
@@ -290,6 +349,22 @@ The roles below are described following this pattern:
 
 **Policy Viewer** (`policy-viewer`):
 - `iam.policy.get`
+
+**Prepaid Deployment Viewer** (`prepaid-deployment-viewer`):
+- `prepaid.prepaiddeployment.get`
+- `prepaid.prepaiddeployment.list`
+
+**Private Endpoint Service Administrator** (`privateendpointservice-admin`):
+- `network.privateendpointservice.create`
+- `network.privateendpointservice.get`
+- `network.privateendpointservice.get-feature`
+- `network.privateendpointservice.get-by-deployment-id`
+- `network.privateendpointservice.update`
+
+**Private Endpoint Service Viewer** (`privateendpointservice-viewer`):
+- `network.privateendpointservice.get`
+- `network.privateendpointservice.get-feature`
+- `network.privateendpointservice.get-by-deployment-id`
 
 **Project Administrator** (`project-admin`):
 - `resourcemanager.project.create`
@@ -348,11 +423,16 @@ Permissions are solely defined by the Oasis API.
 
 | API               | Kind                         | Verbs
 |:------------------|:-----------------------------|:-------------------------------------------
+| `audit`           | `auditlogarchive`            | `delete`, `get`, `list`
+| `audit`           | `auditlogattachment`         | `create`, `delete`, `get`
+| `audit`           | `auditlogevents`             | `get`
+| `audit`           | `auditlogevent`              | `delete`
+| `audit`           | `auditlog`                   | `create`, `delete`, `get`, `list`, `set-default`, `test-https-post-destination`, `update`
 | `backup`          | `backuppolicy`               | `create`, `delete`, `get`, `list`, `update`
 | `backup`          | `backup`                     | `create`, `delete`, `download`, `get`, `list`, `restore`, `update`
 | `backup`          | `feature`                    | `get`
 | `billing`         | `config`                     | `get`, `set`
-| `billing`         | `invoice`                    | `get`, `get-statistics`, `list`
+| `billing`         | `invoice`                    | `get`, `get-preliminary`, `get-statistics`, `list`
 | `billing`         | `organization`               | `get`
 | `billing`         | `paymentmethod`              | `create`, `delete`, `get`, `get-default`, `list`, `set-default`, `update`
 | `billing`         | `paymentprovider`            | `list`
@@ -361,7 +441,8 @@ Permissions are solely defined by the Oasis API.
 | `data`            | `deploymentcredentials`      | `get`
 | `data`            | `deploymentfeatures`         | `get`
 | `data`            | `deploymentprice`            | `calculate`
-| `data`            | `deployment`                 | `create`, `create-test-database`, `delete`, `get`, `list`, `restore-backup`, `resume`, `update`
+| `data`            | `deployment`                 | `create`, `create-test-database`, `delete`, `get`, `list`, `rebalance-shards`, `restore-backup`, `resume`, `rotate-server`, `update`
+| `data`            | `diskperformance`            | `list`
 | `data`            | `limits`                     | `get`
 | `data`            | `nodesize`                   | `list`
 | `data`            | `presets`                    | `list`
@@ -370,7 +451,12 @@ Permissions are solely defined by the Oasis API.
 | `iam`             | `group`                      | `create`, `delete`, `get`, `list`, `update`
 | `iam`             | `policy`                     | `get`, `update`
 | `iam`             | `role`                       | `create`, `delete`, `get`, `list`, `update`
+| `metrics`         | `endpoint`                   | `get`
+| `metrics`         | `token`                      | `create`, `delete`, `get`, `list`, `revoke`, `update`
 | `monitoring`      | `logs`                       | `get`
+| `network`         | `privateendpointservice`     | `create`, `get`, `get-by-deployment-id`, `get-feature`, `update`
+| `notification`    | `deployment-notification`    | `list`, `mark-as-read`, `mark-as-unread`
+| `prepaid`         | `prepaiddeployment`          | `get`, `list`
 | `replication`     | `deployment`                 | `clone-from-backup`
 | `resourcemanager` | `organization-invite`        | `create`, `delete`, `get`, `list`, `update`
 | `resourcemanager` | `organization`               | `delete`, `get`, `update`

--- a/oasis/oasisctl-create-deployment.md
+++ b/oasis/oasisctl-create-deployment.md
@@ -28,6 +28,7 @@ oasisctl create deployment [flags]
       --dbservers int32                      Set number of dbservers for flexible deployments (default 3)
       --description string                   Description of the deployment
       --disable-foxx-authentication          Disable authentication of requests to Foxx application.
+      --disk-performance-id string           Set the disk performance to use for this deployment.
   -h, --help                                 help for deployment
   -i, --ipallowlist-id string                Identifier of the IP allowlist to use for the deployment
       --max-node-disk-size int32             Set maximum disk size for nodes for autoscaler (GB)

--- a/oasis/oasisctl-list.md
+++ b/oasis/oasisctl-list.md
@@ -41,6 +41,7 @@ oasisctl list [flags]
 * [oasisctl list cacertificates](oasisctl-list-cacertificates.html)	 - List all CA certificates of the given project
 * [oasisctl list cpusizes](oasisctl-list-cpusizes.html)	 - List CPU sizes
 * [oasisctl list deployments](oasisctl-list-deployments.html)	 - List all deployments of the given project
+* [oasisctl list diskperformances](oasisctl-list-diskperformances.html)	 - List disk performances
 * [oasisctl list effective](oasisctl-list-effective.html)	 - List effective information
 * [oasisctl list example](oasisctl-list-example.html)	 - List example ...
 * [oasisctl list examples](oasisctl-list-examples.html)	 - List all example datasets

--- a/oasis/oasisctl-update-deployment.md
+++ b/oasis/oasisctl-update-deployment.md
@@ -28,6 +28,7 @@ oasisctl update deployment [flags]
   -d, --deployment-id string                 Identifier of the deployment
       --description string                   Description of the deployment
       --disable-foxx-authentication          Disable authentication of requests to Foxx application.
+      --disk-performance-id string           Set the disk performance to use for this deployment.
   -h, --help                                 help for deployment
   -i, --ipallowlist-id string                Identifier of the IP allowlist to use for the deployment
       --max-node-disk-size int32             Set maximum disk size for nodes for autoscaler (GB)

--- a/oasisctl.rb
+++ b/oasisctl.rb
@@ -13,7 +13,7 @@
 # 1. Remove the generated files from the docs target folder
 #    (oasisctl-*.md but not oasisctl-getting-started.md and oasisctl.md!)
 #
-# 2. Create a temporary folder (oasisctl defaults to ./docs)
+# 2. Create a temporary folder (oasisctl defaults to --output-dir ./docs)
 #
 # 3. Generate the documentation
 #    > oasisctl generate-docs --link-file-ext .html --replace-underscore-with -
@@ -35,6 +35,7 @@ TITLE_CASE = {
     'auditlog' => 'Audit Log',
     'cacertificate' => 'CA Certificate',
     'cacertificates' => 'CA Certificates',
+    'diskperformances' => 'Disk Performances',
     'ipallowlist' => 'IP Allowlist',
     'ipallowlists' => 'IP Allowlists',
     'tandc' => 'Terms & Conditions',


### PR DESCRIPTION
`oasisctl list roles` lists `ipwhitelist-admin` - wasn't this role renamed to `ipallowlist-admin`?