### PR TITLE
optionally use range delete markers in WAL for truncates

### DIFF
--- a/3.10/programs-arangod-rocksdb.md
+++ b/3.10/programs-arangod-rocksdb.md
@@ -258,6 +258,27 @@ If true, skip corrupted records in WAL recovery. Default: false.
 
 ### Write-ahead Log
 
+<small>Introduced in: v3.10.0</small>
+
+`--rocksdb.use-range-delete-in-wal`
+
+Controls whether the collection truncate operation in the cluster can use 
+RangeDelete operations in RocksDB. Using RangeDeletes is fast and reduces
+the algorithmic complexity of the truncate operation to O(1), compared to
+O(n) for when this option is turned off (with n being the number of
+documents in the collection/shard).
+Previous versions of ArangoDB used RangeDeletes only on single server, but
+never in cluster. 
+
+The default value for this startup option is `true`, and the option should
+only be changed in case of emergency. This option is only honored in the
+cluster. Single server and active failover deployments will use RangeDeletes
+regardless of the value of this option.
+
+Note that it is not guaranteed that all truncate operations will use a 
+RangeDelete operation. For collections containing a low number of documents,
+the O(n) truncate method may still be used.
+
 `--rocksdb.wal-file-timeout`
 
 Timeout after which unused WAL files are deleted (in seconds). Default: 10.0s.

--- a/3.10/programs-arangod-rocksdb.md
+++ b/3.10/programs-arangod-rocksdb.md
@@ -267,8 +267,8 @@ RangeDelete operations in RocksDB. Using RangeDeletes is fast and reduces
 the algorithmic complexity of the truncate operation to O(1), compared to
 O(n) for when this option is turned off (with n being the number of
 documents in the collection/shard).
-Previous versions of ArangoDB used RangeDeletes only on single server, but
-never in cluster. 
+Previous versions of ArangoDB used RangeDeletes only on a single server, but
+never in a cluster. 
 
 The default value for this startup option is `true`, and the option should
 only be changed in case of emergency. This option is only honored in the

--- a/3.10/release-notes-api-changes310.md
+++ b/3.10/release-notes-api-changes310.md
@@ -27,8 +27,8 @@ For the metrics APIs at `/_admin/metrics` and `/_admin/metrics/v2`, unnecessary 
 
 APIs that return data from ArangoDB's write-ahead log (WAL) may now return
 collection truncate markers in the cluster, too. Previously such truncate
-markers were only issued in single server and active failover mode, but not
-in cluster. Client applications that tail ArangoDB's WAL are thus supposed
+markers were only issued in the single server and active failover modes, but not
+in a cluster. Client applications that tail ArangoDB's WAL are thus supposed
 to handle WAL markers of type `2004`.
 
 The following HTTP APIs are affected:

--- a/3.10/release-notes-api-changes310.md
+++ b/3.10/release-notes-api-changes310.md
@@ -25,6 +25,16 @@ For the metrics APIs at `/_admin/metrics` and `/_admin/metrics/v2`, unnecessary 
 
 ### Endpoints augmented
 
+APIs that return data from ArangoDB's write-ahead log (WAL) may now return
+collection truncate markers in the cluster, too. Previously such truncate
+markers were only issued in single server and active failover mode, but not
+in cluster. Client applications that tail ArangoDB's WAL are thus supposed
+to handle WAL markers of type `2004`.
+
+The following HTTP APIs are affected:
+* `/_api/wal/tail`
+* `/_api/replication/logger-follow`
+
 #### Cursor API
 
 The cursor API can now return two additional statistics values in its `stats` subattribute:

--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -173,6 +173,21 @@ It is possible to opt out of these changes and get back the memory and performan
 of previous versions by setting the `--rocksdb.cache-index-and-filter-blocks` 
 and `--rocksdb.enforce-block-cache-size-limit` startup options to `false` on startup.
 
+The new startup option `--rocksdb.use-range-delete-in-wal` controls whether the collection 
+truncate operation in the cluster can use RangeDelete operations in RocksDB. Using RangeDeletes
+s fast and reduces the algorithmic complexity of the truncate operation to O(1), compared to
+O(n) for when this option is turned off (with n being the number of documents in the 
+collection/shard).
+Previous versions of ArangoDB used RangeDeletes only on single server, but never in cluster. 
+
+The default value for this startup option is `true`, and the option should only be changed in
+case of emergency. This option is only honored in the cluster. Single server and active failover
+deployments will use RangeDeletes regardless of the value of this option.
+
+Note that it is not guaranteed that all truncate operations will use a RangeDelete operation. 
+For collections containing a low number of documents, the O(n) truncate method may still be used.
+
+
 Miscellaneous changes
 ---------------------
 

--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -173,12 +173,12 @@ It is possible to opt out of these changes and get back the memory and performan
 of previous versions by setting the `--rocksdb.cache-index-and-filter-blocks` 
 and `--rocksdb.enforce-block-cache-size-limit` startup options to `false` on startup.
 
-The new startup option `--rocksdb.use-range-delete-in-wal` controls whether the collection 
-truncate operation in the cluster can use RangeDelete operations in RocksDB. Using RangeDeletes
-s fast and reduces the algorithmic complexity of the truncate operation to O(1), compared to
-O(n) for when this option is turned off (with n being the number of documents in the 
+The new `--rocksdb.use-range-delete-in-wal` startup option controls whether the collection 
+truncate operation in a cluster can use RangeDelete operations in RocksDB. Using RangeDeletes
+is fast and reduces the algorithmic complexity of the truncate operation to O(1), compared to
+O(n) when this option is turned off (with n being the number of documents in the 
 collection/shard).
-Previous versions of ArangoDB used RangeDeletes only on single server, but never in cluster. 
+Previous versions of ArangoDB used RangeDeletes only on a single server, but never in a cluster. 
 
 The default value for this startup option is `true`, and the option should only be changed in
 case of emergency. This option is only honored in the cluster. Single server and active failover


### PR DESCRIPTION
Docs PR for https://github.com/arangodb/arangodb/pull/15791
Enable truncate WAL markers in the cluster too. This can speed up truncate operations for large collections/shards.
The newest version of arangosync can now handle truncate markers, so it is safe to activate truncate markers on the arangod side as well.
There is a feature toggle `--rocksdb.use-range-delete-in-wal` to turn off the usage of truncate markers in case of emergency.