### PR TITLE
BTS-746 | Patch out fragment identifiers in HTTP API endpoints

### DIFF
--- a/_plugins/DocuBlockTag.rb
+++ b/_plugins/DocuBlockTag.rb
@@ -131,7 +131,7 @@ class DocuBlockBlock < Liquid::Tag
                         Jekyll.logger.debug "Missing @startDocuBlock #{line}. Ignoring"
                     end
                 when /^@RESTHEADER\s*{([^,]+),\s*([^,\}]+)/
-                    local["header"] = "### #{$2}\n#{local['header']}\n`#{$1}`\n"
+                    local["header"] = "### #{$2}\n#{local['header']}\n`#{$1.sub(/#[^?]*/, "")}`\n"
                 when /^@RESTDESCRIPTION/
                     currentObject = local
                     currentKey = "description"


### PR DESCRIPTION
We use them to describe polymorphic endpoints. Swagger uses paths as attribute keys, which thus needs to be unique:

```json
"paths": {
    "/_api/index#persistent": { "post": { ... } },
    "/_api/index#ttl": { "post": { ... } },
    ...
}
```

Fragments allow us to have the same path multiple times, each with a different description for a specific index type, but they are not supposed to be used in requests.

It is easy to remove fragments in the docs generation. In Swagger UI, it is not. The internal data structure follows the spec and uses paths as keys. Therefore, removing fragments early when the spec is loaded is not possible. Removing them late would need to be done in many places, resulting in a very messy workaround. I couldn't make "Try out" requests work so far and Anastasia and I agree that it's not worth any more trouble.

Before: https://www.arangodb.com/docs/stable/http/indexes-persistent.html
After: https://deploy-preview-952--zealous-morse-14392b.netlify.app/docs/3.9/http/indexes-persistent.html