### PR TITLE
Report true referencing DocuBlock when missing a struct

### DIFF
--- a/_plugins/DocuBlockTag.rb
+++ b/_plugins/DocuBlockTag.rb
@@ -24,7 +24,7 @@ class DocuBlockBlock < Liquid::Tag
         content
     end
 
-    def get_struct(struct, blocks, level, parentKey, omitNecessity=false)
+    def get_struct(struct, blocks, rootBlockName, level, parentKey, omitNecessity=false)
         result = ""
         if blocks[struct]
             blocks[struct].each do |name, description|
@@ -44,12 +44,12 @@ class DocuBlockBlock < Liquid::Tag
                     end
                 end
                 if description["struct"]
-                    result += get_struct(description["struct"], blocks, level + 1, name, omitNecessity)
+                    result += get_struct(description["struct"], blocks, rootBlockName, level + 1, name, omitNecessity)
                 end
             end
         else
             unless blocks[:isVersionDeprecated]
-                Jekyll.logger.error "Missing struct '#{struct}', referenced by '#{parentKey}' in DocuBlock '#{@blockname}', version #{blocks[:version]}"
+                Jekyll.logger.error "Missing struct '#{struct}', referenced by '#{parentKey}' in DocuBlock '#{rootBlockName}', version #{blocks[:version]}"
             end
         end
         result
@@ -108,7 +108,7 @@ class DocuBlockBlock < Liquid::Tag
                     end
                 end
                 if value["struct"]
-                    result += get_struct(value["struct"], blocks, level + 1, key)
+                    result += get_struct(value["struct"], blocks, block["name"], level + 1, key)
                 end
             end
         end
@@ -138,7 +138,7 @@ class DocuBlockBlock < Liquid::Tag
                             end
                         end
                         if value["struct"]
-                            result += get_struct(value["struct"], blocks, level + 1, key, true)
+                            result += get_struct(value["struct"], blocks, block["name"], level + 1, key, true)
                         end
                     end
                 end


### PR DESCRIPTION
Fixes the error messages like the following:
https://app.netlify.com/sites/zealous-morse-14392b/deploys/6261204442c805000846bbb8#L121-L178

The shared structs are missing for 3.9, will re-generate them.