### PR TITLE
allow usage of suffix `b` in startup option values

### DIFF
--- a/3.10/programs-arangod-env-vars.md
+++ b/3.10/programs-arangod-env-vars.md
@@ -11,10 +11,14 @@ title: arangod environment variables
    
    This variable can be used to override the automatic detection of the total
    amount of RAM present on the system. One can specify a decimal number
-   (in bytes). Furthermore, if `G` or `g` is appended, the value is multiplied
-   by `2^30`. If `M` or `m` is appended, the value is multiplied by `2^20`.
-   If `K` or `k` is appended, the value is multiplied by `2^10`. That is,
-   `64G` means 64 gigabytes.
+   (in bytes). Furthermore, numbers can have the following suffixes:
+   
+   - `GB`, `G`, `gb`, `g`: number is multipled by 1,000,000,000 (gigabytes).
+   - `MB`, `M`, `mb`, `m`: number is multipled by 1,000,000 (megabytes).
+   - `KB`, `K`, `kb`, `k`: number is multipled by 1,000 (kilobytes).
+   - `GIB`, `GiB`, `gib`: number is multipled by 1,073,741,824 (gibibytes).
+   - `MIB`, `MiB`, `mib`: number is multipled by 1,048,576 (mebibytes).
+   - `KIB`, `KiB`, `kib`: number is multipled by 1,024 (kibibytes).
 
    The total amount of RAM detected is logged as an INFO message at
    server start. If the variable is set, the overridden value is shown.
@@ -30,6 +34,20 @@ title: arangod environment variables
    2. If `arangod` is running alongside other services on the same
       machine and thus sharing the RAM with them, one should limit the
       amount of memory using this environment variable.
+   
+   Note that setting this environment variable mainly affects the default 
+   values of startup options that have to do with memory usage. 
+   If the values of these startup options are explicitly set anyway, then 
+   setting the environment variable will not have effect.
+
+   For example, the default value for the RocksDB block cache size (option
+   `--rocksdb.block-cache-size`) depends on the amount of available memory.
+   When setting `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`, the default
+   value for the block cache size will be `(32GB - 2GB) * 0.3 = 9GB`.
+   However, when setting the startup option `--rocksdb.block-cache-size`
+   explicitly via a configuration file or via the command line, then the
+   latter value will be used, but not the option's default value based on
+   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`.
  
  - `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` _(introduced in v3.7.1)_
    

--- a/3.10/programs-arangod-env-vars.md
+++ b/3.10/programs-arangod-env-vars.md
@@ -13,12 +13,12 @@ title: arangod environment variables
    amount of RAM present on the system. One can specify a decimal number
    (in bytes). Furthermore, numbers can have the following suffixes:
    
-   - `GB`, `G`, `gb`, `g`: number is multipled by 1,000,000,000 (gigabytes).
-   - `MB`, `M`, `mb`, `m`: number is multipled by 1,000,000 (megabytes).
-   - `KB`, `K`, `kb`, `k`: number is multipled by 1,000 (kilobytes).
-   - `GIB`, `GiB`, `gib`: number is multipled by 1,073,741,824 (gibibytes).
-   - `MIB`, `MiB`, `mib`: number is multipled by 1,048,576 (mebibytes).
-   - `KIB`, `KiB`, `kib`: number is multipled by 1,024 (kibibytes).
+   - `GB`, `G`, `gb`, `g`: the number is multiplied by 1,000,000,000 (gigabytes).
+   - `MB`, `M`, `mb`, `m`: the number is multiplied by 1,000,000 (megabytes).
+   - `KB`, `K`, `kb`, `k`: the number is multiplied by 1,000 (kilobytes).
+   - `GIB`, `GiB`, `gib`: the number is multiplied by 1,073,741,824 (gibibytes).
+   - `MIB`, `MiB`, `mib`: the number is multiplied by 1,048,576 (mebibytes).
+   - `KIB`, `KiB`, `kib`: the number is multiplied by 1,024 (kibibytes).
 
    The total amount of RAM detected is logged as an INFO message at
    server start. If the variable is set, the overridden value is shown.
@@ -34,21 +34,21 @@ title: arangod environment variables
    2. If `arangod` is running alongside other services on the same
       machine and thus sharing the RAM with them, one should limit the
       amount of memory using this environment variable.
-   
+
    Note that setting this environment variable mainly affects the default 
    values of startup options that have to do with memory usage. 
    If the values of these startup options are explicitly set anyway, then 
-   setting the environment variable will not have effect.
+   setting the environment variable has no effect.
 
-   For example, the default value for the RocksDB block cache size (option
-   `--rocksdb.block-cache-size`) depends on the amount of available memory.
-   When setting `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`, the default
-   value for the block cache size will be `(32GB - 2GB) * 0.3 = 9GB`.
-   However, when setting the startup option `--rocksdb.block-cache-size`
-   explicitly via a configuration file or via the command line, then the
-   latter value will be used, but not the option's default value based on
-   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`.
- 
+   For example, the default value for the RocksDB block cache size
+   (`--rocksdb.block-cache-size` startup option) depends on the amount of
+   available memory. If you set `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`,
+   the default value for the block cache size is `(32GB - 2GB) * 0.3 = 9GB`.
+   However, if you set the `--rocksdb.block-cache-size` startup option explicitly
+   via a configuration file or via the command-line, then the latter value is
+   used, and not the option's default value based on the
+   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` environment variable.
+
  - `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` _(introduced in v3.7.1)_
    
    This variable can be used to override the automatic detection of the

--- a/3.11/administration-configuration.md
+++ b/3.11/administration-configuration.md
@@ -200,6 +200,7 @@ in megabytes, gigabytes, or terabytes.
 | `mib`, `MiB`, `MIB`  | 1024<sup>2</sup> | 1,048,576         | `64mib`   |
 | `gib`, `GiB`, `GIB`  | 1024<sup>3</sup> | 1,073,741,824     | `3GIB`    |
 | `tib`, `TiB`, `TIB`  | 1024<sup>4</sup> | 1,099,511,627,776 | `3tib`    |
+| `b`, `B`             | 1                | 1                 | `10b`     |
 | `k`, `K`, `kb`, `KB` | 1000             | 1,000             | `3k`      |
 | `m`, `M`, `mb`, `MB` | 1000<sup>2</sup> | 1,000,000         | `3M`      |
 | `g`, `G`, `gb`, `GB` | 1000<sup>3</sup> | 1,000,000,000     | `3GB`     |

--- a/3.11/administration-configuration.md
+++ b/3.11/administration-configuration.md
@@ -173,19 +173,19 @@ Specific to arangod, move to programs detail page?
 Does the resolution order for config files apply to all binaries?
 Linux only? Also macOS? Windows not addressed so far.
 
-If this command is not passed to the server, then by default, the server will
-attempt to first locate a file named *~/.arango/arangod.conf* in the user's home
+If this command is not passed to the server, then by default, the server
+attempts to first locate a file named `~/.arango/arangod.conf` in the user's home
 directory.
 
-If no such file is found, the server will proceed to look for a file
-*arangod.conf* in the system configuration directory. The system configuration
+If no such file is found, the server proceeds to look for a file
+`arangod.conf` in the system configuration directory. The system configuration
 directory is platform-specific, and may be changed when compiling ArangoDB
-yourself. It may default to */etc/arangodb* or */usr/local/etc/arangodb*. This
+yourself. It may default to `/etc/arangodb` or `/usr/local/etc/arangodb`. This
 file is installed when using a package manager like rpm or dpkg. If you modify
 this file and later upgrade to a new version of ArangoDB, then the package
 manager normally warns you about the conflict. In order to avoid these warning
 for small adjustments, you can put local overrides into a file
-*arangod.conf.local*.
+`arangod.conf.local`.
 {% endcomment %}
 
 ## Suffixes for Numeric Options
@@ -287,7 +287,7 @@ level = startup=info
 There are built-in defaults, with which all configuration variables are first
 initialized. They can be overridden by configuration files and command line
 options (in this order). Only a fraction of all available options are set in
-the configuration files that ArangoDB ships with. Many options will therefore
+the configuration files that ArangoDB ships with. Many options therefore
 fall back to the built-in defaults unless they are overridden by the user.
 
 It is common to use modified configuration files together with startup
@@ -295,21 +295,21 @@ options on a command line to override specific settings. Command line options
 take precedence over values set in a configuration file.
 
 If the same option is set multiple times, but only supports a single value,
-then the last occurrence of the option will become the final value.
-For example, if you edit `arangosh.conf` to set:
+then the last occurrence of the option becomes the final value.
+For example, if you edit `arangosh.conf` as follows:
 
-```
+```conf
 server.database = myDB1
 server.database = myDB2
 ```
 
-… and start ArangoShell like:
+Then start ArangoShell like this:
 
 ```
 arangosh --server.database myDB3 --server.database myDB4
 ```
 
-… then the database it will connect to is `myDB4`, because this startup option
+The database it connects to is `myDB4`, because this startup option
 takes a single value only (i.e. it is not a vector), the built-in default
 is `_system` but the configuration file overrules the setting. It gets set to
 `myDB1` temporarily before it is replaced by `myDB2`, which in turn gets

--- a/3.11/programs-arangod-env-vars.md
+++ b/3.11/programs-arangod-env-vars.md
@@ -13,14 +13,14 @@ title: arangod environment variables
    amount of RAM present on the system. One can specify a decimal number
    (in bytes). Furthermore, numbers can have the following suffixes:
 
-   - `TB`, `T`, `tb`, `t`: number is multipled by 1,000,000,000,000 (terabytes).
-   - `GB`, `G`, `gb`, `g`: number is multipled by 1,000,000,000 (gigabytes).
-   - `MB`, `M`, `mb`, `m`: number is multipled by 1,000,000 (megabytes).
-   - `KB`, `K`, `kb`, `k`: number is multipled by 1,000 (kilobytes).
-   - `TIB`, `TiB`, `tib`: number is multipled by 1,099,511,627,776 (tebibytes).
-   - `GIB`, `GiB`, `gib`: number is multipled by 1,073,741,824 (gibibytes).
-   - `MIB`, `MiB`, `mib`: number is multipled by 1,048,576 (mebibytes).
-   - `KIB`, `KiB`, `kib`: number is multipled by 1,024 (kibibytes).
+   - `TB`, `T`, `tb`, `t`: the number is multiplied by 1,000,000,000,000 (terabytes).
+   - `GB`, `G`, `gb`, `g`: the number is multiplied by 1,000,000,000 (gigabytes).
+   - `MB`, `M`, `mb`, `m`: the number is multiplied by 1,000,000 (megabytes).
+   - `KB`, `K`, `kb`, `k`: the number is multiplied by 1,000 (kilobytes).
+   - `TIB`, `TiB`, `tib`: the number is multiplied by 1,099,511,627,776 (tebibytes).
+   - `GIB`, `GiB`, `gib`: the number is multiplied by 1,073,741,824 (gibibytes).
+   - `MIB`, `MiB`, `mib`: the number is multiplied by 1,048,576 (mebibytes).
+   - `KIB`, `KiB`, `kib`: the number is multiplied by 1,024 (kibibytes).
    - `B`, `b`: bytes
 
    The total amount of RAM detected is logged as an INFO message at
@@ -41,17 +41,17 @@ title: arangod environment variables
    Note that setting this environment variable mainly affects the default 
    values of startup options that have to do with memory usage. 
    If the values of these startup options are explicitly set anyway, then 
-   setting the environment variable will not have effect.
+   setting the environment variable has no effect.
 
-   For example, the default value for the RocksDB block cache size (option
-   `--rocksdb.block-cache-size`) depends on the amount of available memory.
-   When setting `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`, the default
-   value for the block cache size will be `(32GB - 2GB) * 0.3 = 9GB`.
-   However, when setting the startup option `--rocksdb.block-cache-size`
-   explicitly via a configuration file or via the command line, then the
-   latter value will be used, but not the option's default value based on
-   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`.
- 
+   For example, the default value for the RocksDB block cache size
+   (`--rocksdb.block-cache-size` startup option) depends on the amount of
+   available memory. If you set `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`,
+   the default value for the block cache size is `(32GB - 2GB) * 0.3 = 9GB`.
+   However, if you set the `--rocksdb.block-cache-size` startup option explicitly
+   via a configuration file or via the command-line, then the latter value is
+   used, and not the option's default value based on the
+   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` environment variable.
+
  - `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` _(introduced in v3.7.1)_
    
    This variable can be used to override the automatic detection of the

--- a/3.11/programs-arangod-env-vars.md
+++ b/3.11/programs-arangod-env-vars.md
@@ -11,14 +11,21 @@ title: arangod environment variables
    
    This variable can be used to override the automatic detection of the total
    amount of RAM present on the system. One can specify a decimal number
-   (in bytes). Furthermore, if `G` or `g` is appended, the value is multiplied
-   by `2^30`. If `M` or `m` is appended, the value is multiplied by `2^20`.
-   If `K` or `k` is appended, the value is multiplied by `2^10`. That is,
-   `64G` means 64 gigabytes.
+   (in bytes). Furthermore, numbers can have the following suffixes:
+
+   - `TB`, `T`, `tb`, `t`: number is multipled by 1,000,000,000,000 (terabytes).
+   - `GB`, `G`, `gb`, `g`: number is multipled by 1,000,000,000 (gigabytes).
+   - `MB`, `M`, `mb`, `m`: number is multipled by 1,000,000 (megabytes).
+   - `KB`, `K`, `kb`, `k`: number is multipled by 1,000 (kilobytes).
+   - `TIB`, `TiB`, `tib`: number is multipled by 1,099,511,627,776 (tebibytes).
+   - `GIB`, `GiB`, `gib`: number is multipled by 1,073,741,824 (gibibytes).
+   - `MIB`, `MiB`, `mib`: number is multipled by 1,048,576 (mebibytes).
+   - `KIB`, `KiB`, `kib`: number is multipled by 1,024 (kibibytes).
+   - `B`, `b`: bytes
 
    The total amount of RAM detected is logged as an INFO message at
    server start. If the variable is set, the overridden value is shown.
-   Various default sizes are calculated based on this value (e.g.
+   Various default sizes are calculated based on this value (e.g. the
    RocksDB buffer cache size).
 
    Setting this option can in particular be useful in two cases:
@@ -30,6 +37,20 @@ title: arangod environment variables
    2. If `arangod` is running alongside other services on the same
       machine and thus sharing the RAM with them, one should limit the
       amount of memory using this environment variable.
+
+   Note that setting this environment variable mainly affects the default 
+   values of startup options that have to do with memory usage. 
+   If the values of these startup options are explicitly set anyway, then 
+   setting the environment variable will not have effect.
+
+   For example, the default value for the RocksDB block cache size (option
+   `--rocksdb.block-cache-size`) depends on the amount of available memory.
+   When setting `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=32GB`, the default
+   value for the block cache size will be `(32GB - 2GB) * 0.3 = 9GB`.
+   However, when setting the startup option `--rocksdb.block-cache-size`
+   explicitly via a configuration file or via the command line, then the
+   latter value will be used, but not the option's default value based on
+   `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY`.
  
  - `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES` _(introduced in v3.7.1)_
    

--- a/3.11/release-notes-new-features311.md
+++ b/3.11/release-notes-new-features311.md
@@ -42,7 +42,7 @@ on startup, all SST files in the `engine-rocksdb` folder in the database
 directory are validated, then the process finishes execution.
 The default value is `false`.
 
-### Support for terabyte and tebibyte suffixes
+### Support for additional value suffixes
 
 Numeric startup options support suffixes like `m` (megabytes) and `GiB` (gibibytes)
 to make it easier to specify values that are expected in bytes. The following
@@ -50,6 +50,7 @@ suffixes are now also supported:
 
 - `tib`, `TiB`, `TIB`: tebibytes (factor 1024<sup>4</sup>)
 - `t`, `tb`, `T`, `TB`: terabytes (factor 1000<sup>4</sup>)
+- `b`, `B`: bytes (factor 1)
 
 Example: `arangod --rocksdb.total-write-buffer-size 2TiB`
 


### PR DESCRIPTION
Documentation PR for https://github.com/arangodb/arangodb/pull/17977