### PR TITLE
Mention new `shardingStrategy` value in release notes

### DIFF
--- a/3.10/release-notes-api-changes310.md
+++ b/3.10/release-notes-api-changes310.md
@@ -77,6 +77,17 @@ section of the HTTP API reference manual.
 
 ### Endpoints augmented
 
+#### EnterpriseGraphs (Enterprise Edition)
+
+You can create EnterpriseGraphs by setting `isSmart` to `true`, the `numberOfShards`,
+but no `smartGraphAttribute`. You can optionally specify which collections shall
+be `satellites`. There are no new attributes for creating this type of graph.
+
+The vertex collections of an EnterpriseGraph have a new `shardingStrategy` value
+of `enterprise-hex-smart-vertex`.
+
+Also see [EnterpriseGraphs](graphs-enterprise-graphs.html).
+
 #### Inverted Indexes
 
 The `/_api/index` endpoints support a new `inverted` index type.


### PR DESCRIPTION
Vertex collections of EnterpriseGraphs have the shardingStrategy set to the value "enterprise-hex-smart-vertex" - which was added to the docs in #1144, except the API changes page