### PR TITLE
Add unit to lockTimeout option (seconds)

### DIFF
--- a/3.10/transactions-transaction-invocation.md
+++ b/3.10/transactions-transaction-invocation.md
@@ -59,7 +59,7 @@ Executes a server-side transaction, as specified by *object*.
 Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
-- *lockTimeout*: a numeric value that can be used to set a timeout for
+- *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
   waiting on collection locks. If not specified, a default value will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->

--- a/3.10/transactions-transaction-invocation.md
+++ b/3.10/transactions-transaction-invocation.md
@@ -60,7 +60,8 @@ Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
 - *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
-  waiting on collection locks. If not specified, a default value will be
+  waiting on collection locks. This option is only meaningful when using
+  exclusive locks. If not specified, a default value of 900 seconds will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->
 - *params*: optional arguments passed to the function specified in

--- a/3.7/transactions-transaction-invocation.md
+++ b/3.7/transactions-transaction-invocation.md
@@ -59,7 +59,7 @@ Executes a server-side transaction, as specified by *object*.
 Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
-- *lockTimeout*: a numeric value that can be used to set a timeout for
+- *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
   waiting on collection locks. If not specified, a default value will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->

--- a/3.7/transactions-transaction-invocation.md
+++ b/3.7/transactions-transaction-invocation.md
@@ -60,7 +60,8 @@ Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
 - *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
-  waiting on collection locks. If not specified, a default value will be
+  waiting on collection locks. This option is only meaningful when using
+  exclusive locks. If not specified, a default value of 900 seconds will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->
 - *params*: optional arguments passed to the function specified in

--- a/3.8/transactions-transaction-invocation.md
+++ b/3.8/transactions-transaction-invocation.md
@@ -59,7 +59,7 @@ Executes a server-side transaction, as specified by *object*.
 Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
-- *lockTimeout*: a numeric value that can be used to set a timeout for
+- *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
   waiting on collection locks. If not specified, a default value will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->

--- a/3.8/transactions-transaction-invocation.md
+++ b/3.8/transactions-transaction-invocation.md
@@ -60,7 +60,8 @@ Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
 - *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
-  waiting on collection locks. If not specified, a default value will be
+  waiting on collection locks. This option is only meaningful when using
+  exclusive locks. If not specified, a default value of 900 seconds will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->
 - *params*: optional arguments passed to the function specified in

--- a/3.9/transactions-transaction-invocation.md
+++ b/3.9/transactions-transaction-invocation.md
@@ -59,7 +59,7 @@ Executes a server-side transaction, as specified by *object*.
 Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
-- *lockTimeout*: a numeric value that can be used to set a timeout for
+- *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
   waiting on collection locks. If not specified, a default value will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->

--- a/3.9/transactions-transaction-invocation.md
+++ b/3.9/transactions-transaction-invocation.md
@@ -60,7 +60,8 @@ Additionally, *object* can have the following optional attributes:
 - *waitForSync*: boolean flag indicating whether the transaction
   is forced to be synchronous. <!-- TODO: obsolete? -->
 - *lockTimeout*: a numeric value that can be used to set a timeout in seconds for
-  waiting on collection locks. If not specified, a default value will be
+  waiting on collection locks. This option is only meaningful when using
+  exclusive locks. If not specified, a default value of 900 seconds will be
   used. Setting *lockTimeout* to *0* will make ArangoDB not time
   out waiting for a lock. <!-- TODO: obsolete? -->
 - *params*: optional arguments passed to the function specified in


### PR DESCRIPTION
Missing unit reported in #938

Upstream: https://github.com/arangodb/arangodb/pull/16001