### PR TITLE
Restore JavaScript highlighting

### DIFF
--- a/styles/pygments-arango.css
+++ b/styles/pygments-arango.css
@@ -20,12 +20,10 @@
 .highlight .s { color: #a31515 } /* Literal.String */
 .highlight .nc { color: #2b91af } /* Name.Class */
 .highlight .no { color: #0000ff } /* Name.Constant */
-.highlight .nb { color: #0000ff } /* Name.Builtin */
-.highlight .np { color: #0000ff; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .bp { color: #0000ff; font-style: italic } /* Name.Builtin.Pseudo */
 .highlight .nf { color: #3c4c72; } /* Name.Function */
 .highlight .nv { color: #8959a8 } /* Name.Variable */
 .highlight .vg { color: #8959a8 } /* Name.Variable.Global */
-.highlight .nx { color: #0000ff } /* Name.Other */
 .highlight .ow { color: #0000ff } /* Operator.Word */
 .highlight .sb { color: #a31515 } /* Literal.String.Backtick */
 .highlight .sc { color: #a31515 } /* Literal.String.Char */


### PR DESCRIPTION
#1032 accidentally changed how AQL is colorized using the JavaScript highlighter (3.9 and earlier). Too many tokens are blue, e.g.

![image](https://user-images.githubusercontent.com/7819991/175990456-b5d07bb2-3d0c-436c-b789-ea6e5c34b78d.png)

https://deploy-preview-1032--zealous-morse-14392b.netlify.app/docs/3.9/aql/tutorial-crud.html#update-documents

- Remove definition of `Name.Builtin` and `Name.Other` (only used by JS highlighter) to use the default color again
- Fix `Name.Builtin.Pseudo` class name to properly apply the style to AQL colorized with the AQL highlighter

Reverted:

![image](https://user-images.githubusercontent.com/7819991/175990401-3e61952d-693a-458f-b13e-dcaac8d3d874.png)

https://deploy-preview-1046--zealous-morse-14392b.netlify.app/docs/3.9/aql/tutorial-crud.html#update-documents