### PR TITLE
DOC-278 | Edge cache refilling (experimental) [3.9]

### DIFF
--- a/3.9/aql/operations-insert.md
+++ b/3.9/aql/operations-insert.md
@@ -168,6 +168,16 @@ FOR doc IN collection
   OPTIONS { exclusive: true }
 ```
 
+### `refillIndexCaches`
+
+Whether to add new entries to the in-memory edge cache if edge documents are
+inserted.
+
+```js
+INSERT { _from: "vert/A", _to: "vert/B" } INTO coll
+  OPTIONS { refillIndexCaches: true }
+```
+
 Returning the inserted documents
 --------------------------------
 

--- a/3.9/aql/operations-remove.md
+++ b/3.9/aql/operations-remove.md
@@ -143,6 +143,16 @@ FOR doc IN collection
   OPTIONS { exclusive: true }
 ```
 
+### `refillIndexCaches`
+
+Whether to delete existing entries from the in-memory edge cache and refill it
+with other edges if edge documents are removed.
+
+```js
+REMOVE { _key: "123" } IN edgeColl
+  OPTIONS { refillIndexCaches: true }
+```
+
 Returning the removed documents
 -------------------------------
 

--- a/3.9/aql/operations-replace.md
+++ b/3.9/aql/operations-replace.md
@@ -144,6 +144,16 @@ FOR doc IN collection
   OPTIONS { exclusive: true }
 ```
 
+### `refillIndexCaches`
+
+Whether to update existing entries in the in-memory edge cache if
+edge documents are replaced.
+
+```js
+REPLACE { _key: "123", _from: "vert/C", _to: "vert/D" } IN edgeColl
+  OPTIONS { refillIndexCaches: true }
+```
+
 Returning the modified documents
 --------------------------------
 

--- a/3.9/aql/operations-update.md
+++ b/3.9/aql/operations-update.md
@@ -273,6 +273,16 @@ FOR doc IN collection
   OPTIONS { exclusive: true }
 ```
 
+### `refillIndexCaches`
+
+Whether to update existing entries in the in-memory edge cache if
+edge documents are updated.
+
+```js
+UPDATE { _key: "123", _from: "vert/C", _to: "vert/D" } IN edgeColl
+  OPTIONS { refillIndexCaches: true }
+```
+
 Returning the modified documents
 --------------------------------
 

--- a/3.9/release-notes-api-changes39.md
+++ b/3.9/release-notes-api-changes39.md
@@ -271,6 +271,21 @@ endpoints.
 See the [`arangosearch` Views Reference](arangosearch-views.html#link-properties)
 for details.
 
+#### Document API
+
+<small>Introduced in: v3.9.6</small>
+
+The following endpoints support a new, experimental `refillIndexCaches` query
+parameter to repopulate the edge cache after requests that insert, update,
+replace, or remove single or multiple edge documents:
+
+- `POST /_api/document/{collection}`
+- `PATCH /_api/document/{collection}/{key}`
+- `PUT /_api/document/{collection}/{key}`
+- `DELETE /_api/document/{collection}/{key}`
+
+It is a boolean option and the default is `false`.
+
 #### Metrics API
 
 <small>Introduced in: v3.9.5</small>
@@ -288,6 +303,16 @@ The metrics endpoints include the following new traffic accounting metrics:
 - `arangodb_client_user_connection_statistics_bytes_received`
 - `arangodb_client_user_connection_statistics_bytes_sent`
 - `arangodb_http1_connections_total`
+
+---
+
+<small>Introduced in: v3.9.6</small>
+
+The metrics endpoints include the following new edge cache (re-)filling metrics:
+
+- `rocksdb_cache_auto_refill_loaded_total`
+- `rocksdb_cache_auto_refill_dropped_total`
+- `rocksdb_cache_full_index_refills_total`
 
 ### Endpoints moved
 

--- a/3.9/release-notes-new-features39.md
+++ b/3.9/release-notes-new-features39.md
@@ -512,10 +512,6 @@ The following metrics are available:
 This feature is experimental.
 
 Also see:
-- [AQL `INSERT` operation](aql/operations-insert.html#refillindexcaches)
-- [AQL `UPDATE` operation](aql/operations-update.html#refillindexcaches)
-- [AQL `REPLACE` operation](aql/operations-replace.html#refillindexcaches)
-- [AQL `REMOVE` operation](aql/operations-remove.html#refillindexcaches)
 - [Document HTTP API](http/document-working-with-documents.html)
 - [Edge cache refill options](#edge-cache-refill-options)
 


### PR DESCRIPTION
Feature PR: https://github.com/arangodb/arangodb/pull/17705

Upstream (DocuBlocks, Metrics, startup options): https://github.com/arangodb/arangodb/pull/17758

(The 3.9.6 release process has already started so we may need to merge this docs PR and leave the upstream PR open for later)

To be forward-ported to 3.10(.2) with minimal changes (introduced in versions). Forward port to 3.11 needs adjustments because the feature also supports persistent indexes with in-memory hash cache and not only the edge cache.