### PR TITLE
Partially revert #1175 because `primarySortCache` will be released in v3.9.6

### DIFF
--- a/3.10/arangosearch-views-search-alias.md
+++ b/3.10/arangosearch-views-search-alias.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: search-alias Views Reference
 ---
 # `search-alias` Views Reference
 

--- a/3.10/arangosearch-views.md
+++ b/3.10/arangosearch-views.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: arangosearch Views Reference
 ---
 `arangosearch` Views Reference
 ==============================

--- a/3.11/arangosearch-views-search-alias.md
+++ b/3.11/arangosearch-views-search-alias.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: search-alias Views Reference
 ---
 # `search-alias` Views Reference
 

--- a/3.11/arangosearch-views.md
+++ b/3.11/arangosearch-views.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: arangosearch Views Reference
 ---
 `arangosearch` Views Reference
 ==============================

--- a/3.9/arangosearch-performance.md
+++ b/3.9/arangosearch-performance.md
@@ -120,41 +120,6 @@ The View needs to be created via the HTTP or JavaScript API (arangosh) to set it
 The primary sort data is LZ4 compressed by default (`primarySortCompression` is
 `"lz4"`). Set it to `"none"` on View creation to trade space for speed.
 
-You can additionally set the `primarySortCache` option to `true` to always cache
-the primary sort columns in memory, which can improve the query performance:
-
-```json
-{
-  "links": {
-    "coll1": {
-      "fields": {
-        "text": {},
-        "date": {}
-      }
-    },
-    "coll2": {
-      "fields": {
-        "text": {}
-      }
-    },
-    "primarySort": [
-      {
-        "field": "date",
-        "direction": "desc"
-      },
-      {
-        "field": "text",
-        "direction": "asc"
-      }
-    ],
-    "primarySortCache": true
-  }
-}
-```
-
-See the [`primarySortCache` View property](arangosearch-views.html#view-properties)
-for details.
-
 ## Stored Values
 
 It is possible to directly store the values of document attributes in View

--- a/3.9/arangosearch-views.md
+++ b/3.9/arangosearch-views.md
@@ -143,21 +143,6 @@ During view modification the following directives apply:
 
   - `"lz4"` (default): use LZ4 fast compression.
   - `"none"`: disable compression to trade space for speed.
-  
-- **primarySortCache** (_optional_; type: `boolean`; default: `false`)
-
-  <small>Introduced in: v3.9.5</small>
-
-  If you enable this option, then the primary sort columns are always cached in
-  memory. This can improve the performance of queries that utilize the
-  [primary sort order](arangosearch-performance.html#primary-sort-order).
-  Otherwise, these values are memory-mapped and it is up to the operating system
-  to load them from disk into memory and to evict them from memory.
-
-  See the [`--arangosearch.columns-cache-limit` startup option](programs-arangod-arangosearch.html)
-  to control the memory consumption of this cache.
-
-  {% include hint-ee.md feature="ArangoSearch caching" %}
 
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 

--- a/3.9/release-notes-api-changes39.md
+++ b/3.9/release-notes-api-changes39.md
@@ -246,6 +246,25 @@ The `text` and `norm` Analyzers support `language[_COUNTRY]`, the `stem`
 Analyzer only `language`. The former syntax is still supported but automatically
 normalized to the new syntax.
 
+#### Views API
+
+Views of the type `arangosearch` support new caching options in the
+Enterprise Edition.
+
+<small>Introduced in: v3.9.5</small>
+
+- A `cache` option for individual View links or fields (boolean, default: `false`).
+- A `cache` option in the definition of a `storedValues` View property
+  (boolean, immutable, default: `false`).
+
+The `POST /_api/view` endpoint accepts these new options for `arangosearch`
+Views, the `GET /_api/view/<view-name>/properties` endpoint may return these
+options, and you can change them with the `PUT /_api/view/<view-name>/properties`
+and `PATCH /_api/view/<view-name>/properties` endpoints (except the immutable one).
+
+See the [`arangosearch` Views Reference](arangosearch-views.html#link-properties)
+for details.
+
 #### Metrics API
 
 <small>Introduced in: v3.9.5</small>

--- a/3.9/release-notes-new-features39.md
+++ b/3.9/release-notes-new-features39.md
@@ -87,9 +87,6 @@ Views of the type `arangosearch` support three new options:
 - You can enable the new `cache` option for individual View links or fields
   to always cache field normalization values in memory. This can improve the
   performance of scoring and ranking queries.
-- You can enable the new `primarySortCache` View property to always cache the
-  primary sort columns in memory. This can improve the performance of queries
-  that utilize the primary sort order.
 - You can enable the new `cache` option in the definition of a `storedValues`
   View property to always cache stored values in memory. This can improve the
   query performance if stored values are involved.


### PR DESCRIPTION
~~Upstream: https://github.com/arangodb/arangodb/pull/17602 (adds missing `cache` option to storedValues)~~

Too late to include upstream PRs for v3.9.5, added the changes to #1191 for v3.9.6 instead.