### PR TITLE
AQL: k Paths recognizes pseudo-keyword TO

### DIFF
--- a/3.10/aql/fundamentals-syntax.md
+++ b/3.10/aql/fundamentals-syntax.md
@@ -175,7 +175,8 @@ based on the context:
   [SEARCH](operations-search.html) operation
 - `TO` –
   [Shortest Path](graphs-shortest-path.html) /
-  [k Shortest Paths](graphs-kshortest-paths.html) graph traversal
+  [k Shortest Paths](graphs-kshortest-paths.html) /
+  [k Paths](graphs-k-paths.html) graph traversal
 
 Last but not least, there are special variables which are available in certain
 contexts. Unlike keywords, they are **case-sensitive**:

--- a/3.8/aql/fundamentals-syntax.md
+++ b/3.8/aql/fundamentals-syntax.md
@@ -175,7 +175,8 @@ based on the context:
   [SEARCH](operations-search.html) operation
 - `TO` –
   [Shortest Path](graphs-shortest-path.html) /
-  [k Shortest Paths](graphs-kshortest-paths.html) graph traversal
+  [k Shortest Paths](graphs-kshortest-paths.html) /
+  [k Paths](graphs-k-paths.html) graph traversal
 
 Last but not least, there are special variables which are available in certain
 contexts. Unlike keywords, they are **case-sensitive**:

--- a/3.9/aql/fundamentals-syntax.md
+++ b/3.9/aql/fundamentals-syntax.md
@@ -175,7 +175,8 @@ based on the context:
   [SEARCH](operations-search.html) operation
 - `TO` –
   [Shortest Path](graphs-shortest-path.html) /
-  [k Shortest Paths](graphs-kshortest-paths.html) graph traversal
+  [k Shortest Paths](graphs-kshortest-paths.html) /
+  [k Paths](graphs-k-paths.html) graph traversal
 
 Last but not least, there are special variables which are available in certain
 contexts. Unlike keywords, they are **case-sensitive**:


### PR DESCRIPTION
I also noticed that SEARCH is listed as high-level operation and we state that all of them would be reserved keywords, but this is contradicted by the list of non-reserved pseudo-keyword that includes SEARCH. Shall I add a remark?