### PR TITLE
add requirement for system page size to documentation

### DIFF
--- a/3.10/installation-linux-osconfiguration.md
+++ b/3.10/installation-linux-osconfiguration.md
@@ -74,10 +74,12 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
-Note that the official release executables of ArangoDB require the operating system
-to use a page size of 4096 or less.
-Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+{% hint 'info' %}
+The official release executables of ArangoDB require the operating system
+to use a page size of **4096 bytes** or less.
+Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+{% endhint %}
 
 Swap Space
 ----------

--- a/3.10/installation-linux-osconfiguration.md
+++ b/3.10/installation-linux-osconfiguration.md
@@ -74,6 +74,11 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
+Note that the official release executables of ArangoDB require the operating system
+to use a page size of 4096 or less.
+Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+during startup.
+
 Swap Space
 ----------
 

--- a/3.10/installation-linux-osconfiguration.md
+++ b/3.10/installation-linux-osconfiguration.md
@@ -79,6 +79,8 @@ The official release executables of ArangoDB require the operating system
 to use a page size of **4096 bytes** or less.
 Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+
+You can check the page size with the `getconf PAGESIZE` command.
 {% endhint %}
 
 Swap Space

--- a/3.10/installation.md
+++ b/3.10/installation.md
@@ -53,6 +53,9 @@ ArangoDB is available for the following architectures:
 - **ARM**: The processor(s) must be 64-bit ARM chips (**AArch64**). The minimum
   requirement is **ARMv8** with **Neon** (SIMD extension).
 
+The official Linux release executables of ArangoDB require the operating system
+to use a page size of **4096 bytes** or less.
+
 ## macOS
 
 ArangoDB is available for the following architectures:

--- a/3.11/installation-linux-osconfiguration.md
+++ b/3.11/installation-linux-osconfiguration.md
@@ -74,10 +74,12 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
-Note that the official release executables of ArangoDB require the operating system
-to use a page size of 4096 or less.
-Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+{% hint 'info' %}
+The official release executables of ArangoDB require the operating system
+to use a page size of **4096 bytes** or less.
+Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+{% endhint %}
 
 Swap Space
 ----------

--- a/3.11/installation-linux-osconfiguration.md
+++ b/3.11/installation-linux-osconfiguration.md
@@ -74,6 +74,11 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
+Note that the official release executables of ArangoDB require the operating system
+to use a page size of 4096 or less.
+Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+during startup.
+
 Swap Space
 ----------
 

--- a/3.11/installation-linux-osconfiguration.md
+++ b/3.11/installation-linux-osconfiguration.md
@@ -79,6 +79,8 @@ The official release executables of ArangoDB require the operating system
 to use a page size of **4096 bytes** or less.
 Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+
+You can check the page size with the `getconf PAGESIZE` command.
 {% endhint %}
 
 Swap Space

--- a/3.11/installation.md
+++ b/3.11/installation.md
@@ -53,6 +53,9 @@ ArangoDB is available for the following architectures:
 - **ARM**: The processor(s) must be 64-bit ARM chips (**AArch64**). The minimum
   requirement is **ARMv8** with **Neon** (SIMD extension).
 
+The official Linux release executables of ArangoDB require the operating system
+to use a page size of **4096 bytes** or less.
+
 ## macOS
 
 ArangoDB is available for the following architectures:

--- a/3.9/installation-linux-osconfiguration.md
+++ b/3.9/installation-linux-osconfiguration.md
@@ -74,10 +74,12 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
-Note that the official release executables of ArangoDB require the operating system
-to use a page size of 4096 or less.
-Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+{% hint 'info' %}
+The official release executables of ArangoDB require the operating system
+to use a page size of **4096 bytes** or less.
+Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+{% endhint %}
 
 Swap Space
 ----------

--- a/3.9/installation-linux-osconfiguration.md
+++ b/3.9/installation-linux-osconfiguration.md
@@ -74,6 +74,11 @@ sudo bash -c "echo madvise >/sys/kernel/mm/transparent_hugepage/defrag"
 
 before executing `arangod`.
 
+Note that the official release executables of ArangoDB require the operating system
+to use a page size of 4096 or less.
+Larger page sizes will lead to the error `<jemalloc>: Unsupported system page size`
+during startup.
+
 Swap Space
 ----------
 

--- a/3.9/installation-linux-osconfiguration.md
+++ b/3.9/installation-linux-osconfiguration.md
@@ -79,6 +79,8 @@ The official release executables of ArangoDB require the operating system
 to use a page size of **4096 bytes** or less.
 Larger page sizes lead to the error `<jemalloc>: Unsupported system page size`
 during startup.
+
+You can check the page size with the `getconf PAGESIZE` command.
 {% endhint %}
 
 Swap Space


### PR DESCRIPTION
Inspired by https://arangodb.atlassian.net/browse/BTS-1163. 
The requirement for the operating system page size to be <= 4096 was not documented anywhere.
This PR adds it.