### PR TITLE
Ensure "On this page" is above example boxes and remove unused, empty CSS file

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -90,6 +90,8 @@ h6:hover a.anchor-link,
 }
 
 .page-toc {
+    position: relative;
+    z-index: 999;
     float: right;
     background: #f8f8f8;
     border: 1px solid rgba(0, 0, 0, 0.07);


### PR DESCRIPTION
On https://www.arangodb.com/docs/stable/aql/invocation-with-arangosh.html, the example box doesn't visually overlap the ToC but the actual element seems to extend to the right content border. You can see the anchor link floating above the ToC and the ToC cannot be interacted with in the area of the box. This CSS change should fix it. Requires clearing the Cloudflare cache for at least the affected CSS file.