### PR TITLE
clarify that unicodes names must be NFC-normalized

### DIFF
--- a/3.11/release-notes-api-changes311.md
+++ b/3.11/release-notes-api-changes311.md
@@ -32,11 +32,17 @@ payloads that contain database, collection, View, or index names, as well as
 document identifiers (because they are comprised of the collection name and the
 document key). If client applications assemble URLs with extended names
 programmatically, they need to ensure that extended names are properly
-URL-encoded and also NFC-normalized if they contain UTF-8 characters.
+URL-encoded.
+
+When using extended names, any Unicode characters in names need to be 
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
+create a database, collection, View or index with a non-NFC-normalized
+name will be rejected by the server.
 
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with full support for the extended naming constraints.
+ship with support for the extended naming constraints, but they require the
+user to provide NFC-normalized names.
 
 Please be aware that dumps containing extended names cannot be restored
 into older versions that only support the traditional naming constraints. In a

--- a/3.11/release-notes-api-changes311.md
+++ b/3.11/release-notes-api-changes311.md
@@ -35,14 +35,14 @@ programmatically, they need to ensure that extended names are properly
 URL-encoded.
 
 When using extended names, any Unicode characters in names need to be 
-[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
-create a database, collection, View or index with a non-NFC-normalized
-name will be rejected by the server.
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms){:target="_blank"}.
+If you try to create a database, collection, View, or index with a non-NFC-normalized
+name, the server rejects it.
 
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with support for the extended naming constraints, but they require the
-user to provide NFC-normalized names.
+ship with support for the extended naming constraints, but they require you
+to provide NFC-normalized names.
 
 Please be aware that dumps containing extended names cannot be restored
 into older versions that only support the traditional naming constraints. In a

--- a/3.11/release-notes-new-features311.md
+++ b/3.11/release-notes-new-features311.md
@@ -529,14 +529,14 @@ FOR doc IN `🥑~колекція =)`
 ```
 
 When using extended names, any Unicode characters in names need to be 
-[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
-create a database, collection, View or index with a non-NFC-normalized
-name will be rejected by the server.
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms){:target="_blank"}.
+If you try to create a database, collection, View, or index with a non-NFC-normalized
+name, the server rejects it.
 
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with support for the extended naming constraints, but they require the
-user to provide NFC-normalized names.
+ship with support for the extended naming constraints, but they require you
+to provide NFC-normalized names.
 
 Note that the default value for `--database.extended-names` is `false`
 for compatibility with existing client drivers and applications that only support

--- a/3.11/release-notes-new-features311.md
+++ b/3.11/release-notes-new-features311.md
@@ -528,9 +528,15 @@ FOR doc IN `🥑~колекція =)`
   RETURN doc
 ```
 
+When using extended names, any Unicode characters in names need to be 
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
+create a database, collection, View or index with a non-NFC-normalized
+name will be rejected by the server.
+
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with full support for the extended naming constraints.
+ship with support for the extended naming constraints, but they require the
+user to provide NFC-normalized names.
 
 Note that the default value for `--database.extended-names` is `false`
 for compatibility with existing client drivers and applications that only support

--- a/3.11/release-notes-upgrading-changes311.md
+++ b/3.11/release-notes-upgrading-changes311.md
@@ -32,11 +32,17 @@ payloads that contain database, collection, View, or index names, as well as
 document identifiers (because they are comprised of the collection name and the
 document key). If client applications assemble URLs with extended names
 programmatically, they need to ensure that extended names are properly
-URL-encoded and also NFC-normalized if they contain UTF-8 characters.
+URL-encoded.
+
+When using extended names, any Unicode characters in names need to be 
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
+create a database, collection, View or index with a non-NFC-normalized
+name will be rejected by the server.
 
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with full support for the extended naming constraints.
+ship with support for the extended naming constraints, but they require the
+user to provide NFC-normalized names.
 
 Please be aware that dumps containing extended names cannot be restored
 into older versions that only support the traditional naming constraints. In a

--- a/3.11/release-notes-upgrading-changes311.md
+++ b/3.11/release-notes-upgrading-changes311.md
@@ -35,14 +35,14 @@ programmatically, they need to ensure that extended names are properly
 URL-encoded.
 
 When using extended names, any Unicode characters in names need to be 
-[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms). Trying to
-create a database, collection, View or index with a non-NFC-normalized
-name will be rejected by the server.
+[NFC-normalized](http://unicode.org/reports/tr15/#Norm_Forms){:target="_blank"}.
+If you try to create a database, collection, View, or index with a non-NFC-normalized
+name, the server rejects it.
 
 The ArangoDB web interface as well as the _arangobench_, _arangodump_,
 _arangoexport_, _arangoimport_, _arangorestore_, and _arangosh_ client tools
-ship with support for the extended naming constraints, but they require the
-user to provide NFC-normalized names.
+ship with support for the extended naming constraints, but they require you
+to provide NFC-normalized names.
 
 Please be aware that dumps containing extended names cannot be restored
 into older versions that only support the traditional naming constraints. In a


### PR DESCRIPTION
Created to clarify that there is a requirement that database names, collection names, view names and index names with Unicode characters must be properly NFC-normalized, or they will be rejected by the server.
