### PR TITLE
Add note about non-root users

### DIFF
--- a/oasis/getting-started.md
+++ b/oasis/getting-started.md
@@ -98,7 +98,7 @@ used for multiple accounts.
    (user `root` and its password) and log in.
    
    {% hint 'info' %}
-   It is highly recommended to create additional users and not use the `root` user for everyday operations.
+   It is highly recommended to create additional users and not use the `root` user for everyday operations. See [Managing Users in the Web Interface](3.9/programs-web-interface-users.html) for more details.
    {% endhint %}
 
 5. You can install example datasets and follow the accompanying guides to get

--- a/oasis/getting-started.md
+++ b/oasis/getting-started.md
@@ -98,7 +98,7 @@ used for multiple accounts.
    (user `root` and its password) and log in.
    
    {% hint 'info' %}
-   It is highly recommended to create additional users and not use the `root` user for everyday operations. See [Managing Users in the Web Interface](3.9/programs-web-interface-users.html) for more details.
+   It is highly recommended to create additional users and not use the `root` user for everyday operations. See [Managing Users in the Web Interface](../programs-web-interface-users.html) for more details.
    {% endhint %}
 
 5. You can install example datasets and follow the accompanying guides to get

--- a/oasis/getting-started.md
+++ b/oasis/getting-started.md
@@ -97,7 +97,7 @@ used for multiple accounts.
    button to bring up the ArangoDB web interface. Enter the credentials
    (user `root` and its password) and log in.
    
-   {% hint 'info' %}
+   {% hint 'security' %}
    It is highly recommended to create additional users and not use the `root` user for everyday operations.
    See [Managing Users in the Web Interface](../programs-web-interface-users.html) for more details.
    {% endhint %}

--- a/oasis/getting-started.md
+++ b/oasis/getting-started.md
@@ -96,6 +96,10 @@ used for multiple accounts.
    button below the label __ROOT PASSWORD__. Then click the __Open endpoint__
    button to bring up the ArangoDB web interface. Enter the credentials
    (user `root` and its password) and log in.
+   
+   {% hint 'info' %}
+   It is highly recommended to create additional users and not use the `root` user for everyday operations.
+   {% endhint %}
 
 5. You can install example datasets and follow the accompanying guides to get
    started with ArangoDB and its query language. In the Oasis dashboard, click

--- a/oasis/getting-started.md
+++ b/oasis/getting-started.md
@@ -98,7 +98,8 @@ used for multiple accounts.
    (user `root` and its password) and log in.
    
    {% hint 'info' %}
-   It is highly recommended to create additional users and not use the `root` user for everyday operations. See [Managing Users in the Web Interface](../programs-web-interface-users.html) for more details.
+   It is highly recommended to create additional users and not use the `root` user for everyday operations.
+   See [Managing Users in the Web Interface](../programs-web-interface-users.html) for more details.
    {% endhint %}
 
 5. You can install example datasets and follow the accompanying guides to get


### PR DESCRIPTION
Added a note about creating non-root users in the Getting Started with Oasis.
In the Oasis manual, the [Users](https://www.arangodb.com/docs/stable/oasis/users.html) chapter has no info about creating/managing users in ArangoDB Web Interface. We could refer to [this page](https://www.arangodb.com/docs/3.9/programs-web-interface-users.html) for more details.