### PR TITLE
add example combining POSITION and the array expansion operator

### DIFF
--- a/3.10/aql/functions-array.md
+++ b/3.10/aql/functions-array.md
@@ -547,6 +547,10 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](functions-string.html#contains).
 
+If you want to search a list of objects,
+[the array expansion operator [*]](advanced-array-operators.html#array-expansion) might also be of
+interest. The third example below will illustrate its usage in this context.
+
 **Examples**
 
 {% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
@@ -564,6 +568,16 @@ RETURN POSITION( [2,4,6,8], 4 )
 RETURN POSITION( [2,4,6,8], 4, true )
 @END_EXAMPLE_AQL
 @endDocuBlock aqlArrayPosition_2
+{% endaqlexample %}
+{% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
+
+{% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
+@startDocuBlockInline aqlArrayPosition_3
+@EXAMPLE_AQL{aqlArrayPosition_3}
+LET arr = [{field_name: "foo"}, {field_name: "bar"}, {field_name: "baz"}, {field_name: "bay"}]
+RETURN POSITION(arr[*].field_name, "baz", true)
+@END_EXAMPLE_AQL
+@endDocuBlock aqlArrayPosition_3
 {% endaqlexample %}
 {% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
 

--- a/3.11/aql/functions-array.md
+++ b/3.11/aql/functions-array.md
@@ -547,6 +547,10 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](functions-string.html#contains).
 
+If you want to search a list of objects,
+[the array expansion operator [*]](advanced-array-operators.html#array-expansion) might also be of
+interest. The third example below will illustrate its usage in this context.
+
 **Examples**
 
 {% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
@@ -564,6 +568,16 @@ RETURN POSITION( [2,4,6,8], 4 )
 RETURN POSITION( [2,4,6,8], 4, true )
 @END_EXAMPLE_AQL
 @endDocuBlock aqlArrayPosition_2
+{% endaqlexample %}
+{% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
+
+{% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
+@startDocuBlockInline aqlArrayPosition_3
+@EXAMPLE_AQL{aqlArrayPosition_3}
+LET arr = [{field_name: "foo"}, {field_name: "bar"}, {field_name: "baz"}, {field_name: "bay"}]
+RETURN POSITION(arr[*].field_name, "baz", true)
+@END_EXAMPLE_AQL
+@endDocuBlock aqlArrayPosition_3
 {% endaqlexample %}
 {% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
 

--- a/3.7/aql/functions-array.md
+++ b/3.7/aql/functions-array.md
@@ -547,6 +547,10 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](functions-string.html#contains).
 
+If you want to search a list of objects,
+[the array expansion operator [*]](advanced-array-operators.html#array-expansion) might also be of
+interest. The third example below will illustrate its usage in this context.
+
 **Examples**
 
 {% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
@@ -564,6 +568,16 @@ RETURN POSITION( [2,4,6,8], 4 )
 RETURN POSITION( [2,4,6,8], 4, true )
 @END_EXAMPLE_AQL
 @endDocuBlock aqlArrayPosition_2
+{% endaqlexample %}
+{% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
+
+{% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
+@startDocuBlockInline aqlArrayPosition_3
+@EXAMPLE_AQL{aqlArrayPosition_3}
+LET arr = [{field_name: "foo"}, {field_name: "bar"}, {field_name: "baz"}, {field_name: "bay"}]
+RETURN POSITION(arr[*].field_name, "baz", true)
+@END_EXAMPLE_AQL
+@endDocuBlock aqlArrayPosition_3
 {% endaqlexample %}
 {% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
 

--- a/3.8/aql/functions-array.md
+++ b/3.8/aql/functions-array.md
@@ -547,6 +547,10 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](functions-string.html#contains).
 
+If you want to search a list of objects,
+[the array expansion operator [*]](advanced-array-operators.html#array-expansion) might also be of
+interest. The third example below will illustrate its usage in this context.
+
 **Examples**
 
 {% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
@@ -564,6 +568,16 @@ RETURN POSITION( [2,4,6,8], 4 )
 RETURN POSITION( [2,4,6,8], 4, true )
 @END_EXAMPLE_AQL
 @endDocuBlock aqlArrayPosition_2
+{% endaqlexample %}
+{% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
+
+{% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
+@startDocuBlockInline aqlArrayPosition_3
+@EXAMPLE_AQL{aqlArrayPosition_3}
+LET arr = [{field_name: "foo"}, {field_name: "bar"}, {field_name: "baz"}, {field_name: "bay"}]
+RETURN POSITION(arr[*].field_name, "baz", true)
+@END_EXAMPLE_AQL
+@endDocuBlock aqlArrayPosition_3
 {% endaqlexample %}
 {% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
 

--- a/3.9/aql/functions-array.md
+++ b/3.9/aql/functions-array.md
@@ -547,6 +547,10 @@ Return whether *search* is contained in *array*. Optionally return the position.
 To determine if or at which position a string occurs in another string, see the
 [CONTAINS() string function](functions-string.html#contains).
 
+If you want to search a list of objects,
+[the array expansion operator [*]](advanced-array-operators.html#array-expansion) might also be of
+interest. The third example below will illustrate its usage in this context.
+
 **Examples**
 
 {% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
@@ -564,6 +568,16 @@ RETURN POSITION( [2,4,6,8], 4 )
 RETURN POSITION( [2,4,6,8], 4, true )
 @END_EXAMPLE_AQL
 @endDocuBlock aqlArrayPosition_2
+{% endaqlexample %}
+{% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
+
+{% aqlexample examplevar="examplevar" type="type" query="query" bind="bind" result="result" %}
+@startDocuBlockInline aqlArrayPosition_3
+@EXAMPLE_AQL{aqlArrayPosition_3}
+LET arr = [{field_name: "foo"}, {field_name: "bar"}, {field_name: "baz"}, {field_name: "bay"}]
+RETURN POSITION(arr[*].field_name, "baz", true)
+@END_EXAMPLE_AQL
+@endDocuBlock aqlArrayPosition_3
 {% endaqlexample %}
 {% include aqlexample.html id=examplevar type=type query=query bind=bind result=result %}
 


### PR DESCRIPTION
I initially made the mistake of doing something like this:

```
FOR row IN coll
   FOR entry in doc.array
      FILTER entry.field_name != @field_name
   LIMIT @limit
   RETURN DISTINCT doc
```

I now realize that this is _not_ how it works (the last two liens should be indented one more and hence this will in most cases not yield `@limit` many entries.

The intention behind this PR is to add a concrete example pushing folks in the right direction to do something like this

```
FOR row IN coll
    FILTER POSITION(doc.array[*].field_name , @field_name) == false
    LIMIT @limit
    RETURN doc
```

instead.