### PR TITLE
DOC-166 | Add `computedValues` collection property to more JS API pages

### DIFF
--- a/3.10/data-modeling-collections-collection-methods.md
+++ b/3.10/data-modeling-collections-collection-methods.md
@@ -141,6 +141,9 @@ Returns an object containing all collection properties.
   The attribute keys `rule`, `level` and `message` must follow the rules
   documented in [Document Schema Validation](document-schema-validation.html)
 
+- `computedValues` (optional, default: `null`): An array of objects,
+  each representing a [Computed Value](data-modeling-documents-computed-values.html).
+
 In a cluster setup, the result also contains the following attributes:
 
 - `numberOfShards`: the number of shards of the collection.

--- a/3.10/data-modeling-collections-collection-methods.md
+++ b/3.10/data-modeling-collections-collection-methods.md
@@ -10,12 +10,13 @@ Drop
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-drops a collection
+Drops a collection:
+
 `collection.drop(options)`
 
-Drops a *collection* and all its indexes and data.
-In order to drop a system collection, an *options* object
-with attribute *isSystem* set to *true* must be specified.
+Drops a `collection` and all its indexes and data.
+In order to drop a system collection, an `options` object
+with attribute `isSystem` set to `true` must be specified.
 
 {% hint 'info' %}
 Dropping a collection in a cluster, which is prototype for sharing
@@ -25,7 +26,9 @@ such a collection, all dependent collections must be dropped first.
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+Drop a collection:
+
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDrop
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDrop}
     ~ db._create("example");
@@ -35,10 +38,12 @@ such a collection, all dependent collections must be dropped first.
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDrop
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+Drop a system collection:
+
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDropSystem
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDropSystem}
     ~ db._create("_example", { isSystem: true });
@@ -48,26 +53,26 @@ such a collection, all dependent collections must be dropped first.
     ~ db._drop("example", { isSystem: true });
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDropSystem
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Truncate
 --------
 
 <!-- js/server/modules/@arangodb/arango-collection.js-->
 
+Truncate a collection:
 
-truncates a collection
 `collection.truncate()`
 
-Truncates a *collection*, removing all documents but keeping all its
+Truncates a `collection`, removing all documents but keeping all its
 indexes.
 
 **Examples**
 
 Truncates a collection:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionTruncate
     @EXAMPLE_ARANGOSH_OUTPUT{collectionTruncate}
     ~ db._create("example");
@@ -79,8 +84,8 @@ Truncates a collection:
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionTruncate
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Compact
 -------
@@ -89,16 +94,17 @@ Compact
 
 <small>Introduced in: v3.4.5</small>
 
-Compacts the data of a collection
+Compacts the data of a collection:
+
 `collection.compact()`
 
 Compacts the data of a collection in order to reclaim disk space.
-The operation will compact the document and index
-data by rewriting the underlying .sst files and only keeping the relevant
+The operation compacts the document and index
+data by rewriting the underlying .sst files and only keeps the relevant
 entries.
 
 Under normal circumstances running a compact operation is not necessary,
-as the collection data will eventually get compacted anyway. However, in 
+as the collection data is eventually compacted anyway. However, in 
 some situations, e.g. after running lots of update/replace or remove 
 operations, the disk data for a collection may contain a lot of outdated data
 for which the space shall be reclaimed. In this case the compaction operation
@@ -107,83 +113,86 @@ can be used.
 Properties
 ----------
 
-gets or sets the properties of a collection
+Get or set the properties of a collection:
+
 `collection.properties()`
 
 Returns an object containing all collection properties.
 
-- *waitForSync*: If *true* creating a document will only return
+- `waitForSync`: If `true`, creating a document only returns
   after the data was synced to disk.
 
-* *keyOptions* (optional) additional options for key generation. This is
+- `keyOptions` (optional) additional options for key generation. This is
   a JSON object containing the following attributes (note: some of the
   attributes are optional):
-  * *type*: the type of the key generator used for the collection.
-  * *allowUserKeys*: if set to *true*, then it is allowed to supply
-    own key values in the *_key* attribute of a document. If set to
-    *false*, then the key generator will solely be responsible for
-    generating keys and supplying own key values in the *_key* attribute
+  - `type`: the type of the key generator used for the collection.
+  - `allowUserKeys`: if set to `true`, then it is allowed to supply
+    own key values in the `_key` attribute of a document. If set to
+    `false`, then the key generator is solely responsible for
+    generating keys and supplying own key values in the `_key` attribute
     of documents is considered an error.
-  * *increment*: increment value for *autoincrement* key generator.
+  - `increment`: increment value for `autoincrement` key generator.
     Not used for other key generator types.
-  * *offset*: initial offset value for *autoincrement* key generator.
+  - `offset`: initial offset value for `autoincrement` key generator.
     Not used for other key generator types.
 
-* *schema* (optional, default is *null*): 
+- `schema` (optional, default: `null`): 
   Object that specifies the collection level document schema for documents.
   The attribute keys `rule`, `level` and `message` must follow the rules
   documented in [Document Schema Validation](document-schema-validation.html)
 
-In a cluster setup, the result will also contain the following attributes:
+In a cluster setup, the result also contains the following attributes:
 
-* *numberOfShards*: the number of shards of the collection.
+- `numberOfShards`: the number of shards of the collection.
 
-* *shardKeys*: contains the names of document attributes that are used to
+- `shardKeys`: contains the names of document attributes that are used to
   determine the target shard for documents.
 
-* *replicationFactor*: determines how many copies of each shard are kept
+- `replicationFactor`: determines how many copies of each shard are kept
   on different DB-Servers. Has to be in the range of 1-10 or the string
   `"satellite"` for a SatelliteCollection (Enterprise Edition only).
   _(cluster only)_
 
-* *writeConcern*: determines how many copies of each shard are required to be
+- `writeConcern`: determines how many copies of each shard are required to be
   in sync on the different DB-Servers. If there are less then these many copies
-  in the cluster a shard will refuse to write. Writes to shards with enough
-  up-to-date copies will succeed at the same time however. The value of
-  *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_
+  in the cluster, a shard refuses to write. Writes to shards with enough
+  up-to-date copies succeed at the same time, however. The value of
+  `writeConcern` can not be larger than `replicationFactor`. _(cluster only)_
 
-* *shardingStrategy*: the sharding strategy selected for the collection.
-  This attribute will only be populated in cluster mode and is not populated
+- `shardingStrategy`: the sharding strategy selected for the collection.
+  This attribute is only populated in cluster mode and is not populated
   in single-server mode. _(cluster only)_
 
 `collection.properties(properties)`
 
-Changes the collection properties. *properties* must be an object with
+Changes the collection properties. `properties` must be an object with
 one or more of the following attribute(s):
 
-* *waitForSync*: If *true* creating a document will only return
+- `waitForSync`: If `true`, creating a document only returns
   after the data was synced to disk.
 
-* *replicationFactor*: Change the number of shard copies kept on
+- `replicationFactor`: Change the number of shard copies kept on
   different DB-Servers. Valid values are integer numbers in the range of 1-10
   or the string `"satellite"` for a SatelliteCollection (Enterprise Edition only).
   _(cluster only)_
 
-* *writeConcern*: change how many copies of each shard are required to be
+- `writeConcern`: change how many copies of each shard are required to be
   in sync on the different DB-Servers. If there are less then these many copies
-  in the cluster a shard will refuse to write. Writes to shards with enough
-  up-to-date copies will succeed at the same time however. The value of
-  *writeConcern* can not be larger than *replicationFactor*. _(cluster only)_
+  in the cluster, a shard refuses to write. Writes to shards with enough
+  up-to-date copies succeed at the same time however. The value of
+  `writeConcern` can not be larger than `replicationFactor`. _(cluster only)_
 
-**Note**: some other collection properties, such as *type*,
-*keyOptions*, *numberOfShards* or *shardingStrategy* cannot be changed once
+{% hint 'info' %}
+Some other collection properties, such as `type`,
+`keyOptions`, `numberOfShards` or `shardingStrategy` cannot be changed once
 the collection is created.
+{% endhint %}
 
 **Examples**
 
-Read all properties
+Read all properties:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionProperties
     @EXAMPLE_ARANGOSH_OUTPUT{collectionProperties}
     ~ db._create("example");
@@ -191,12 +200,12 @@ Read all properties
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionProperties
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
-Change a property
+Change a property:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionProperty
     @EXAMPLE_ARANGOSH_OUTPUT{collectionProperty}
     ~ db._create("example");
@@ -204,67 +213,73 @@ Change a property
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionProperty
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Figures
 -------
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-returns the figures of a collection
+Return the figures of a collection:
+
 `collection.figures(details)`
 
 Returns an object containing statistics about the collection.
 
-Setting `details` to `true` will return extended storage engine-specific
+Setting `details` to `true` returns extended storage engine-specific
 details to the figures (introduced in v3.8.0). The details are intended for
 debugging ArangoDB itself and their format is subject to change. By default,
 `details` is set to `false`, so no details are returned and the behavior is
 identical to previous versions of ArangoDB.
 
-* *indexes.count*: The total number of indexes defined for the
+- `indexes.count`: The total number of indexes defined for the
   collection, including the pre-defined indexes (e.g. primary index).
-* *indexes.size*: The total memory allocated for indexes in bytes.
+- `indexes.size`: The total memory allocated for indexes in bytes.
 <!-- TODO: describe RocksDB figures -->
-* *documentsSize*
-* *cacheInUse*
-* *cacheSize*
-* *cacheUsage*
+- `documentsSize`
+- `cacheInUse`
+- `cacheSize`
+- `cacheUsage`
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+Get the basic collection figures:
+
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionFigures
     @EXAMPLE_ARANGOSH_OUTPUT{collectionFigures}
     ~ require("internal").wal.flush(true, true);
       db.demo.figures()
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionFigures
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+Get the detailed collection figures:
+
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionFiguresDetails
     @EXAMPLE_ARANGOSH_OUTPUT{collectionFiguresDetails}
     ~ require("internal").wal.flush(true, true);
       db.demo.figures(true)
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionFiguresDetails
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 GetResponsibleShard
 -------------------
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-returns the responsible shard for the given document.
+Return the responsible shard for the given document:
+
 `collection.getResponsibleShard(document)`
 
 Returns a string with the responsible shard's ID. Note that the
 returned shard ID is the ID of responsible shard for the document's
-shard key values, and it will be returned even if no such document exists.
+shard key values, and it returns even if no such document exists.
 
 {% hint 'info' %}
 The `getResponsibleShard()` method can only be used on Coordinators
@@ -276,7 +291,8 @@ Shards
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-returns the available shards for the collection.
+Return the available shards for the collection:
+
 `collection.shards(details)`
 
 If `details` is not set, or set to `false`, returns an array with the names of 
@@ -297,7 +313,8 @@ Load
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-loads a collection
+Load a collection:
+
 `collection.load()`
 
 Loads a collection into memory.
@@ -307,14 +324,14 @@ Cluster collections are loaded at all times.
 {% endhint %}
 
 {% hint 'warning' %}
-The *load()* function is **deprecated** as of ArangoDB 3.8.0.
+The `load()` function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to load a collection with the RocksDB storage engine.
 {% endhint %}
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionLoad
     @EXAMPLE_ARANGOSH_OUTPUT{collectionLoad}
     ~ db._create("example");
@@ -324,27 +341,28 @@ any need to load a collection with the RocksDB storage engine.
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionLoad
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Revision
 --------
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-returns the revision id of a collection
+Return the revision ID of a collection:
+
 `collection.revision()`
 
-Returns the revision id of the collection
+Returns the revision ID of the collection
 
-The revision id is updated when the document data is modified, either by
+The revision ID is updated when the document data is modified, either by
 inserting, deleting, updating or replacing documents in it.
 
-The revision id of a collection can be used by clients to check whether
+The revision ID of a collection can be used by clients to check whether
 data in a collection has changed or if it is still unmodified since a
-previous fetch of the revision id.
+previous fetch of the revision ID.
 
-The revision id returned is a string value. Clients should treat this value
+The revision ID returned is a string value. Clients should treat this value
 as an opaque string, and only use it for equality/non-equality comparisons.
 
 Checksum
@@ -352,28 +370,27 @@ Checksum
 
 <!-- arangod/V8Server/v8-query.cpp -->
 
-calculates a checksum for the data in a collection
+Calculate a checksum for the data in a collection:
+
 `collection.checksum(withRevisions, withData)`
 
-The *checksum* operation calculates an aggregate hash value for all document
-keys contained in collection *collection*.
+The `checksum` operation calculates an aggregate hash value for all document
+keys contained in collection `collection`.
 
-If the optional argument *withRevisions* is set to *true*, then the
+If the optional argument `withRevisions` is set to `true`, then the
 revision ids of the documents are also included in the hash calculation.
 
-If the optional argument *withData* is set to *true*, then all user-defined
+If the optional argument `withData` is set to `true`, then all user-defined
 document attributes are also checksummed. Including the document data in
-checksumming will make the calculation slower, but is more accurate.
-
-The checksum calculation algorithm changed in ArangoDB 3.0, so checksums from
-3.0 and earlier versions for the same data will differ.
+checksumming makes the calculation slower, but is more accurate.
 
 Unload
 ------
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-unloads a collection
+Unload a collection:
+
 `collection.unload()`
 
 Starts unloading a collection from memory. Note that unloading is deferred
@@ -384,14 +401,14 @@ Cluster collections cannot be unloaded.
 {% endhint %}
 
 {% hint 'warning' %}
-The *unload()* function is **deprecated** as of ArangoDB 3.8.0.
+The `unload()` function is **deprecated** as of ArangoDB 3.8.0.
 The function may be removed in future versions of ArangoDB. There should not be
 any need to unload a collection with the RocksDB storage engine.
 {% endhint %}
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline CollectionUnload
     @EXAMPLE_ARANGOSH_OUTPUT{CollectionUnload}
     ~ db._create("example");
@@ -401,19 +418,20 @@ any need to unload a collection with the RocksDB storage engine.
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock CollectionUnload
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Rename
 ------
 
 <!-- arangod/V8Server/v8-collection.cpp -->
 
-renames a collection
+Rename a collection:
+
 `collection.rename(new-name)`
 
-Renames a collection using the *new-name*. The *new-name* must not
-already be used for a different collection. *new-name* must also be a
+Renames a collection using the `new-name`. The `new-name` must not
+already be used for a different collection. `new-name` must also be a
 valid collection name. For more information on valid collection names please
 refer to the [naming conventions](data-modeling-naming-conventions.html).
 
@@ -428,7 +446,7 @@ The `rename()` method can not be used in clusters.
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionRename
     @EXAMPLE_ARANGOSH_OUTPUT{collectionRename}
     ~ db._create("example");
@@ -438,5 +456,5 @@ The `rename()` method can not be used in clusters.
     ~ db._drop("better-example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionRename
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}

--- a/3.10/data-modeling-collections-database-methods.md
+++ b/3.10/data-modeling-collections-database-methods.md
@@ -124,6 +124,14 @@ to the [naming conventions](data-modeling-naming-conventions.html).
   - `offset`: initial offset value for `autoincrement` key generator.
     Not used for other key generator types.
 
+- `schema` (optional, default: `null`): 
+  Object that specifies the collection level document schema for documents.
+  The attribute keys `rule`, `level` and `message` must follow the rules
+  documented in [Document Schema Validation](document-schema-validation.html)
+
+- `computedValues` (optional, default: `null`): An array of objects,
+  each representing a [Computed Value](data-modeling-documents-computed-values.html).
+
 - `numberOfShards` (optional, default `1`): in a cluster, this value
   determines the number of shards to create for the collection. In a single
   server setup, this option is meaningless.

--- a/3.10/data-modeling-collections-database-methods.md
+++ b/3.10/data-modeling-collections-database-methods.md
@@ -10,33 +10,31 @@ Collection
 
 <!-- arangod/V8Server/v8-vocbase.cpp -->
 
+Return a single collection:
 
-returns a single collection or null
 `db._collection(collection-name)`
 
-Returns the collection with the given name or null if no such collection
+Returns the collection with the given name, or `null` if no such collection
 exists.
 
 `db._collection(collection-identifier)`
 
-Returns the collection with the given identifier or null if no such
+Returns the collection with the given identifier or `null` if no such
 collection exists. Accessing collections by identifier is discouraged for
 end users. End users should access collections using the collection name.
 
-
 **Examples**
-
 
 Get a collection by name:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseNameKnown
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseNameKnown}
       db._collection("demo");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseNameKnown
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Get a collection by id:
 
@@ -47,66 +45,66 @@ arangosh> db._collection(123456);
 
 Unknown collection:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseNameUnknown
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseNameUnknown}
       db._collection("unknown");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseNameUnknown
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Create
 ------
 
 <!-- arangod/V8Server/v8-vocindex.cpp -->
 
+Create a new document or edge collection:
 
-creates a new document or edge collection
 `db._create(collection-name)`
 
-Creates a new document collection named *collection-name*.
+Creates a new document collection named `collection-name`.
 If the collection name already exists or if the name format is invalid, an
 error is thrown. For more information on valid collection names please refer
 to the [naming conventions](data-modeling-naming-conventions.html).
 
 `db._create(collection-name, properties)`
 
-*properties* must be an object with the following attributes:
+`properties` must be an object with the following attributes:
 
-- *waitForSync* (optional, default *false*): If *true* creating
-  a document will only return after the data was synced to disk.
+- `waitForSync` (optional, default `false`): If `true`, creating
+  a document only returns after the data is synced to disk.
 
-- *isSystem* (optional, default is *false*): If *true*, create a
-  system collection. In this case *collection-name* should start with
+- `isSystem` (optional, default is `false`): If `true`, create a
+  system collection. In this case `collection-name` should start with
   an underscore. End users should normally create non-system collections
   only. API implementors may be required to create system collections in
-  very special occasions, but normally a regular collection will do.
+  very special occasions, but normally a regular collection is sufficient.
 
-- *keyOptions* (optional): additional options for key generation. If
-  specified, then *keyOptions* should be a JSON object containing the
+- `keyOptions` (optional): additional options for key generation. If
+  specified, then `keyOptions` should be a JSON object containing the
   following attributes (**note**: some of them are optional):
-  - *type*: specifies the type of the key generator. The currently
-    available generators are *traditional*, *autoincrement*, *uuid* and
-    *padded*.
-    The `traditional` key generator generates numerical keys in ascending order.
-    The sequence of keys is not guaranteed to be gap-free.
-    The `autoincrement` key generator generates numerical keys in ascending order, 
-    the initial offset and the spacing can be configured (**note**: 
-    *autoincrement* is currently only supported for non-sharded or 
-    single-sharded collections). 
-    The sequence of generated keys is not guaranteed to be gap-free, because a new key
-    will be generated on every document insert attempt, not just for successful
-    inserts.
-    The `padded` key generator generates keys of a fixed length (16 bytes) in
-    ascending lexicographical sort order. This is ideal for usage with the _RocksDB_
-    engine, which will slightly benefit keys that are inserted in lexicographically
-    ascending order. The key generator can be used in a single-server or cluster.
-    The sequence of generated keys is not guaranteed to be gap-free.
-    The `uuid` key generator generates universally unique 128 bit keys, which 
-    are stored in hexadecimal human-readable format. This key generator can be used
-    in a single-server or cluster to generate "seemingly random" keys. The keys 
-    produced by this key generator are not lexicographically sorted.
+  - `type`: specifies the type of the key generator.
+    The available generators are `traditional`, `autoincrement`, `uuid` and
+    `padded`.
+    - The `traditional` key generator generates numerical keys in ascending order.
+      The sequence of keys is not guaranteed to be gap-free.
+    - The `autoincrement` key generator generates numerical keys in ascending order, 
+      the initial offset and the spacing can be configured (**note**: 
+      `autoincrement` is only supported for non-sharded or 
+      single-sharded collections). 
+      The sequence of generated keys is not guaranteed to be gap-free, because a new key
+      is generated on every document insert attempt, not just for successful
+      inserts.
+    - The `padded` key generator generates keys of a fixed length (16 bytes) in
+      ascending lexicographical sort order. This is ideal for usage with the _RocksDB_
+      engine, which slightly benefits keys that are inserted in lexicographically
+      ascending order. The key generator can be used in a single-server or cluster.
+      The sequence of generated keys is not guaranteed to be gap-free.
+    - The `uuid` key generator generates universally unique 128 bit keys, which 
+      are stored in hexadecimal human-readable format. This key generator can be used
+      in a single-server or cluster to generate "seemingly random" keys. The keys 
+      produced by this key generator are not lexicographically sorted.
 
     Please note that keys are only guaranteed to be truly ascending in single
     server deployments and for collections that only have a single shard (that includes
@@ -116,21 +114,21 @@ to the [naming conventions](data-modeling-naming-conventions.html).
     keys are generated on the leader DB-Server, which has full control over the key
     sequence.
 
-  - *allowUserKeys*: if set to *true*, then it is allowed to supply
-    own key values in the *_key* attribute of a document. If set to
-    *false*, then the key generator will solely be responsible for
-    generating keys and supplying own key values in the *_key* attribute
+  - `allowUserKeys`: if set to `true`, then it is allowed to supply
+    own key values in the `_key` attribute of a document. If set to
+    `false`, then the key generator is solely responsible for
+    generating keys and supplying own key values in the `_key` attribute
     of documents is considered an error.
-  - *increment*: increment value for *autoincrement* key generator.
+  - `increment`: increment value for `autoincrement` key generator.
     Not used for other key generator types.
-  - *offset*: initial offset value for *autoincrement* key generator.
+  - `offset`: initial offset value for `autoincrement` key generator.
     Not used for other key generator types.
 
-- *numberOfShards* (optional, default is *1*): in a cluster, this value
+- `numberOfShards` (optional, default `1`): in a cluster, this value
   determines the number of shards to create for the collection. In a single
   server setup, this option is meaningless.
 
-- *shardKeys* (optional, default is `[ "_key" ]`): in a cluster, this
+- `shardKeys` (optional, default is `[ "_key" ]`): in a cluster, this
   attribute determines which document attributes are used to determine the
   target shard for documents. Documents are sent to shards based on the
   values they have in their shard key attributes. The values of all shard
@@ -139,27 +137,27 @@ to the [naming conventions](data-modeling-naming-conventions.html).
   be changed once set.
   This option is meaningless in a single server setup.
 
-  When choosing the shard keys, one must be aware of the following
+  When choosing the shard keys, you must be aware of the following
   rules and limitations: In a sharded collection with more than
   one shard it is not possible to set up a unique constraint on
   an attribute that is not the one and only shard key given in
-  *shardKeys*. This is because enforcing a unique constraint
+  `shardKeys`. This is because enforcing a unique constraint
   would otherwise make a global index necessary or need extensive
   communication for every single write operation. Furthermore, if
-  *_key* is not the one and only shard key, then it is not possible
-  to set the *_key* attribute when inserting a document, provided
+  `_key` is not the one and only shard key, then it is not possible
+  to set the `_key` attribute when inserting a document, provided
   the collection has more than one shard. Again, this is because
-  the database has to enforce the unique constraint on the *_key*
+  the database has to enforce the unique constraint on the `_key`
   attribute and this can only be done efficiently if this is the
   only shard key by delegating to the individual shards.
 
-- *replicationFactor* (optional, default is 1): in a cluster, this
+- `replicationFactor` (optional, default `1`): in a cluster, this
   attribute determines how many copies of each shard are kept on 
   different DB-Servers. The value 1 means that only one copy (no
   synchronous replication) is kept. A value of k means that
   k-1 replicas are kept. Any two copies reside on different DB-Servers.
   Replication between them is synchronous, that is, every write operation
-  to the "leader" copy will be replicated to all "follower" replicas,
+  to the "leader" copy is replicated to all "follower" replicas,
   before the write operation is reported successful.
 
   If a server fails, this is detected automatically and one of the
@@ -172,24 +170,24 @@ to the [naming conventions](data-modeling-naming-conventions.html).
   dramatically when using joins in AQL at the costs of reduced write
   performance on these collections.
 
-- *writeConcern* (optional, default is 1): in a cluster, this
+- `writeConcern` (optional, default `1`): in a cluster, this
   attribute determines how many copies of each shard are required
   to be in sync on the different DB-Servers. If there are less then these
-  many copies in the cluster a shard will refuse to write. The value of
-  *writeConcern* can not be larger than *replicationFactor*.
+  many copies in the cluster, a shard refuses to write. The value of
+  `writeConcern` can not be larger than `replicationFactor`.
   Please note: during server failures this might lead to writes
   not being possible until the failover is sorted out and might cause
   write slow downs in trade for data durability.
 
-- *distributeShardsLike*: distribute the shards of this collection
+- `distributeShardsLike`: distribute the shards of this collection
   cloning the shard distribution of another. If this value is set,
-  it will copy the attributes *replicationFactor*, *numberOfShards* and 
-  *shardingStrategy* from the other collection. 
+  it copies the attributes `replicationFactor`, `numberOfShards` and 
+  `shardingStrategy` from the other collection. 
 
-- *shardingStrategy* (optional): specifies the name of the sharding
+- `shardingStrategy` (optional): specifies the name of the sharding
   strategy to use for the collection. Since ArangoDB 3.4 there are
   different sharding strategies to select from when creating a new 
-  collection. The selected *shardingStrategy* value will remain
+  collection. The selected `shardingStrategy` value remains
   fixed for the collection and cannot be changed afterwards. This is
   important to make the collection keep its sharding settings and
   always find documents already distributed to shards using the same
@@ -207,58 +205,57 @@ to the [naming conventions](data-modeling-naming-conventions.html).
   - `enterprise-hash-smart-edge`: default sharding used for new
     smart edge collections starting from version 3.4
 
-  If no sharding strategy is specified, the default will be `hash` for
+  If no sharding strategy is specified, the default is `hash` for
   all collections, and `enterprise-hash-smart-edge` for all smart edge
   collections (requires the *Enterprise Edition* of ArangoDB). 
   Manually overriding the sharding strategy does not yet provide a 
   benefit, but it may later in case other sharding strategies are added.
   
-  In single-server mode, the *shardingStrategy* attribute is meaningless 
-  and will be ignored.
+  In single-server mode, the `shardingStrategy` attribute is meaningless 
+  and is ignored.
 
-- *smartJoinAttribute: in an *Enterprise Edition* cluster, this attribute 
+- `smartJoinAttribute`: in an *Enterprise Edition* cluster, this attribute 
   determines an attribute of the collection that must contain the shard key value 
   of the referred-to SmartJoin collection. Additionally, the sharding key 
   for a document in this collection must contain the value of this attribute, 
   followed by a colon, followed by the actual primary key of the document.
 
   This feature can only be used in the *Enterprise Edition* and requires the
-  *distributeShardsLike* attribute of the collection to be set to the name
-  of another collection. It also requires the *shardKeys* attribute of the
-  collection to be set to a single shard key attribute, with an additional ':'
+  `distributeShardsLike` attribute of the collection to be set to the name
+  of another collection. It also requires the `shardKeys` attribute of the
+  collection to be set to a single shard key attribute, with an additional `:`
   at the end.
   A further restriction is that whenever documents are stored or updated in the 
-  collection, the value stored in the *smartJoinAttribute* must be a string.
+  collection, the value stored in the `smartJoinAttribute` must be a string.
 
 `db._create(collection-name, properties, type)`
 
-Specifies the optional *type* of the collection, it can either be *document* 
-or *edge*. On default it is document. Instead of giving a type you can also use 
-*db._createEdgeCollection* or *db._createDocumentCollection*.
+Specifies the optional `type` of the collection, it can either be `document` 
+or `edge`. On default it is document. Instead of giving a type you can also use 
+`db._createEdgeCollection()` or `db._createDocumentCollection()`.
 
 `db._create(collection-name, properties[, type], options)`
 
-As an optional third (if the *type* string is being omitted) or fourth
+As an optional third (if the `type` string is being omitted) or fourth
 parameter you can specify an optional options map that controls how the
-cluster will create the collection. These options are only relevant at
-creation time and will not be persisted:
+cluster creates the collection. These options are only relevant at
+creation time and are not persisted:
 
-- *waitForSyncReplication* (default: true)
-  When enabled the server will only report success back to the client
-  if all replicas have created the collection. Set to *false* if you want faster
+- `waitForSyncReplication` (default: `true`)
+  If enabled, the server only reports success back to the client
+  if all replicas have created the collection. Set to `false` if you want faster
   server responses and don't care about full replication.
 
-- *enforceReplicationFactor* (default: true)
-  When enabled which means the server will check if there are enough replicas
-  available at creation time and bail out otherwise. Set to *false* to disable
+- `enforceReplicationFactor` (default: `true`)
+  If enabled, the server checks if there are enough replicas
+  available at creation time and bails out otherwise. Set to `false` to disable
   this extra check.
 
 **Examples**
 
-
 With defaults:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseCreateSuccess
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCreateSuccess}
       c = db._create("users");
@@ -266,12 +263,12 @@ With defaults:
     ~ db._drop("users");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseCreateSuccess
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 With properties:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseCreateProperties
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCreateProperties}
       c = db._create("users", { waitForSync: true });
@@ -279,12 +276,12 @@ With properties:
     ~ db._drop("users");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseCreateProperties
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 With a key generator:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseCreateKey
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCreateKey}
     | db._create("users",
@@ -295,12 +292,12 @@ With a key generator:
     ~ db._drop("users");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseCreateKey
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 With a special key option:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseCreateSpecialKey
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCreateSpecialKey}
       db._create("users", { keyOptions: { allowUserKeys: false } });
@@ -310,52 +307,49 @@ With a special key option:
     ~ db._drop("users");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseCreateSpecialKey
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 <!-- arangod/V8Server/v8-vocindex.cpp -->
 
+Create a new edge collection:
 
-creates a new edge collection
 `db._createEdgeCollection(collection-name)`
 
-Creates a new edge collection named *collection-name*. If the
+Creates a new edge collection named `collection-name`. If the
 collection name already exists an error is thrown. The default value
-for *waitForSync* is *false*.
+for `waitForSync` is `false`.
 
 `db._createEdgeCollection(collection-name, properties)`
 
-*properties* must be an object with the following attributes:
+`properties` must be an object with the following attributes:
 
-- *waitForSync* (optional, default *false*): If *true* creating
-  a document will only return after the data was synced to disk.
-
+- `waitForSync` (optional, default: `false`): If `true`, creating
+  a document only returns after the data is synced to disk.
 
 <!-- arangod/V8Server/v8-vocindex.cpp -->
 
+Create a new document collection:
 
-creates a new document collection
 `db._createDocumentCollection(collection-name)`
 
-Creates a new document collection named *collection-name*. If the
+Creates a new document collection named `collection-name`. If the
 document name already exists and error is thrown.
-
 
 All Collections
 ---------------
 
 <!-- arangod/V8Server/v8-vocbase.cpp -->
 
+Return all collections:
 
-returns all collections
 `db._collections()`
 
 Returns all collections of the given database.
 
-
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionsDatabaseName
     @EXAMPLE_ARANGOSH_OUTPUT{collectionsDatabaseName}
     ~ db._create("example");
@@ -363,27 +357,25 @@ Returns all collections of the given database.
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionsDatabaseName
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
-
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Collection Name
 ---------------
 
 <!-- arangod/V8Server/v8-vocbase.cpp -->
 
+Select a collection from the database:
 
-selects a collection from the database
 `db.collection-name`
 
-Returns the collection with the given *collection-name*. If no such
-collection exists, create a collection named *collection-name* with the
+Returns the collection with the given `collection-name`. If no such
+collection exists, create a collection named `collection-name` with the
 default properties.
-
 
 **Examples**
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseCollectionName
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseCollectionName}
     ~ db._create("example");
@@ -391,45 +383,46 @@ default properties.
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseCollectionName
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
-
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Drop
 ----
 
 <!-- js/server/modules/@arangodb/arango-database.js -->
 
+Drop a collection:
 
-drops a collection
 `db._drop(collection)`
 
-Drops a *collection* and all its indexes and data.
+Drops a `collection` and all its indexes and data.
 
 `db._drop(collection-identifier)`
 
-Drops a collection identified by *collection-identifier* with all its
+Drops a collection identified by `collection-identifier` with all its
 indexes and data. No error is thrown if there is no such collection.
 
 `db._drop(collection-name)`
 
-Drops a collection named *collection-name* and all its indexes. No error
+Drops a collection named `collection-name` and all its indexes. No error
 is thrown if there is no such collection.
 
 `db._drop(collection-name, options)`
 
-In order to drop a system collection, one must specify an *options* object
-with attribute *isSystem* set to *true*. Otherwise it is not possible to
+In order to drop a system collection, you must specify an `options` object
+with attribute `isSystem` set to `true`. Otherwise it is not possible to
 drop system collections.
 
-**Note**: cluster collection, which are prototypes for collections
-with *distributeShardsLike* parameter, cannot be dropped.
+{% hint 'info' %}
+Cluster collection, which are prototypes for collections
+with `distributeShardsLike` parameter, cannot be dropped.
+{% endhint %}
 
-*Examples*
+**Examples**
 
 Drops a collection:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseDropByObject
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseDropByObject}
     ~ db._create("example");
@@ -439,12 +432,12 @@ Drops a collection:
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseDropByObject
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Drops a collection identified by name:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseDropName
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseDropName}
     ~ db._create("example");
@@ -453,12 +446,12 @@ Drops a collection identified by name:
       col;
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseDropName
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Drops a system collection
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseDropSystem
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseDropSystem}
     ~ db._create("_example", { isSystem: true });
@@ -467,38 +460,36 @@ Drops a system collection
       col;
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseDropSystem
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Truncate
 --------
 
 <!-- js/server/modules/@arangodb/arango-database.js -->
 
+Truncate a collection:
 
-truncates a collection
 `db._truncate(collection)`
 
-Truncates a *collection*, removing all documents but keeping all its
+Truncates a `collection`, removing all documents but keeping all its
 indexes.
 
 `db._truncate(collection-identifier)`
 
-Truncates a collection identified by *collection-identified*. No error is
+Truncates a collection identified by `collection-identified`. No error is
 thrown if there is no such collection.
 
 `db._truncate(collection-name)`
 
-Truncates a collection named *collection-name*. No error is thrown if
+Truncates a collection named `collection-name`. No error is thrown if
 there is no such collection.
-
 
 **Examples**
 
-
 Truncates a collection:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseTruncateByObject
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseTruncateByObject}
     ~ db._create("example");
@@ -510,12 +501,12 @@ Truncates a collection:
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseTruncateByObject
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}
 
 Truncates a collection identified by name:
 
-{% arangoshexample examplevar="examplevar" script="script" result="result" %}
+    {% arangoshexample examplevar="examplevar" script="script" result="result" %}
     @startDocuBlockInline collectionDatabaseTruncateName
     @EXAMPLE_ARANGOSH_OUTPUT{collectionDatabaseTruncateName}
     ~ db._create("example");
@@ -527,6 +518,5 @@ Truncates a collection identified by name:
     ~ db._drop("example");
     @END_EXAMPLE_ARANGOSH_OUTPUT
     @endDocuBlock collectionDatabaseTruncateName
-{% endarangoshexample %}
-{% include arangoshexample.html id=examplevar script=script result=result %}
-
+    {% endarangoshexample %}
+    {% include arangoshexample.html id=examplevar script=script result=result %}

--- a/3.10/data-modeling-documents-computed-values.md
+++ b/3.10/data-modeling-documents-computed-values.md
@@ -24,9 +24,10 @@ stored like any other attribute, which means that you may use them in indexes,
 but also that the schema validation is applied if you use one.
 
 Possible use cases are to add timestamps of the creation or last modification to
-every document, or to automatically combine multiple attributes into one,
-possibly with filtering and a conversion to lowercase characters, to then index
-the attribute and use it to perform case-insensitive searches.
+every document, to add default attributes, or to automatically process attributes
+for indexing purposes. For example, you can combine multiple attributes into one,
+filter out array elements, and convert text to lowercase characters, to then index
+the new attribute and use it to perform case-insensitive searches.
 
 ## Using Computed Values
 

--- a/3.10/data-modeling-documents-computed-values.md
+++ b/3.10/data-modeling-documents-computed-values.md
@@ -79,9 +79,10 @@ Each object represents a computed value and can have the following attributes:
 
 ## HTTP API
 
-See the `computedValues` collection property in the HTTP API documentation for
-[Creating Collections](http/collection-creating.html) and
-[Modifying Collections](http/collection-modifying.html).
+See the `computedValues` collection property in the HTTP API documentation:
+- [Create a collection](http/collection-creating.html#create-collection),
+- [Read properties of a collection](http/collection-getting.html#read-properties-of-a-collection),
+- [Change properties of a collection](http/collection-modifying.html#change-properties-of-a-collection).
 
 ## Computed Value Expressions
 

--- a/3.10/http/document-address-and-etag.md
+++ b/3.10/http/document-address-and-etag.md
@@ -207,13 +207,13 @@ The following APIs support reading from followers:
 - Batch document reads (`PUT /_api/document?onlyget=true`)
 - Read-only AQL queries (`POST /_api/cursor`)
 - The edge API (`GET /_api/edges`)
-- Read-only stream transactions and their sub-operations
+- Read-only Stream Transactions and their sub-operations
   (`POST /_api/transaction/begin` etc.)
 
 The following APIs do not support reading from followers:
 
 - The graph API (`GET /_api/gharial` etc.)
-- JavaScript transactions (`POST /_api/transaction`)
+- JavaScript Transactions (`POST /_api/transaction`)
 
 You need to set the following HTTP header in an API request to ask for reads
 from followers:
@@ -226,7 +226,7 @@ This is in line with the older support to read from followers in the
 Active Failover deployment mode (see [Reading from Followers](../architecture-deployment-modes-active-failover-architecture.html#reading-from-followers)).
 
 For single requests, you specify this header in the read request.
-For stream transactions, the header has to be set on the request that
+For Stream Transactions, the header has to be set on the request that
 creates a read-only transaction.
 
 Every response to a request that could produce dirty reads has

--- a/3.10/programs-arangobackup-examples.md
+++ b/3.10/programs-arangobackup-examples.md
@@ -53,7 +53,7 @@ global write transaction lock:
   be used with caution, as it will potentially abort valid write transactions,
   meaning client applications will see errors for otherwise valid operations
   and queries. The force option currently only aborts Stream Transactions but
-  no JavaScript transactions.
+  no JavaScript Transactions.
 
 Restore
 -------

--- a/3.10/programs-arangod-javascript.md
+++ b/3.10/programs-arangod-javascript.md
@@ -82,7 +82,7 @@ collection for JavaScript objects will be run in each thread.
 
 `--javascript.v8-options options`
 
-Optional arguments to pass to the V8 Javascript engine. The V8 engine will run
+Optional arguments to pass to the V8 JavaScript engine. The V8 engine will run
 with default settings unless explicit options are specified using this
 option. The options passed will be forwarded to the V8 engine which will parse
 them on its own. Passing invalid options may result in an error being printed on

--- a/3.10/release-notes-api-changes310.md
+++ b/3.10/release-notes-api-changes310.md
@@ -72,6 +72,27 @@ section of the HTTP API reference manual.
 
 ### Endpoints augmented
 
+#### Computed Values
+
+The [Computed Values](data-modeling-documents-computed-values.html) feature
+extends the following endpoints with a new `computedValues` collection property
+that you can read or write to manage the computed value definitions:
+
+- Create a collection (`POST /_api/collection`)
+- Read the properties of a collection (`GET /_api/collection/{collection-name}/properties`)
+- Change the properties of a collection (`PUT /_api/collection/{collection-name}/properties`)
+
+The `computedValues` attribute is either `null` or an array of objects with the
+following attributes:
+- `name` (string, _required_)
+- `expression` (string, _required_)
+- `overwrite` (boolean, _required_)
+- `computeOn` (array of strings, _optional_, default: `["insert","update","replace"]`)
+- `keepNull` (boolean, _optional_, default: `true`)
+- `failOnWarning` (boolean, _optional_, default: `false`)
+
+#### Collection truncation markers
+
 APIs that return data from ArangoDB's write-ahead log (WAL) may now return
 collection truncate markers in the cluster, too. Previously such truncate
 markers were only issued in the single server and active failover modes, but not
@@ -79,9 +100,10 @@ in a cluster. Client applications that tail ArangoDB's WAL are thus supposed
 to handle WAL markers of type `2004`.
 
 The following HTTP APIs are affected:
-* `/_api/wal/tail`
-* `/_api/replication/logger-follow`
+- `/_api/wal/tail`
+- `/_api/replication/logger-follow`
 
+#### Startup and recovery information
 
 The GET `/_admin/status` API now also returns startup and recovery information. This
 can be used to determine the instance's progress during startup. The new `progress`
@@ -96,7 +118,6 @@ attribute is returned inside the `serverInfo` object with the following subattri
   the last handled recovery sequence number.
 
 See [Responding to Liveliness Probes](http/general.html#responding-to-liveliness-probes) for more information.
-
 
 #### Read from Followers
 
@@ -180,4 +201,6 @@ one needs to be created.
 
 ## JavaScript API
 
-
+The Computed Values feature extends the collection properties with a new
+`computedValues` attribute. See [Computed Values](data-modeling-documents-computed-values.html#javascript-api)
+for details.

--- a/3.10/release-notes-api-changes310.md
+++ b/3.10/release-notes-api-changes310.md
@@ -112,7 +112,7 @@ The following APIs are affected:
 - Batch document reads (`PUT /_api/document?onlyget=true`)
 - Read-only AQL queries (`POST /_api/cursor`)
 - The edge API (`GET /_api/edges`)
-- Read-only stream transactions and their sub-operations
+- Read-only Stream Transactions and their sub-operations
   (`POST /_api/transaction/begin` etc.)
 
 If the header is not specified, the behavior is the same as before.

--- a/3.10/release-notes-new-features310.md
+++ b/3.10/release-notes-new-features310.md
@@ -23,6 +23,55 @@ run 3.8.x and older versions on these systems via Rosetta 2 emulation, but not
 ArangoDB 3.10.x also runs on 64-bit ARM (AArch64) chips under Linux.
 The minimum requirement is an ARMv8 chip with Neon (SIMD).
 
+Computed Values
+---------------
+
+This feature lets you define expressions on the collection level
+that run on inserts, modifications, or both. You can access the data of the
+current document to compute new values using a subset of AQL.
+
+Possible use cases are to add timestamps of the creation or last modification to
+every document, to add default attributes, or to automatically process
+attributes for indexing purposes, like filtering, combining multiple attributes
+into one, and to convert characters to lowercase.
+
+The following example uses the JavaScript API to create a collection with two
+computed values, one to add a timestamp of the document creation, and another
+to maintain an attribute that combines two other attributes:
+
+```js
+var coll = db._create("users", {
+  computedValues: [
+    {
+      name: "createdAt",
+      expression: "RETURN DATE_ISO8601(DATE_NOW())",
+      overwrite: true,
+      computeOn: ["insert"]
+    },
+    {
+      name: "fullName",
+      expression: "RETURN LOWER(CONCAT_SEPARATOR(' ', @doc.firstName, @doc.lastName))",
+      overwrite: false,
+      computeOn: ["insert", "update", "replace"], // default
+      keepNull: false,
+      failOnWarning: true
+    }
+  ]
+});
+var doc = db.users.save({ firstName: "Paula", lastName: "Plant" });
+/* Stored document:
+  {
+    "createdAt": "2022-08-08T17:14:37.362Z",
+    "fullName": "paula plant",
+    "firstName": "Paula",
+    "lastName": "Plant"
+  }
+*/
+```
+
+See [Computed Values](data-modeling-documents-computed-values.html) for more
+information and examples.
+
 ArangoSearch
 ------------
 

--- a/3.10/security-security-options.md
+++ b/3.10/security-security-options.md
@@ -332,7 +332,7 @@ extra options are available for locking down JavaScript access to server functio
   [JavaScript tasks](appendix-java-script-modules-tasks.html).
 
 - `--javascript.transactions`: This option be set to `false` to turn off
-  [JavaScript transactions](http/transaction-js-transaction.html).
+  [JavaScript Transactions](http/transaction-js-transaction.html).
 
 ## Security options for managing Foxx applications
 

--- a/3.10/transactions-transaction-invocation.md
+++ b/3.10/transactions-transaction-invocation.md
@@ -50,7 +50,7 @@ Executes a server-side transaction, as specified by *object*.
     used in the transaction in read-only mode
   - *write*: a single collection or a list of collections that will be
     used in the transaction in write or read mode.
-- *action*: a Javascript function or a string with Javascript code
+- *action*: a JavaScript function or a string with JavaScript code
   containing all the instructions to be executed inside the transaction.
   If the code runs through successfully, the transaction will be committed
   at the end. If the code throws an exception, the transaction will be
@@ -145,7 +145,7 @@ Declaration of data modification and retrieval operations
 ---------------------------------------------------------
 
 All data modification and retrieval operations that are to be executed inside
-the transaction need to be specified in a Javascript function, using the *action*
+the transaction need to be specified in a JavaScript function, using the *action*
 attribute:
 
 ```js
@@ -159,10 +159,10 @@ db._executeTransaction({
 });
 ```
 
-Any valid Javascript code is allowed inside *action* but the code may only
+Any valid JavaScript code is allowed inside *action* but the code may only
 access the collections declared in *collections*.
-*action* may be a Javascript function as shown above, or a string representation
-of a Javascript function:
+*action* may be a JavaScript function as shown above, or a string representation
+of a JavaScript function:
 
 ```js
 db._executeTransaction({

--- a/3.8/programs-arangobackup-examples.md
+++ b/3.8/programs-arangobackup-examples.md
@@ -53,7 +53,7 @@ global write transaction lock:
   be used with caution, as it will potentially abort valid write transactions,
   meaning client applications will see errors for otherwise valid operations
   and queries. The force option currently only aborts Stream Transactions but
-  no JavaScript transactions.
+  no JavaScript Transactions.
 
 Restore
 -------

--- a/3.8/programs-arangod-javascript.md
+++ b/3.8/programs-arangod-javascript.md
@@ -82,7 +82,7 @@ collection for JavaScript objects will be run in each thread.
 
 `--javascript.v8-options options`
 
-Optional arguments to pass to the V8 Javascript engine. The V8 engine will run
+Optional arguments to pass to the V8 JavaScript engine. The V8 engine will run
 with default settings unless explicit options are specified using this
 option. The options passed will be forwarded to the V8 engine which will parse
 them on its own. Passing invalid options may result in an error being printed on

--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -699,7 +699,7 @@ areas of JavaScript code execution:
   executed.
 
 - `--javascript.transactions`: the default value for this option is
-  `true`, meaning JavaScript transactions are available as before. However,
+  `true`, meaning JavaScript Transactions are available as before. However,
   with this option they can be turned off by admins to limit the amount of
   JavaScript user code that is executed.
 

--- a/3.8/security-security-options.md
+++ b/3.8/security-security-options.md
@@ -313,7 +313,7 @@ extra options are available for locking down JavaScript access to server functio
   [JavaScript tasks](appendix-java-script-modules-tasks.html).
 
 - `--javascript.transactions`: This option be set to `false` to turn off
-  [JavaScript transactions](http/transaction-js-transaction.html).
+  [JavaScript Transactions](http/transaction-js-transaction.html).
 
 ## Security options for managing Foxx applications
 

--- a/3.8/transactions-transaction-invocation.md
+++ b/3.8/transactions-transaction-invocation.md
@@ -50,7 +50,7 @@ Executes a server-side transaction, as specified by *object*.
     used in the transaction in read-only mode
   - *write*: a single collection or a list of collections that will be
     used in the transaction in write or read mode.
-- *action*: a Javascript function or a string with Javascript code
+- *action*: a JavaScript function or a string with JavaScript code
   containing all the instructions to be executed inside the transaction.
   If the code runs through successfully, the transaction will be committed
   at the end. If the code throws an exception, the transaction will be
@@ -145,7 +145,7 @@ Declaration of data modification and retrieval operations
 ---------------------------------------------------------
 
 All data modification and retrieval operations that are to be executed inside
-the transaction need to be specified in a Javascript function, using the *action*
+the transaction need to be specified in a JavaScript function, using the *action*
 attribute:
 
 ```js
@@ -159,10 +159,10 @@ db._executeTransaction({
 });
 ```
 
-Any valid Javascript code is allowed inside *action* but the code may only
+Any valid JavaScript code is allowed inside *action* but the code may only
 access the collections declared in *collections*.
-*action* may be a Javascript function as shown above, or a string representation
-of a Javascript function:
+*action* may be a JavaScript function as shown above, or a string representation
+of a JavaScript function:
 
 ```js
 db._executeTransaction({

--- a/3.9/programs-arangobackup-examples.md
+++ b/3.9/programs-arangobackup-examples.md
@@ -53,7 +53,7 @@ global write transaction lock:
   be used with caution, as it will potentially abort valid write transactions,
   meaning client applications will see errors for otherwise valid operations
   and queries. The force option currently only aborts Stream Transactions but
-  no JavaScript transactions.
+  no JavaScript Transactions.
 
 Restore
 -------

--- a/3.9/programs-arangod-javascript.md
+++ b/3.9/programs-arangod-javascript.md
@@ -82,7 +82,7 @@ collection for JavaScript objects will be run in each thread.
 
 `--javascript.v8-options options`
 
-Optional arguments to pass to the V8 Javascript engine. The V8 engine will run
+Optional arguments to pass to the V8 JavaScript engine. The V8 engine will run
 with default settings unless explicit options are specified using this
 option. The options passed will be forwarded to the V8 engine which will parse
 them on its own. Passing invalid options may result in an error being printed on

--- a/3.9/security-security-options.md
+++ b/3.9/security-security-options.md
@@ -332,7 +332,7 @@ extra options are available for locking down JavaScript access to server functio
   [JavaScript tasks](appendix-java-script-modules-tasks.html).
 
 - `--javascript.transactions`: This option be set to `false` to turn off
-  [JavaScript transactions](http/transaction-js-transaction.html).
+  [JavaScript Transactions](http/transaction-js-transaction.html).
 
 ## Security options for managing Foxx applications
 

--- a/3.9/transactions-transaction-invocation.md
+++ b/3.9/transactions-transaction-invocation.md
@@ -50,7 +50,7 @@ Executes a server-side transaction, as specified by *object*.
     used in the transaction in read-only mode
   - *write*: a single collection or a list of collections that will be
     used in the transaction in write or read mode.
-- *action*: a Javascript function or a string with Javascript code
+- *action*: a JavaScript function or a string with JavaScript code
   containing all the instructions to be executed inside the transaction.
   If the code runs through successfully, the transaction will be committed
   at the end. If the code throws an exception, the transaction will be
@@ -145,7 +145,7 @@ Declaration of data modification and retrieval operations
 ---------------------------------------------------------
 
 All data modification and retrieval operations that are to be executed inside
-the transaction need to be specified in a Javascript function, using the *action*
+the transaction need to be specified in a JavaScript function, using the *action*
 attribute:
 
 ```js
@@ -159,10 +159,10 @@ db._executeTransaction({
 });
 ```
 
-Any valid Javascript code is allowed inside *action* but the code may only
+Any valid JavaScript code is allowed inside *action* but the code may only
 access the collections declared in *collections*.
-*action* may be a Javascript function as shown above, or a string representation
-of a Javascript function:
+*action* may be a JavaScript function as shown above, or a string representation
+of a JavaScript function:
 
 ```js
 db._executeTransaction({

--- a/drivers/dotnet-usage.md
+++ b/drivers/dotnet-usage.md
@@ -31,7 +31,7 @@ serializer.DefaultOptions.IgnoreNullValues = false;
 
 APIs that support specifying HTTP request headers have an optional method argument to pass in header values.
 
-For example, to specify a stream transaction ID when creating a document:
+For example, to specify a Stream Transaction ID when creating a document:
 
 
 ```csharp


### PR DESCRIPTION
Also adds a description for `schema` that was missing. I haven't checked if more properties are missing.

The important changes are in this commit: https://github.com/arangodb/docs/pull/1082/commits/a42066dededd681dd32381a822681fbe12336e99