### PR TITLE
explicitly mention OS configuration in prod checklist

### DIFF
--- a/3.10/deployment-production-checklist.md
+++ b/3.10/deployment-production-checklist.md
@@ -13,7 +13,9 @@ Operating System
 ----------------
 
 - Executed the OS optimization scripts if you run ArangoDB on Linux.
-  See [Installing ArangoDB on Linux](installation-linux.html) for details.
+  See [Installing ArangoDB on Linux](installation-linux.html) and its sub pages
+  [Linux Operating System Configuration](installation-linux-osconfiguration.html) and
+  [Linux OS Tuning Script Examples](installation-linux-ostuning-scripts.html) for details.
 
 - OS monitoring is in place
   (most common metrics, e.g. disk, CPU, RAM utilization).

--- a/3.11/deployment-production-checklist.md
+++ b/3.11/deployment-production-checklist.md
@@ -13,7 +13,9 @@ Operating System
 ----------------
 
 - Executed the OS optimization scripts if you run ArangoDB on Linux.
-  See [Installing ArangoDB on Linux](installation-linux.html) for details.
+  See [Installing ArangoDB on Linux](installation-linux.html) and its sub pages
+  [Linux Operating System Configuration](installation-linux-osconfiguration.html) and
+  [Linux OS Tuning Script Examples](installation-linux-ostuning-scripts.html) for details.
 
 - OS monitoring is in place
   (most common metrics, e.g. disk, CPU, RAM utilization).

--- a/3.8/deployment-production-checklist.md
+++ b/3.8/deployment-production-checklist.md
@@ -13,7 +13,9 @@ Operating System
 ----------------
 
 - Executed the OS optimization scripts if you run ArangoDB on Linux.
-  See [Installing ArangoDB on Linux](installation-linux.html) for details.
+  See [Installing ArangoDB on Linux](installation-linux.html) and its sub pages
+  [Linux Operating System Configuration](installation-linux-osconfiguration.html) and
+  [Linux OS Tuning Script Examples](installation-linux-ostuning-scripts.html) for details.
 
 - OS monitoring is in place
   (most common metrics, e.g. disk, CPU, RAM utilization).

--- a/3.9/deployment-production-checklist.md
+++ b/3.9/deployment-production-checklist.md
@@ -13,7 +13,9 @@ Operating System
 ----------------
 
 - Executed the OS optimization scripts if you run ArangoDB on Linux.
-  See [Installing ArangoDB on Linux](installation-linux.html) for details.
+  See [Installing ArangoDB on Linux](installation-linux.html) and its sub pages
+  [Linux Operating System Configuration](installation-linux-osconfiguration.html) and
+  [Linux OS Tuning Script Examples](installation-linux-ostuning-scripts.html) for details.
 
 - OS monitoring is in place
   (most common metrics, e.g. disk, CPU, RAM utilization).


### PR DESCRIPTION
The production checklist page doesn't mention explicitly that some OS configuration/tuning should happen.
It links to a page about "Installing on Linux", but not to that page's sub pages. It may not be obvious to users that some configuration changes/tuning are recommend.
Now the sub pages are explicitly mentioned, so that this can't be overlooked.