### PR TITLE
BTS-1023 | `--javascript.copy-installation` fails on some file systems

### DIFF
--- a/3.10/programs-arangod-general.md
+++ b/3.10/programs-arangod-general.md
@@ -160,3 +160,22 @@ way to work with the server in this mode is by using the emergency
 console.
 Note that the server cannot be started in this mode if it is
 already running in this or another mode.
+
+## File copying mode
+
+<small>Introduced in: v3.9.4</small>
+
+`--use-splice-syscall`
+
+This is a Linux-specific startup option that controls whether the 
+Linux-specific `splice()` syscall should be used for copying file
+contents. While that syscall is generally available since Linux 2.6.x,
+it is also required that the underlying filesystem supports the splice
+operation. This is not true for some encrypted filesystems (e.g.
+ecryptfs), on which splice() calls can fail.
+
+By setting the startup option `--use-splice-syscall` to `false`, 
+a less efficient, but more portable file copying method will be used 
+instead, which should work on all filesystems.
+
+The startup option is not available on other operating systems than Linux.

--- a/3.10/programs-arangod-general.md
+++ b/3.10/programs-arangod-general.md
@@ -172,7 +172,7 @@ Linux-specific `splice()` syscall should be used for copying file
 contents. While that syscall is generally available since Linux 2.6.x,
 it is also required that the underlying filesystem supports the splice
 operation. This is not true for some encrypted filesystems (e.g.
-ecryptfs), on which splice() calls can fail.
+ecryptfs), on which `splice()` calls can fail.
 
 You can set the `--use-splice-syscall` startup option to `false`
 to use a less efficient, but more portable file copying method

--- a/3.10/programs-arangod-general.md
+++ b/3.10/programs-arangod-general.md
@@ -174,8 +174,8 @@ it is also required that the underlying filesystem supports the splice
 operation. This is not true for some encrypted filesystems (e.g.
 ecryptfs), on which splice() calls can fail.
 
-By setting the startup option `--use-splice-syscall` to `false`, 
-a less efficient, but more portable file copying method will be used 
+You can set the `--use-splice-syscall` startup option to `false`
+to use a less efficient, but more portable file copying method
 instead, which should work on all filesystems.
 
 The startup option is not available on other operating systems than Linux.

--- a/3.11/programs-arangod-general.md
+++ b/3.11/programs-arangod-general.md
@@ -160,3 +160,22 @@ way to work with the server in this mode is by using the emergency
 console.
 Note that the server cannot be started in this mode if it is
 already running in this or another mode.
+
+## File copying mode
+
+<small>Introduced in: v3.9.4</small>
+
+`--use-splice-syscall`
+
+This is a Linux-specific startup option that controls whether the 
+Linux-specific `splice()` syscall should be used for copying file
+contents. While that syscall is generally available since Linux 2.6.x,
+it is also required that the underlying filesystem supports the splice
+operation. This is not true for some encrypted filesystems (e.g.
+ecryptfs), on which splice() calls can fail.
+
+By setting the startup option `--use-splice-syscall` to `false`, 
+a less efficient, but more portable file copying method will be used 
+instead, which should work on all filesystems.
+
+The startup option is not available on other operating systems than Linux.

--- a/3.11/programs-arangod-general.md
+++ b/3.11/programs-arangod-general.md
@@ -172,10 +172,10 @@ Linux-specific `splice()` syscall should be used for copying file
 contents. While that syscall is generally available since Linux 2.6.x,
 it is also required that the underlying filesystem supports the splice
 operation. This is not true for some encrypted filesystems (e.g.
-ecryptfs), on which splice() calls can fail.
+ecryptfs), on which `splice() calls can fail.
 
-By setting the startup option `--use-splice-syscall` to `false`, 
-a less efficient, but more portable file copying method will be used 
+You can set the `--use-splice-syscall` startup option to `false`
+to use a less efficient, but more portable file copying method
 instead, which should work on all filesystems.
 
 The startup option is not available on other operating systems than Linux.

--- a/3.9/programs-arangod-general.md
+++ b/3.9/programs-arangod-general.md
@@ -170,10 +170,10 @@ Linux-specific `splice()` syscall should be used for copying file
 contents. While that syscall is generally available since Linux 2.6.x,
 it is also required that the underlying filesystem supports the splice
 operation. This is not true for some encrypted filesystems (e.g.
-ecryptfs), on which splice() calls can fail.
+ecryptfs), on which `splice()` calls can fail.
 
-By setting the startup option `--use-splice-syscall` to `false`, 
-a less efficient, but more portable file copying method will be used 
+You can set the `--use-splice-syscall` startup option to `false`
+to use a less efficient, but more portable file copying method
 instead, which should work on all filesystems.
 
 The startup option is not available on other operating systems than Linux.

--- a/3.9/programs-arangod-general.md
+++ b/3.9/programs-arangod-general.md
@@ -158,3 +158,22 @@ way to work with the server in this mode is by using the emergency
 console.
 Note that the server cannot be started in this mode if it is
 already running in this or another mode.
+
+## File copying mode
+
+<small>Introduced in: v3.9.4</small>
+
+`--use-splice-syscall`
+
+This is a Linux-specific startup option that controls whether the 
+Linux-specific `splice()` syscall should be used for copying file
+contents. While that syscall is generally available since Linux 2.6.x,
+it is also required that the underlying filesystem supports the splice
+operation. This is not true for some encrypted filesystems (e.g.
+ecryptfs), on which splice() calls can fail.
+
+By setting the startup option `--use-splice-syscall` to `false`, 
+a less efficient, but more portable file copying method will be used 
+instead, which should work on all filesystems.
+
+The startup option is not available on other operating systems than Linux.


### PR DESCRIPTION
Documentation for https://arangodb.atlassian.net/browse/BTS-1023:

Refers to:
* devel: https://github.com/arangodb/arangodb/pull/17099
* 3.10: https://github.com/arangodb/arangodb/pull/17098
* 3.9.4: https://github.com/arangodb/arangodb/pull/17109 (3.9.4)
