### PR TITLE
From 3.9 on, Hot Backups include View data (not only View definitions)

### DIFF
--- a/3.10/http/hot-backup.md
+++ b/3.10/http/hot-backup.md
@@ -13,7 +13,7 @@ description: >-
 
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
-indexes, View definitions, and users at any given time.
+indexes, Views, graphs, and users at any given time.
 
 For creations a label may be specified, which if omitted
 is replaced with a generated UUID. This label is then combined with a

--- a/3.11/http/hot-backup.md
+++ b/3.11/http/hot-backup.md
@@ -13,7 +13,7 @@ description: >-
 
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
-indexes, View definitions, and users at any given time.
+indexes, Views, graphs, and users at any given time.
 
 For creations a label may be specified, which if omitted
 is replaced with a generated UUID. This label is then combined with a

--- a/3.12/http/hot-backup.md
+++ b/3.12/http/hot-backup.md
@@ -13,7 +13,7 @@ description: >-
 
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
-indexes, View definitions, and users at any given time.
+indexes, Views, graphs, and users at any given time.
 
 For creations a label may be specified, which if omitted
 is replaced with a generated UUID. This label is then combined with a

--- a/3.9/http/hot-backup.md
+++ b/3.9/http/hot-backup.md
@@ -15,7 +15,7 @@ Hot Backups
 
 Hot backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB service. This includes all databases, collections,
-indexes, view definitions and users at any given time. 
+indexes, Views, graphs, and users at any given time. 
 
 For creations a label may be specified, which if omitted
 is replaced with a generated UUID. This label is then combined with a


### PR DESCRIPTION
Named graphs are also preserved.

Should we mention anything else?
- Foxx services (but it doesn't include any files they might write to the local file system)
- UDFs
- Analyzers (but not stopword lists that are in the local filesystem)
- ?