### PR TITLE
DOC-67 | Only built-in JS AQL functions use _aql namespace

### DIFF
--- a/3.10/aql/extending-conventions.md
+++ b/3.10/aql/extending-conventions.md
@@ -9,24 +9,28 @@ Conventions
 Naming
 ------
 
-Built-in AQL functions that are shipped with ArangoDB reside in the namespace
-`_aql`, which is also the default namespace to look in if an unqualified
-function name is found.
+AQL functions that are implemented with JavaScript are always in a namespace.
+To register a user-defined AQL function, you need to give it a name with a
+namespace. The `::` symbol is used as the namespace separator, for example,
+`MYGROUP::MYFUNC`. You can use one or multiple levels of namespaces to create
+meaningful function groups.
 
-To refer to a user-defined AQL function, the function name must be fully
-qualified to also include the user-defined namespace. The `::` symbol is used
-as the namespace separator. Users can create a multi-level hierarchy of function
-groups if required:
+The names of user-defined functions are case-insensitive, like all function
+names in AQL.
+
+To refer to and call user-defined functions in AQL queries, you need to use the
+fully qualified name with the namespaces:
 
 ```aql
 MYGROUP::MYFUNC()
 MYFUNCTIONS::MATH::RANDOM()
 ```
 
-**Note**: Adding user functions to the *_aql* namespace is disallowed and will
-fail.
-
-User function names are case-insensitive like all function names in AQL.
+ArangoDB's built-in AQL functions are all implemented in C++ and are not in a
+namespace, except for the internal `V8()` function, which resides in the `_aql`
+namespace. It is the default namespace, which means that you can use the
+unqualified name of the function (without `_aql::`) to refer to it. Note that
+you cannot add own functions to this namespace.
 
 Variables and side effects
 --------------------------
@@ -96,7 +100,7 @@ and state outside of the user function itself.
 Return values
 -------------
 
-User functions must only return primitive types (i.e. *null*, boolean
+User functions must only return primitive types (i.e. `null`, boolean
 values, numeric values, string values) or aggregate types (arrays or
 objects) composed of these types.
 Returning any other JavaScript object type (Function, Date, RegExp etc.) from
@@ -105,9 +109,9 @@ a user function may lead to undefined behavior and should be avoided.
 Enforcing strict mode
 ---------------------
 
-By default, any user function code will be executed in *sloppy mode*, not
-*strict* or *strong mode*. In order to make a user function run in strict
-mode, use `"use strict"` explicitly inside the user function, e.g.:
+By default, any user function code is executed in *sloppy mode*. In order to
+make a user function run in strict mode, use `"use strict"` explicitly inside
+the user function:
 
 ```js
 function (values) {
@@ -123,4 +127,4 @@ function (values) {
 }
 ```
 
-Any violation of the strict mode will trigger a runtime error.
+Any violation of the strict mode triggers a runtime error.

--- a/3.10/aql/extending-functions.md
+++ b/3.10/aql/extending-functions.md
@@ -6,7 +6,7 @@ Registering and Unregistering User Functions
 ============================================
 
 User-defined functions (UDFs) can be registered in the selected database 
-using the *aqlfunctions* object as follows:
+using the `@arangodb/aql/functions` module as follows:
 
 ```js
 var aqlfunctions = require("@arangodb/aql/functions");
@@ -20,10 +20,10 @@ User Functions management.
 
 In a cluster setup, make sure to connect to a Coordinator to manage the UDFs.
 
-Documents in the *_aqlfunctions* collection (or any other system collection)
+Documents in the `_aqlfunctions` collection (or any other system collection)
 should not be accessed directly, but only via the dedicated interfaces.
 Otherwise you might see caching issues or accidentally break something.
-The interfaces will ensure the correct format of the documents and invalidate
+The interfaces ensure the correct format of the documents and invalidate
 the UDF cache.
 
 Registering an AQL user function
@@ -54,38 +54,36 @@ arangosh> var func = require("path/to/file.js");
 arangosh> aqlfunctions.register("HUMAN::GREETING", func, true);
 ```
 
-Note that a return value of *false* means that the function `HUMAN::GREETING`
-was newly created, and not that it failed to register. *true* is returned
+Note that a return value of `false` means that the function `HUMAN::GREETING`
+was newly created, and not that it failed to register. `true` is returned
 if a function of that name existed before and was just updated.
 
 `aqlfunctions.register(name, code, isDeterministic)`
 
 Registers an AQL user function, identified by a fully qualified function
-name. The function code in *code* must be specified as a JavaScript
+name. The function code in `code` must be specified as a JavaScript
 function or a string representation of a JavaScript function.
-If the function code in *code* is passed as a string, it is required that
+If the function code in `code` is passed as a string, it is required that
 the string evaluates to a JavaScript function definition.
 
-If a function identified by *name* already exists, the previous function
-definition will be updated. Please also make sure that the function code
+If a function identified by `name` already exists, the previous function
+definition is updated. Please also make sure that the function code
 does not violate the [Conventions](extending-conventions.html) for AQL 
 functions.
 
-The *isDeterministic* attribute can be used to specify whether the
+The `isDeterministic` attribute can be used to specify whether the
 function results are fully deterministic (i.e. depend solely on the input
 and are the same for repeated calls with the same input values). It is not
 used at the moment but may be used for optimizations later.
 
 The registered function is stored in the selected database's system 
-collection *_aqlfunctions*.
+collection `_aqlfunctions`.
 
-The function returns *true* when it updates/replaces an existing AQL 
-function of the same name, and *false* otherwise. It will throw an exception
-when it detects syntactically invalid function code.
-
+The function returns `true` when it updates/replaces an existing AQL 
+function of the same name, and `false` otherwise. It throws an exception
+if it detects syntactically invalid function code.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").register("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT",
@@ -94,7 +92,7 @@ function (celsius) {
 });
 ```
 
-The function code will not be executed in *strict mode* or *strong mode* by 
+The function code is not executed in *strict mode* or *strong mode* by 
 default. In order to make a user function being run in strict mode, use
 `use strict` explicitly, e.g.:
 
@@ -132,7 +130,7 @@ invalid number of arguments for function '%s()', expected number of arguments: m
 
 In the example above, `%s` is replaced by `this.name` (the AQL function name),
 and both `%d` placeholders by `1` (number of expected arguments). If you call
-the function without an argument, you will see this:
+the function without an argument, you see this:
 
 ```js
 arangosh> db._query("RETURN MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()")
@@ -153,42 +151,34 @@ Deleting an existing AQL user function
 Unregisters an existing AQL user function, identified by the fully qualified
 function name.
 
-Trying to unregister a function that does not exist will result in an
+Trying to unregister a function that does not exist results in an
 exception.
 
-
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregister("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT");
 ```
 
-
 Unregister Group
 ----------------
 
-<!-- js/common/modules/@arangodb/aql/functions.js -->
+Delete a group of AQL user functions:
 
-
-delete a group of AQL user functions
 `aqlfunctions.unregisterGroup(prefix)`
 
 Unregisters a group of AQL user function, identified by a common function
 group prefix.
 
-This will return the number of functions unregistered.
-
+This returns the number of functions unregistered.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS::TEMPERATURE");
 
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS");
 ```
-
 
 Listing all AQL user functions
 ------------------------------
@@ -198,11 +188,10 @@ Listing all AQL user functions
 Returns all previously registered AQL user functions, with their fully
 qualified names and function code.
 
-The result may optionally be restricted to a specified group of functions
-by specifying a group prefix:
-
 `aqlfunctions.toArray(prefix)`
 
+Returns all previously registered AQL user functions, restricted to a specified
+group of functions by specifying a group prefix.
 
 **Examples**
 

--- a/3.11/aql/extending-conventions.md
+++ b/3.11/aql/extending-conventions.md
@@ -9,24 +9,28 @@ Conventions
 Naming
 ------
 
-Built-in AQL functions that are shipped with ArangoDB reside in the namespace
-`_aql`, which is also the default namespace to look in if an unqualified
-function name is found.
+AQL functions that are implemented with JavaScript are always in a namespace.
+To register a user-defined AQL function, you need to give it a name with a
+namespace. The `::` symbol is used as the namespace separator, for example,
+`MYGROUP::MYFUNC`. You can use one or multiple levels of namespaces to create
+meaningful function groups.
 
-To refer to a user-defined AQL function, the function name must be fully
-qualified to also include the user-defined namespace. The `::` symbol is used
-as the namespace separator. Users can create a multi-level hierarchy of function
-groups if required:
+The names of user-defined functions are case-insensitive, like all function
+names in AQL.
+
+To refer to and call user-defined functions in AQL queries, you need to use the
+fully qualified name with the namespaces:
 
 ```aql
 MYGROUP::MYFUNC()
 MYFUNCTIONS::MATH::RANDOM()
 ```
 
-**Note**: Adding user functions to the *_aql* namespace is disallowed and will
-fail.
-
-User function names are case-insensitive like all function names in AQL.
+ArangoDB's built-in AQL functions are all implemented in C++ and are not in a
+namespace, except for the internal `V8()` function, which resides in the `_aql`
+namespace. It is the default namespace, which means that you can use the
+unqualified name of the function (without `_aql::`) to refer to it. Note that
+you cannot add own functions to this namespace.
 
 Variables and side effects
 --------------------------
@@ -96,7 +100,7 @@ and state outside of the user function itself.
 Return values
 -------------
 
-User functions must only return primitive types (i.e. *null*, boolean
+User functions must only return primitive types (i.e. `null`, boolean
 values, numeric values, string values) or aggregate types (arrays or
 objects) composed of these types.
 Returning any other JavaScript object type (Function, Date, RegExp etc.) from
@@ -105,9 +109,9 @@ a user function may lead to undefined behavior and should be avoided.
 Enforcing strict mode
 ---------------------
 
-By default, any user function code will be executed in *sloppy mode*, not
-*strict* or *strong mode*. In order to make a user function run in strict
-mode, use `"use strict"` explicitly inside the user function, e.g.:
+By default, any user function code is executed in *sloppy mode*. In order to
+make a user function run in strict mode, use `"use strict"` explicitly inside
+the user function:
 
 ```js
 function (values) {
@@ -123,4 +127,4 @@ function (values) {
 }
 ```
 
-Any violation of the strict mode will trigger a runtime error.
+Any violation of the strict mode triggers a runtime error.

--- a/3.11/aql/extending-functions.md
+++ b/3.11/aql/extending-functions.md
@@ -6,7 +6,7 @@ Registering and Unregistering User Functions
 ============================================
 
 User-defined functions (UDFs) can be registered in the selected database 
-using the *aqlfunctions* object as follows:
+using the `@arangodb/aql/functions` module as follows:
 
 ```js
 var aqlfunctions = require("@arangodb/aql/functions");
@@ -20,10 +20,10 @@ User Functions management.
 
 In a cluster setup, make sure to connect to a Coordinator to manage the UDFs.
 
-Documents in the *_aqlfunctions* collection (or any other system collection)
+Documents in the `_aqlfunctions` collection (or any other system collection)
 should not be accessed directly, but only via the dedicated interfaces.
 Otherwise you might see caching issues or accidentally break something.
-The interfaces will ensure the correct format of the documents and invalidate
+The interfaces ensure the correct format of the documents and invalidate
 the UDF cache.
 
 Registering an AQL user function
@@ -54,38 +54,36 @@ arangosh> var func = require("path/to/file.js");
 arangosh> aqlfunctions.register("HUMAN::GREETING", func, true);
 ```
 
-Note that a return value of *false* means that the function `HUMAN::GREETING`
-was newly created, and not that it failed to register. *true* is returned
+Note that a return value of `false` means that the function `HUMAN::GREETING`
+was newly created, and not that it failed to register. `true` is returned
 if a function of that name existed before and was just updated.
 
 `aqlfunctions.register(name, code, isDeterministic)`
 
 Registers an AQL user function, identified by a fully qualified function
-name. The function code in *code* must be specified as a JavaScript
+name. The function code in `code` must be specified as a JavaScript
 function or a string representation of a JavaScript function.
-If the function code in *code* is passed as a string, it is required that
+If the function code in `code` is passed as a string, it is required that
 the string evaluates to a JavaScript function definition.
 
-If a function identified by *name* already exists, the previous function
-definition will be updated. Please also make sure that the function code
+If a function identified by `name` already exists, the previous function
+definition is updated. Please also make sure that the function code
 does not violate the [Conventions](extending-conventions.html) for AQL 
 functions.
 
-The *isDeterministic* attribute can be used to specify whether the
+The `isDeterministic` attribute can be used to specify whether the
 function results are fully deterministic (i.e. depend solely on the input
 and are the same for repeated calls with the same input values). It is not
 used at the moment but may be used for optimizations later.
 
 The registered function is stored in the selected database's system 
-collection *_aqlfunctions*.
+collection `_aqlfunctions`.
 
-The function returns *true* when it updates/replaces an existing AQL 
-function of the same name, and *false* otherwise. It will throw an exception
-when it detects syntactically invalid function code.
-
+The function returns `true` when it updates/replaces an existing AQL 
+function of the same name, and `false` otherwise. It throws an exception
+if it detects syntactically invalid function code.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").register("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT",
@@ -94,7 +92,7 @@ function (celsius) {
 });
 ```
 
-The function code will not be executed in *strict mode* or *strong mode* by 
+The function code is not executed in *strict mode* or *strong mode* by 
 default. In order to make a user function being run in strict mode, use
 `use strict` explicitly, e.g.:
 
@@ -132,7 +130,7 @@ invalid number of arguments for function '%s()', expected number of arguments: m
 
 In the example above, `%s` is replaced by `this.name` (the AQL function name),
 and both `%d` placeholders by `1` (number of expected arguments). If you call
-the function without an argument, you will see this:
+the function without an argument, you see this:
 
 ```js
 arangosh> db._query("RETURN MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()")
@@ -153,42 +151,34 @@ Deleting an existing AQL user function
 Unregisters an existing AQL user function, identified by the fully qualified
 function name.
 
-Trying to unregister a function that does not exist will result in an
+Trying to unregister a function that does not exist results in an
 exception.
 
-
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregister("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT");
 ```
 
-
 Unregister Group
 ----------------
 
-<!-- js/common/modules/@arangodb/aql/functions.js -->
+Delete a group of AQL user functions:
 
-
-delete a group of AQL user functions
 `aqlfunctions.unregisterGroup(prefix)`
 
 Unregisters a group of AQL user function, identified by a common function
 group prefix.
 
-This will return the number of functions unregistered.
-
+This returns the number of functions unregistered.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS::TEMPERATURE");
 
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS");
 ```
-
 
 Listing all AQL user functions
 ------------------------------
@@ -198,11 +188,10 @@ Listing all AQL user functions
 Returns all previously registered AQL user functions, with their fully
 qualified names and function code.
 
-The result may optionally be restricted to a specified group of functions
-by specifying a group prefix:
-
 `aqlfunctions.toArray(prefix)`
 
+Returns all previously registered AQL user functions, restricted to a specified
+group of functions by specifying a group prefix.
 
 **Examples**
 

--- a/3.8/aql/extending-conventions.md
+++ b/3.8/aql/extending-conventions.md
@@ -9,24 +9,28 @@ Conventions
 Naming
 ------
 
-Built-in AQL functions that are shipped with ArangoDB reside in the namespace
-`_aql`, which is also the default namespace to look in if an unqualified
-function name is found.
+AQL functions that are implemented with JavaScript are always in a namespace.
+To register a user-defined AQL function, you need to give it a name with a
+namespace. The `::` symbol is used as the namespace separator, for example,
+`MYGROUP::MYFUNC`. You can use one or multiple levels of namespaces to create
+meaningful function groups.
 
-To refer to a user-defined AQL function, the function name must be fully
-qualified to also include the user-defined namespace. The `::` symbol is used
-as the namespace separator. Users can create a multi-level hierarchy of function
-groups if required:
+The names of user-defined functions are case-insensitive, like all function
+names in AQL.
+
+To refer to and call user-defined functions in AQL queries, you need to use the
+fully qualified name with the namespaces:
 
 ```js
 MYGROUP::MYFUNC()
 MYFUNCTIONS::MATH::RANDOM()
 ```
 
-**Note**: Adding user functions to the *_aql* namespace is disallowed and will
-fail.
-
-User function names are case-insensitive like all function names in AQL.
+ArangoDB's built-in AQL functions are all implemented in C++ and are not in a
+namespace, except for the internal `V8()` function, which resides in the `_aql`
+namespace. It is the default namespace, which means that you can use the
+unqualified name of the function (without `_aql::`) to refer to it. Note that
+you cannot add own functions to this namespace.
 
 Variables and side effects
 --------------------------
@@ -37,7 +41,7 @@ purely functional and thus free of side effects and state, and state modificatio
 
 {% hint 'warning' %}
 Modification of global variables is unsupported, as is reading or changing
-the data of any collection from inside an AQL user function.
+the data of any collection or running queries from inside an AQL user function.
 {% endhint %}
 
 User function code is late-bound, and may thus not rely on any variables
@@ -96,7 +100,7 @@ and state outside of the user function itself.
 Return values
 -------------
 
-User functions must only return primitive types (i.e. *null*, boolean
+User functions must only return primitive types (i.e. `null`, boolean
 values, numeric values, string values) or aggregate types (arrays or
 objects) composed of these types.
 Returning any other JavaScript object type (Function, Date, RegExp etc.) from
@@ -105,9 +109,9 @@ a user function may lead to undefined behavior and should be avoided.
 Enforcing strict mode
 ---------------------
 
-By default, any user function code will be executed in *sloppy mode*, not
-*strict* or *strong mode*. In order to make a user function run in strict
-mode, use `"use strict"` explicitly inside the user function, e.g.:
+By default, any user function code is executed in *sloppy mode*. In order to
+make a user function run in strict mode, use `"use strict"` explicitly inside
+the user function:
 
 ```js
 function (values) {
@@ -123,4 +127,4 @@ function (values) {
 }
 ```
 
-Any violation of the strict mode will trigger a runtime error.
+Any violation of the strict mode triggers a runtime error.

--- a/3.8/aql/extending-functions.md
+++ b/3.8/aql/extending-functions.md
@@ -6,7 +6,7 @@ Registering and Unregistering User Functions
 ============================================
 
 User-defined functions (UDFs) can be registered in the selected database 
-using the *aqlfunctions* object as follows:
+using the `@arangodb/aql/functions` module as follows:
 
 ```js
 var aqlfunctions = require("@arangodb/aql/functions");
@@ -20,10 +20,10 @@ User Functions management.
 
 In a cluster setup, make sure to connect to a Coordinator to manage the UDFs.
 
-Documents in the *_aqlfunctions* collection (or any other system collection)
+Documents in the `_aqlfunctions` collection (or any other system collection)
 should not be accessed directly, but only via the dedicated interfaces.
 Otherwise you might see caching issues or accidentally break something.
-The interfaces will ensure the correct format of the documents and invalidate
+The interfaces ensure the correct format of the documents and invalidate
 the UDF cache.
 
 Registering an AQL user function
@@ -49,43 +49,41 @@ module.exports = greeting;
 
 Then require it in the shell in order to register a user-defined function:
 
-```
+```js
 arangosh> var func = require("path/to/file.js");
 arangosh> aqlfunctions.register("HUMAN::GREETING", func, true);
 ```
 
-Note that a return value of *false* means that the function `HUMAN::GREETING`
-was newly created, and not that it failed to register. *true* is returned
+Note that a return value of `false` means that the function `HUMAN::GREETING`
+was newly created, and not that it failed to register. `true` is returned
 if a function of that name existed before and was just updated.
 
 `aqlfunctions.register(name, code, isDeterministic)`
 
 Registers an AQL user function, identified by a fully qualified function
-name. The function code in *code* must be specified as a JavaScript
+name. The function code in `code` must be specified as a JavaScript
 function or a string representation of a JavaScript function.
-If the function code in *code* is passed as a string, it is required that
+If the function code in `code` is passed as a string, it is required that
 the string evaluates to a JavaScript function definition.
 
-If a function identified by *name* already exists, the previous function
-definition will be updated. Please also make sure that the function code
+If a function identified by `name` already exists, the previous function
+definition is updated. Please also make sure that the function code
 does not violate the [Conventions](extending-conventions.html) for AQL 
 functions.
 
-The *isDeterministic* attribute can be used to specify whether the
+The `isDeterministic` attribute can be used to specify whether the
 function results are fully deterministic (i.e. depend solely on the input
 and are the same for repeated calls with the same input values). It is not
 used at the moment but may be used for optimizations later.
 
 The registered function is stored in the selected database's system 
-collection *_aqlfunctions*.
+collection `_aqlfunctions`.
 
-The function returns *true* when it updates/replaces an existing AQL 
-function of the same name, and *false* otherwise. It will throw an exception
-when it detects syntactically invalid function code.
-
+The function returns `true` when it updates/replaces an existing AQL 
+function of the same name, and `false` otherwise. It throws an exception
+if it detects syntactically invalid function code.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").register("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT",
@@ -94,7 +92,7 @@ function (celsius) {
 });
 ```
 
-The function code will not be executed in *strict mode* or *strong mode* by 
+The function code is not executed in *strict mode* or *strong mode* by 
 default. In order to make a user function being run in strict mode, use
 `use strict` explicitly, e.g.:
 
@@ -132,9 +130,9 @@ invalid number of arguments for function '%s()', expected number of arguments: m
 
 In the example above, `%s` is replaced by `this.name` (the AQL function name),
 and both `%d` placeholders by `1` (number of expected arguments). If you call
-the function without an argument, you will see this:
+the function without an argument, you see this:
 
-```
+```js
 arangosh> db._query("RETURN MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()")
 [object ArangoQueryCursor, count: 1, hasMore: false, warning: 1541 - invalid
 number of arguments for function 'MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()',
@@ -153,42 +151,34 @@ Deleting an existing AQL user function
 Unregisters an existing AQL user function, identified by the fully qualified
 function name.
 
-Trying to unregister a function that does not exist will result in an
+Trying to unregister a function that does not exist results in an
 exception.
 
-
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregister("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT");
 ```
 
-
 Unregister Group
 ----------------
 
-<!-- js/common/modules/@arangodb/aql/functions.js -->
+Delete a group of AQL user functions:
 
-
-delete a group of AQL user functions
 `aqlfunctions.unregisterGroup(prefix)`
 
 Unregisters a group of AQL user function, identified by a common function
 group prefix.
 
-This will return the number of functions unregistered.
-
+This returns the number of functions unregistered.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS::TEMPERATURE");
 
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS");
 ```
-
 
 Listing all AQL user functions
 ------------------------------
@@ -198,11 +188,10 @@ Listing all AQL user functions
 Returns all previously registered AQL user functions, with their fully
 qualified names and function code.
 
-The result may optionally be restricted to a specified group of functions
-by specifying a group prefix:
-
 `aqlfunctions.toArray(prefix)`
 
+Returns all previously registered AQL user functions, restricted to a specified
+group of functions by specifying a group prefix.
 
 **Examples**
 

--- a/3.9/aql/extending-conventions.md
+++ b/3.9/aql/extending-conventions.md
@@ -9,24 +9,28 @@ Conventions
 Naming
 ------
 
-Built-in AQL functions that are shipped with ArangoDB reside in the namespace
-`_aql`, which is also the default namespace to look in if an unqualified
-function name is found.
+AQL functions that are implemented with JavaScript are always in a namespace.
+To register a user-defined AQL function, you need to give it a name with a
+namespace. The `::` symbol is used as the namespace separator, for example,
+`MYGROUP::MYFUNC`. You can use one or multiple levels of namespaces to create
+meaningful function groups.
 
-To refer to a user-defined AQL function, the function name must be fully
-qualified to also include the user-defined namespace. The `::` symbol is used
-as the namespace separator. Users can create a multi-level hierarchy of function
-groups if required:
+The names of user-defined functions are case-insensitive, like all function
+names in AQL.
+
+To refer to and call user-defined functions in AQL queries, you need to use the
+fully qualified name with the namespaces:
 
 ```js
 MYGROUP::MYFUNC()
 MYFUNCTIONS::MATH::RANDOM()
 ```
 
-**Note**: Adding user functions to the *_aql* namespace is disallowed and will
-fail.
-
-User function names are case-insensitive like all function names in AQL.
+ArangoDB's built-in AQL functions are all implemented in C++ and are not in a
+namespace, except for the internal `V8()` function, which resides in the `_aql`
+namespace. It is the default namespace, which means that you can use the
+unqualified name of the function (without `_aql::`) to refer to it. Note that
+you cannot add own functions to this namespace.
 
 Variables and side effects
 --------------------------
@@ -96,7 +100,7 @@ and state outside of the user function itself.
 Return values
 -------------
 
-User functions must only return primitive types (i.e. *null*, boolean
+User functions must only return primitive types (i.e. `null`, boolean
 values, numeric values, string values) or aggregate types (arrays or
 objects) composed of these types.
 Returning any other JavaScript object type (Function, Date, RegExp etc.) from
@@ -105,9 +109,9 @@ a user function may lead to undefined behavior and should be avoided.
 Enforcing strict mode
 ---------------------
 
-By default, any user function code will be executed in *sloppy mode*, not
-*strict* or *strong mode*. In order to make a user function run in strict
-mode, use `"use strict"` explicitly inside the user function, e.g.:
+By default, any user function code is executed in *sloppy mode*. In order to
+make a user function run in strict mode, use `"use strict"` explicitly inside
+the user function:
 
 ```js
 function (values) {
@@ -123,4 +127,4 @@ function (values) {
 }
 ```
 
-Any violation of the strict mode will trigger a runtime error.
+Any violation of the strict mode triggers a runtime error.

--- a/3.9/aql/extending-functions.md
+++ b/3.9/aql/extending-functions.md
@@ -6,7 +6,7 @@ Registering and Unregistering User Functions
 ============================================
 
 User-defined functions (UDFs) can be registered in the selected database 
-using the *aqlfunctions* object as follows:
+using the `@arangodb/aql/functions` module as follows:
 
 ```js
 var aqlfunctions = require("@arangodb/aql/functions");
@@ -20,10 +20,10 @@ User Functions management.
 
 In a cluster setup, make sure to connect to a Coordinator to manage the UDFs.
 
-Documents in the *_aqlfunctions* collection (or any other system collection)
+Documents in the `_aqlfunctions` collection (or any other system collection)
 should not be accessed directly, but only via the dedicated interfaces.
 Otherwise you might see caching issues or accidentally break something.
-The interfaces will ensure the correct format of the documents and invalidate
+The interfaces ensure the correct format of the documents and invalidate
 the UDF cache.
 
 Registering an AQL user function
@@ -49,43 +49,41 @@ module.exports = greeting;
 
 Then require it in the shell in order to register a user-defined function:
 
-```
+```js
 arangosh> var func = require("path/to/file.js");
 arangosh> aqlfunctions.register("HUMAN::GREETING", func, true);
 ```
 
-Note that a return value of *false* means that the function `HUMAN::GREETING`
-was newly created, and not that it failed to register. *true* is returned
+Note that a return value of `false` means that the function `HUMAN::GREETING`
+was newly created, and not that it failed to register. `true` is returned
 if a function of that name existed before and was just updated.
 
 `aqlfunctions.register(name, code, isDeterministic)`
 
 Registers an AQL user function, identified by a fully qualified function
-name. The function code in *code* must be specified as a JavaScript
+name. The function code in `code` must be specified as a JavaScript
 function or a string representation of a JavaScript function.
-If the function code in *code* is passed as a string, it is required that
+If the function code in `code` is passed as a string, it is required that
 the string evaluates to a JavaScript function definition.
 
-If a function identified by *name* already exists, the previous function
-definition will be updated. Please also make sure that the function code
+If a function identified by `name` already exists, the previous function
+definition is updated. Please also make sure that the function code
 does not violate the [Conventions](extending-conventions.html) for AQL 
 functions.
 
-The *isDeterministic* attribute can be used to specify whether the
+The `isDeterministic` attribute can be used to specify whether the
 function results are fully deterministic (i.e. depend solely on the input
 and are the same for repeated calls with the same input values). It is not
 used at the moment but may be used for optimizations later.
 
 The registered function is stored in the selected database's system 
-collection *_aqlfunctions*.
+collection `_aqlfunctions`.
 
-The function returns *true* when it updates/replaces an existing AQL 
-function of the same name, and *false* otherwise. It will throw an exception
-when it detects syntactically invalid function code.
-
+The function returns `true` when it updates/replaces an existing AQL 
+function of the same name, and `false` otherwise. It throws an exception
+if it detects syntactically invalid function code.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").register("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT",
@@ -94,7 +92,7 @@ function (celsius) {
 });
 ```
 
-The function code will not be executed in *strict mode* or *strong mode* by 
+The function code is not executed in *strict mode* or *strong mode* by 
 default. In order to make a user function being run in strict mode, use
 `use strict` explicitly, e.g.:
 
@@ -132,9 +130,9 @@ invalid number of arguments for function '%s()', expected number of arguments: m
 
 In the example above, `%s` is replaced by `this.name` (the AQL function name),
 and both `%d` placeholders by `1` (number of expected arguments). If you call
-the function without an argument, you will see this:
+the function without an argument, you see this:
 
-```
+```js
 arangosh> db._query("RETURN MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()")
 [object ArangoQueryCursor, count: 1, hasMore: false, warning: 1541 - invalid
 number of arguments for function 'MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT()',
@@ -153,42 +151,34 @@ Deleting an existing AQL user function
 Unregisters an existing AQL user function, identified by the fully qualified
 function name.
 
-Trying to unregister a function that does not exist will result in an
+Trying to unregister a function that does not exist results in an
 exception.
 
-
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregister("MYFUNCTIONS::TEMPERATURE::CELSIUSTOFAHRENHEIT");
 ```
 
-
 Unregister Group
 ----------------
 
-<!-- js/common/modules/@arangodb/aql/functions.js -->
+Delete a group of AQL user functions:
 
-
-delete a group of AQL user functions
 `aqlfunctions.unregisterGroup(prefix)`
 
 Unregisters a group of AQL user function, identified by a common function
 group prefix.
 
-This will return the number of functions unregistered.
-
+This returns the number of functions unregistered.
 
 **Examples**
-
 
 ```js
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS::TEMPERATURE");
 
 require("@arangodb/aql/functions").unregisterGroup("MYFUNCTIONS");
 ```
-
 
 Listing all AQL user functions
 ------------------------------
@@ -198,11 +188,10 @@ Listing all AQL user functions
 Returns all previously registered AQL user functions, with their fully
 qualified names and function code.
 
-The result may optionally be restricted to a specified group of functions
-by specifying a group prefix:
-
 `aqlfunctions.toArray(prefix)`
 
+Returns all previously registered AQL user functions, restricted to a specified
+group of functions by specifying a group prefix.
 
 **Examples**
 


### PR DESCRIPTION
V8() is the only remaining function with a JavaScript implementation, living in the default namespace. Native functions don't have a namespace. User-defined functions require one or more namespaces.