### PR TITLE
Update Reduce Memory Footprint tutorial

### DIFF
--- a/3.10/tutorials-reduce-memory-footprint.md
+++ b/3.10/tutorials-reduce-memory-footprint.md
@@ -116,17 +116,20 @@ Also see:
 - [RocksDB Server Options](programs-arangod-options.html#rocksdb)
 - [Write Buffer Manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager){:target="_blank"}
 
-Edge-Cache
-----------
+Index Caches
+------------
 
 ```
---cache.size 10485760
+--cache.size 0
 ```
 
-This option limits the ArangoDB edge [cache](programs-arangod-cache.html) to 10
-MB. If you do not have a graph use-case and do not use edge collections, it is
-possible to use the minimum without a performance impact. In general, this
-should correspond to the size of the hot-set of edges.
+This option disables the in-memory index [caches](programs-arangod-cache.html).
+In versions before v3.9.2, you can limit the size to a minimum of `10485760` (10 MB).
+
+If you do not have a graph use case and do not use edge collections, nor the optional
+hash cache for persistent indexes, it is possible to use no cache (or a minimal cache size)
+without a performance impact. In general, this should correspond to the size of the hot-set
+of edges and cached lookups from persistent indexes.
 
 AQL Query Memory Usage
 ----------------------

--- a/3.10/tutorials-reduce-memory-footprint.md
+++ b/3.10/tutorials-reduce-memory-footprint.md
@@ -124,7 +124,7 @@ Index Caches
 ```
 
 This option disables the in-memory index [caches](programs-arangod-cache.html).
-In versions before v3.9.2, you can limit the size to a minimum of `10485760` (10 MB).
+In versions before v3.9.2, you can limit the size to a minimum of `1048576` (1 MB).
 
 If you do not have a graph use case and do not use edge collections, nor the optional
 hash cache for persistent indexes, it is possible to use no cache (or a minimal cache size)

--- a/3.9/tutorials-reduce-memory-footprint.md
+++ b/3.9/tutorials-reduce-memory-footprint.md
@@ -120,13 +120,15 @@ Edge-Cache
 ----------
 
 ```
---cache.size 10485760
+--cache.size 0
 ```
 
-This option limits the ArangoDB edge [cache](programs-arangod-cache.html) to 10
-MB. If you do not have a graph use-case and do not use edge collections, it is
-possible to use the minimum without a performance impact. In general, this
-should correspond to the size of the hot-set of edges.
+This option disables the ArangoDB edge [cache](programs-arangod-cache.html).
+In versions before v3.9.2, you can limit the size to a minimum of 10485760 (10 MB).
+
+If you do not have a graph use-case and do not use edge collections, it is
+possible to use a minimal cache size or no edge cache at all without a performance
+impact. In general, this should correspond to the size of the hot-set of edges.
 
 AQL Query Memory Usage
 ----------------------

--- a/3.9/tutorials-reduce-memory-footprint.md
+++ b/3.9/tutorials-reduce-memory-footprint.md
@@ -124,7 +124,7 @@ Edge Cache
 ```
 
 This option disables the ArangoDB edge [cache](programs-arangod-cache.html).
-In versions before v3.9.2, you can limit the size to a minimum of `10485760` (10 MB).
+In versions before v3.9.2, you can limit the size to a minimum of `1048576` (1 MB).
 
 If you do not have a graph use case and do not use edge collections, it is
 possible to use no edge cache (or a minimal cache size) without a performance

--- a/3.9/tutorials-reduce-memory-footprint.md
+++ b/3.9/tutorials-reduce-memory-footprint.md
@@ -116,7 +116,7 @@ Also see:
 - [RocksDB Server Options](programs-arangod-options.html#rocksdb)
 - [Write Buffer Manager](https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager){:target="_blank"}
 
-Edge-Cache
+Edge Cache
 ----------
 
 ```
@@ -124,10 +124,10 @@ Edge-Cache
 ```
 
 This option disables the ArangoDB edge [cache](programs-arangod-cache.html).
-In versions before v3.9.2, you can limit the size to a minimum of 10485760 (10 MB).
+In versions before v3.9.2, you can limit the size to a minimum of `10485760` (10 MB).
 
-If you do not have a graph use-case and do not use edge collections, it is
-possible to use a minimal cache size or no edge cache at all without a performance
+If you do not have a graph use case and do not use edge collections, it is
+possible to use no edge cache (or a minimal cache size) without a performance
 impact. In general, this should correspond to the size of the hot-set of edges.
 
 AQL Query Memory Usage


### PR DESCRIPTION
- 3.9.2 lowers the minimum `--cache.size` to 0 to disable it
- 3.10.0 adds optional hash caches for persistent indexes, whose size is also controlled by the startup option