### PR TITLE
Allow more examples to be generated on Windows

### DIFF
--- a/3.10/analyzers.md
+++ b/3.10/analyzers.md
@@ -964,12 +964,13 @@ Create and use a `classification` Analyzer with a stored "cooking" classifier to
 @EXAMPLE_ARANGOSH_RUN{ClassificationAnalyzerModelSetup}
 var fs = require("fs");
 var internal = require("internal");
+var tmpPath = fs.getTempPath();
 try {
-    fs.makeDirectory("/tmp/embeddingsModels");
+    fs.makeDirectory(fs.join(tmpPath, "embeddingsModels"));
 } catch (e) {
 }
 
-var destModelPath = "/tmp/embeddingsModels/model_cooking.bin";
+var destModelPath = fs.join(tmpPath, "embeddingsModels", "model_cooking.bin");
 if (!fs.exists(destModelPath)) {
     var sourceModelPath = fs.join(internal.pathForTesting("common"), "aql", "iresearch", "model_cooking.bin");
     try {
@@ -980,8 +981,10 @@ if (!fs.exists(destModelPath)) {
 
 @EXAMPLE_ARANGOSH_OUTPUT{analyzerClassification}
 var analyzers = require("@arangodb/analyzers");
-var classifier_single = analyzers.save("classifier_single", "classification", { "model_location": "/tmp/embeddingsModels/model_cooking.bin" }, []);
-var classifier_top_two = analyzers.save("classifier_double", "classification", { "model_location": "/tmp/embeddingsModels/model_cooking.bin", "top_k": 2 }, []);
+var fs = require("fs");
+var tmpPath = fs.getTempPath();
+var classifier_single = analyzers.save("classifier_single", "classification", { "model_location": fs.join(tmpPath, "embeddingsModels", "model_cooking.bin") }, []);
+var classifier_top_two = analyzers.save("classifier_double", "classification", { "model_location": fs.join(tmpPath, "embeddingsModels", "model_cooking.bin"), "top_k": 2 }, []);
 | db._query(`LET str = 'Which baking dish is best to bake a banana bread ?'
 |   RETURN {
 |     "all": TOKENS(str, 'classifier_single'),
@@ -1021,14 +1024,15 @@ Create and use a `nearest_neighbors` Analyzer with a stored "cooking" classifier
 {% arangoshexample examplevar="examplevar" script="script" result="result" %}
 @startDocuBlockInline analyzerNearestNeighbors
 @EXAMPLE_ARANGOSH_RUN{NNAnalyzerModelSetup}
-var fs = require("fs");
 var internal = require("internal");
+var fs = require("fs");
+var tmpPath = fs.getTempPath();
 try {
-    fs.makeDirectory("/tmp/embeddingsModels");
+    fs.makeDirectory(fs.join(tmpPath, "embeddingsModels"));
 } catch (e) {
 }
 
-var destModelPath = "/tmp/embeddingsModels/model_cooking.bin";
+var destModelPath = fs.join(tmpPath, "embeddingsModels", "model_cooking.bin");
 if (!fs.exists(destModelPath)) {
     var sourceModelPath = fs.join(internal.pathForTesting("common"), "aql", "iresearch", "model_cooking.bin");
     try {
@@ -1039,8 +1043,10 @@ if (!fs.exists(destModelPath)) {
 
 @EXAMPLE_ARANGOSH_OUTPUT{analyzerNearestNeighbors}
 var analyzers = require("@arangodb/analyzers");
-var nn_single = analyzers.save("nn_single", "nearest_neighbors", { "model_location": "/tmp/embeddingsModels/model_cooking.bin" }, []);
-var nn_top_two = analyzers.save("nn_double", "nearest_neighbors", { "model_location": "/tmp/embeddingsModels/model_cooking.bin", "top_k": 2 }, []);
+var fs = require("fs");
+var tmpPath = fs.getTempPath();
+var nn_single = analyzers.save("nn_single", "nearest_neighbors", { "model_location": fs.join(tmpPath, "embeddingsModels", "model_cooking.bin") }, []);
+var nn_top_two = analyzers.save("nn_double", "nearest_neighbors", { "model_location": fs.join(tmpPath, "embeddingsModels", "model_cooking.bin"), "top_k": 2 }, []);
 | db._query(`LET str = 'salt and oil'
 |   RETURN {
 |     "all": TOKENS(str, 'nn_single'),

--- a/3.10/aql/execution-and-performance-explaining-queries.md
+++ b/3.10/aql/execution-and-performance-explaining-queries.md
@@ -214,7 +214,7 @@ The command will store all data in a file with a configurable filename:
     @startDocuBlockInline 10_workWithAQL_debugging1
     @EXAMPLE_ARANGOSH_OUTPUT{10_workWithAQL_debugging1}
     var query = "FOR doc IN mycollection FILTER doc.value > 42 RETURN doc";
-    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query);
+    require("@arangodb/aql/explainer").debugDump(fs.join(fs.getTempPath(), "query-debug-info"), query);
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock 10_workWithAQL_debugging1
 {% endarangoshexample %}
@@ -231,7 +231,7 @@ string:
     @EXAMPLE_ARANGOSH_OUTPUT{10_workWithAQL_debugging2}
     var query = "FOR doc IN @@collection FILTER doc.value > @value RETURN doc";
     var bind = { value: 42, "@collection": "mycollection" };
-    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query, bind);
+    require("@arangodb/aql/explainer").debugDump(fs.join(fs.getTempPath(), "query-debug-info"), query, bind);
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock 10_workWithAQL_debugging2
 {% endarangoshexample %}
@@ -252,7 +252,7 @@ queries:
     var query = "FOR doc IN @@collection FILTER doc.value > @value RETURN doc";
     var bind = { value: 42, "@collection": "mycollection" };
     var options = { examples: 10, anonymize: true };
-    require("@arangodb/aql/explainer").debugDump("/tmp/query-debug-info", query, bind, options);
+    require("@arangodb/aql/explainer").debugDump(fs.join(fs.getTempPath(), "query-debug-info"), query, bind, options);
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock 10_workWithAQL_debugging3
 {% endarangoshexample %}


### PR DESCRIPTION
- Make file paths OS-agnostic
- `fs` is available by default in example generation but not regular arangosh. A proper example should include `var fs = require("fs");` because that's what a user would need to run, but it actually unsets the global fs variable (because of JS weirdness?), leading to errors. Rename the variable name in the tooling? Or not polute the global scope in general?
  https://github.com/arangodb/arangodb/blob/devel/Documentation/Scripts/exampleHeader.js
  Every accidental name collision may cause trouble. Helper functions do need to be available, however. Unsure whether side-effects are a necessity or if `eval()` could be sandboxed with an IIFE...
  Do any existing examples need a `require("fs")` if we remove `fs` from the global scope?
- Hot backup-related examples can't be fixed as they fail because the feature isn't available on Windows