### PR TITLE
TTL index expects Unix timestamp in seconds

### DIFF
--- a/3.10/indexing-index-basics.md
+++ b/3.10/indexing-index-basics.md
@@ -279,8 +279,8 @@ Please note that the numeric date time values for the index attribute has to be
 specified **in seconds** since January 1st 1970 (Unix timestamp). To calculate the current 
 timestamp from JavaScript in this format, there is `Date.now() / 1000`; to calculate it
 from an arbitrary Date instance, there is `Date.getTime() / 1000`. In AQL you can do
-`DATE_NOW() / 1000` or divide an arbitrary Unix timestamp in milliseconds by 1000 to
-convert it to seconds.
+`DATE_NOW() / 1000` or divide an arbitrary timestamp that is in milliseconds
+by 1000 to convert it to seconds.
 
 Alternatively, the index attribute values can be specified as a date string in format
 `YYYY-MM-DDTHH:MM:SS`, optionally with milliseconds after a decimal point in the

--- a/3.10/indexing-ttl.md
+++ b/3.10/indexing-ttl.md
@@ -95,7 +95,7 @@ expiration dates differently in the client application.
 ### Format of date/time values
 
 The expiration date time values can be specified either as a numeric timestamp, containing
-the number of milliseconds since January 1st 1970 (commonly referred to as Unix timestamp), 
+the number of seconds since January 1st 1970 (commonly referred to as Unix timestamp),
 or as a date/time string in ISO 8601 format `YYYY-MM-DDTHH:MM:SS`, with optional millisecond 
 precision and an optional timezone offset. The timezone offset can be specified as either 
 `Z` (Zulu/UTC time) or as a deviation from UTC time in hours and minutes (i.e. `+HH:MM` or `-HH:MM`).
@@ -116,7 +116,7 @@ from being inserted into the TTL index, so it will neither be expired nor remove
 No error is raised however.
 
 Please note that date string values can be programmatically validated using the AQL function 
-`IS_DATESTRING`.
+`IS_DATESTRING()`.
 
 ### Preventing documents from being removed
 

--- a/3.7/indexing-index-basics.md
+++ b/3.7/indexing-index-basics.md
@@ -341,8 +341,8 @@ Please note that the numeric date time values for the index attribute has to be
 specified **in seconds** since January 1st 1970 (Unix timestamp). To calculate the current 
 timestamp from JavaScript in this format, there is `Date.now() / 1000`; to calculate it
 from an arbitrary Date instance, there is `Date.getTime() / 1000`. In AQL you can do
-`DATE_NOW() / 1000` or divide an arbitrary Unix timestamp in milliseconds by 1000 to
-convert it to seconds.
+`DATE_NOW() / 1000` or divide an arbitrary timestamp that is in milliseconds
+by 1000 to convert it to seconds.
 
 Alternatively, the index attribute values can be specified as a date string in format
 `YYYY-MM-DDTHH:MM:SS`, optionally with milliseconds after a decimal point in the

--- a/3.7/indexing-ttl.md
+++ b/3.7/indexing-ttl.md
@@ -95,7 +95,7 @@ expiration dates differently in the client application.
 ### Format of date/time values
 
 The expiration date time values can be specified either as a numeric timestamp, containing
-the number of milliseconds since January 1st 1970 (commonly referred to as Unix timestamp), 
+the number of seconds since January 1st 1970 (commonly referred to as Unix timestamp),
 or as a date/time string in ISO 8601 format `YYYY-MM-DDTHH:MM:SS`, with optional millisecond 
 precision and an optional timezone offset. The timezone offset can be specified as either 
 `Z` (Zulu/UTC time) or as a deviation from UTC time in hours and minutes (i.e. `+HH:MM` or `-HH:MM`).

--- a/3.7/indexing-ttl.md
+++ b/3.7/indexing-ttl.md
@@ -116,7 +116,7 @@ from being inserted into the TTL index, so it will neither be expired nor remove
 No error is raised however.
 
 Please note that date string values can be programmatically validated using the AQL function 
-`IS_DATESTRING`.
+`IS_DATESTRING()`.
 
 ### Preventing documents from being removed
 

--- a/3.8/indexing-index-basics.md
+++ b/3.8/indexing-index-basics.md
@@ -341,8 +341,8 @@ Please note that the numeric date time values for the index attribute has to be
 specified **in seconds** since January 1st 1970 (Unix timestamp). To calculate the current 
 timestamp from JavaScript in this format, there is `Date.now() / 1000`; to calculate it
 from an arbitrary Date instance, there is `Date.getTime() / 1000`. In AQL you can do
-`DATE_NOW() / 1000` or divide an arbitrary Unix timestamp in milliseconds by 1000 to
-convert it to seconds.
+`DATE_NOW() / 1000` or divide an arbitrary timestamp that is in milliseconds
+by 1000 to convert it to seconds.
 
 Alternatively, the index attribute values can be specified as a date string in format
 `YYYY-MM-DDTHH:MM:SS`, optionally with milliseconds after a decimal point in the

--- a/3.8/indexing-ttl.md
+++ b/3.8/indexing-ttl.md
@@ -95,7 +95,7 @@ expiration dates differently in the client application.
 ### Format of date/time values
 
 The expiration date time values can be specified either as a numeric timestamp, containing
-the number of milliseconds since January 1st 1970 (commonly referred to as Unix timestamp), 
+the number of seconds since January 1st 1970 (commonly referred to as Unix timestamp),
 or as a date/time string in ISO 8601 format `YYYY-MM-DDTHH:MM:SS`, with optional millisecond 
 precision and an optional timezone offset. The timezone offset can be specified as either 
 `Z` (Zulu/UTC time) or as a deviation from UTC time in hours and minutes (i.e. `+HH:MM` or `-HH:MM`).

--- a/3.8/indexing-ttl.md
+++ b/3.8/indexing-ttl.md
@@ -116,7 +116,7 @@ from being inserted into the TTL index, so it will neither be expired nor remove
 No error is raised however.
 
 Please note that date string values can be programmatically validated using the AQL function 
-`IS_DATESTRING`.
+`IS_DATESTRING()`.
 
 ### Preventing documents from being removed
 

--- a/3.9/indexing-index-basics.md
+++ b/3.9/indexing-index-basics.md
@@ -279,8 +279,8 @@ Please note that the numeric date time values for the index attribute has to be
 specified **in seconds** since January 1st 1970 (Unix timestamp). To calculate the current 
 timestamp from JavaScript in this format, there is `Date.now() / 1000`; to calculate it
 from an arbitrary Date instance, there is `Date.getTime() / 1000`. In AQL you can do
-`DATE_NOW() / 1000` or divide an arbitrary Unix timestamp in milliseconds by 1000 to
-convert it to seconds.
+`DATE_NOW() / 1000` or divide an arbitrary timestamp that is in milliseconds
+by 1000 to convert it to seconds.
 
 Alternatively, the index attribute values can be specified as a date string in format
 `YYYY-MM-DDTHH:MM:SS`, optionally with milliseconds after a decimal point in the

--- a/3.9/indexing-ttl.md
+++ b/3.9/indexing-ttl.md
@@ -95,7 +95,7 @@ expiration dates differently in the client application.
 ### Format of date/time values
 
 The expiration date time values can be specified either as a numeric timestamp, containing
-the number of milliseconds since January 1st 1970 (commonly referred to as Unix timestamp), 
+the number of seconds since January 1st 1970 (commonly referred to as Unix timestamp),
 or as a date/time string in ISO 8601 format `YYYY-MM-DDTHH:MM:SS`, with optional millisecond 
 precision and an optional timezone offset. The timezone offset can be specified as either 
 `Z` (Zulu/UTC time) or as a deviation from UTC time in hours and minutes (i.e. `+HH:MM` or `-HH:MM`).

--- a/3.9/indexing-ttl.md
+++ b/3.9/indexing-ttl.md
@@ -116,7 +116,7 @@ from being inserted into the TTL index, so it will neither be expired nor remove
 No error is raised however.
 
 Please note that date string values can be programmatically validated using the AQL function 
-`IS_DATESTRING`.
+`IS_DATESTRING()`.
 
 ### Preventing documents from being removed
 


### PR DESCRIPTION
Corrects a statement that timestamps would be expected in milliseconds. Found by @solisoft