### PR TITLE
Fix hint overflow & some geo content issues

### DIFF
--- a/3.10/aql/functions-geo.md
+++ b/3.10/aql/functions-geo.md
@@ -33,7 +33,7 @@ which is sufficient for most use cases such as location-aware services.
 DISTANCE(52.5163, 13.3777, 50.9322, 6.94) // 476918.89688380965 (~477km)
 
 // Sort a small number of documents based on distance to Central Park (New York)
-FOR doc IN doc // e.g. documents returned by a traversal
+FOR doc IN coll // e.g. documents returned by a traversal
   SORT DISTANCE(doc.latitude, doc.longitude, 40.78, -73.97)
   RETURN doc
 ```
@@ -485,11 +485,11 @@ the query however.
 ### NEAR()
 
 {% hint 'warning' %}
-`NEAR` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`NEAR()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   SORT DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude) ASC
   RETURN doc
 ```
@@ -523,11 +523,11 @@ contain the distance value in an attribute of that name.
 ### WITHIN()
 
 {% hint 'warning' %}
-`WITHIN` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`WITHIN()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   LET d = DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude)
   FILTER d <= radius
   SORT d ASC
@@ -562,15 +562,24 @@ value in an attribute of that name.
 ### WITHIN_RECTANGLE()
 
 {% hint 'warning' %}
-`WITHIN_RECTANGLE` is a deprecated AQL function from version 3.4.0 on. Use
-[GEO_CONTAINS](#geo_contains) and a GeoJSON polygon instead:
+`WITHIN_RECTANGLE()` is a deprecated AQL function from version 3.4.0 on. Use
+[`GEO_CONTAINS()`](#geo_contains) and a GeoJSON polygon instead - but note that
+this uses geodesic lines from version 3.10.0 onward
+(see [GeoJSON interpretation](../indexing-geo.html#geojson-interpretation)):
 
 ```aql
-LET rect = {type: "Polygon", coordinates: [[[longitude1, latitude1], ...]]]}
-FOR doc IN doc
-  FILTER GEO_CONTAINS(poly, [doc.longitude, doc.latitude])
+LET rect = GEO_POLYGON([ [
+  [longitude1, latitude1], // bottom-left
+  [longitude2, latitude1], // bottom-right
+  [longitude2, latitude2], // top-right
+  [longitude1, latitude2], // top-left
+  [longitude1, latitude1], // bottom-left
+] ])
+FOR doc IN coll
+  FILTER GEO_CONTAINS(rect, [doc.longitude, doc.latitude])
   RETURN doc
 ```
+
 Assuming there exists a geo-type index on `latitude` and `longitude`, the
 optimizer will recognize it and accelerate the query.
 {% endhint %}

--- a/3.10/foxx-guides-queries.md
+++ b/3.10/foxx-guides-queries.md
@@ -138,7 +138,7 @@ const numbers = db._query(`
   RETURN i
 `).toArray();
 // Actual query executed by the code:
-// FOR i IN i..1
+// FOR i IN 1..1
 // FOR u IN myfoxx_users
 // REMOVE u IN myfoxx_users
 // RETURN i

--- a/3.11/aql/functions-geo.md
+++ b/3.11/aql/functions-geo.md
@@ -33,7 +33,7 @@ which is sufficient for most use cases such as location-aware services.
 DISTANCE(52.5163, 13.3777, 50.9322, 6.94) // 476918.89688380965 (~477km)
 
 // Sort a small number of documents based on distance to Central Park (New York)
-FOR doc IN doc // e.g. documents returned by a traversal
+FOR doc IN coll // e.g. documents returned by a traversal
   SORT DISTANCE(doc.latitude, doc.longitude, 40.78, -73.97)
   RETURN doc
 ```
@@ -485,11 +485,11 @@ the query however.
 ### NEAR()
 
 {% hint 'warning' %}
-`NEAR` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`NEAR()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   SORT DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude) ASC
   RETURN doc
 ```
@@ -523,11 +523,11 @@ contain the distance value in an attribute of that name.
 ### WITHIN()
 
 {% hint 'warning' %}
-`WITHIN` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`WITHIN()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   LET d = DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude)
   FILTER d <= radius
   SORT d ASC
@@ -562,15 +562,24 @@ value in an attribute of that name.
 ### WITHIN_RECTANGLE()
 
 {% hint 'warning' %}
-`WITHIN_RECTANGLE` is a deprecated AQL function from version 3.4.0 on. Use
-[GEO_CONTAINS](#geo_contains) and a GeoJSON polygon instead:
+`WITHIN_RECTANGLE()` is a deprecated AQL function from version 3.4.0 on. Use
+[`GEO_CONTAINS()`](#geo_contains) and a GeoJSON polygon instead - but note that
+this uses geodesic lines from version 3.10.0 onward
+(see [GeoJSON interpretation](../indexing-geo.html#geojson-interpretation)):
 
 ```aql
-LET rect = {type: "Polygon", coordinates: [[[longitude1, latitude1], ...]]]}
-FOR doc IN doc
-  FILTER GEO_CONTAINS(poly, [doc.longitude, doc.latitude])
+LET rect = GEO_POLYGON([ [
+  [longitude1, latitude1], // bottom-left
+  [longitude2, latitude1], // bottom-right
+  [longitude2, latitude2], // top-right
+  [longitude1, latitude2], // top-left
+  [longitude1, latitude1], // bottom-left
+] ])
+FOR doc IN coll
+  FILTER GEO_CONTAINS(rect, [doc.longitude, doc.latitude])
   RETURN doc
 ```
+
 Assuming there exists a geo-type index on `latitude` and `longitude`, the
 optimizer will recognize it and accelerate the query.
 {% endhint %}

--- a/3.11/foxx-guides-queries.md
+++ b/3.11/foxx-guides-queries.md
@@ -138,7 +138,7 @@ const numbers = db._query(`
   RETURN i
 `).toArray();
 // Actual query executed by the code:
-// FOR i IN i..1
+// FOR i IN 1..1
 // FOR u IN myfoxx_users
 // REMOVE u IN myfoxx_users
 // RETURN i

--- a/3.12/aql/functions-geo.md
+++ b/3.12/aql/functions-geo.md
@@ -33,7 +33,7 @@ which is sufficient for most use cases such as location-aware services.
 DISTANCE(52.5163, 13.3777, 50.9322, 6.94) // 476918.89688380965 (~477km)
 
 // Sort a small number of documents based on distance to Central Park (New York)
-FOR doc IN doc // e.g. documents returned by a traversal
+FOR doc IN coll // e.g. documents returned by a traversal
   SORT DISTANCE(doc.latitude, doc.longitude, 40.78, -73.97)
   RETURN doc
 ```
@@ -485,11 +485,11 @@ the query however.
 ### NEAR()
 
 {% hint 'warning' %}
-`NEAR` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`NEAR()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   SORT DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude) ASC
   RETURN doc
 ```
@@ -523,11 +523,11 @@ contain the distance value in an attribute of that name.
 ### WITHIN()
 
 {% hint 'warning' %}
-`WITHIN` is a deprecated AQL function from version 3.4.0 on.
-Use [DISTANCE()](#distance) in a query like this instead:
+`WITHIN()` is a deprecated AQL function from version 3.4.0 on.
+Use [`DISTANCE()`](#distance) in a query like this instead:
 
 ```aql
-FOR doc IN doc
+FOR doc IN coll
   LET d = DISTANCE(doc.latitude, doc.longitude, paramLatitude, paramLongitude)
   FILTER d <= radius
   SORT d ASC
@@ -562,15 +562,24 @@ value in an attribute of that name.
 ### WITHIN_RECTANGLE()
 
 {% hint 'warning' %}
-`WITHIN_RECTANGLE` is a deprecated AQL function from version 3.4.0 on. Use
-[GEO_CONTAINS](#geo_contains) and a GeoJSON polygon instead:
+`WITHIN_RECTANGLE()` is a deprecated AQL function from version 3.4.0 on. Use
+[`GEO_CONTAINS()`](#geo_contains) and a GeoJSON polygon instead - but note that
+this uses geodesic lines from version 3.10.0 onward
+(see [GeoJSON interpretation](../indexing-geo.html#geojson-interpretation)):
 
 ```aql
-LET rect = {type: "Polygon", coordinates: [[[longitude1, latitude1], ...]]]}
-FOR doc IN doc
-  FILTER GEO_CONTAINS(poly, [doc.longitude, doc.latitude])
+LET rect = GEO_POLYGON([ [
+  [longitude1, latitude1], // bottom-left
+  [longitude2, latitude1], // bottom-right
+  [longitude2, latitude2], // top-right
+  [longitude1, latitude2], // top-left
+  [longitude1, latitude1], // bottom-left
+] ])
+FOR doc IN coll
+  FILTER GEO_CONTAINS(rect, [doc.longitude, doc.latitude])
   RETURN doc
 ```
+
 Assuming there exists a geo-type index on `latitude` and `longitude`, the
 optimizer will recognize it and accelerate the query.
 {% endhint %}

--- a/3.12/foxx-guides-queries.md
+++ b/3.12/foxx-guides-queries.md
@@ -138,7 +138,7 @@ const numbers = db._query(`
   RETURN i
 `).toArray();
 // Actual query executed by the code:
-// FOR i IN i..1
+// FOR i IN 1..1
 // FOR u IN myfoxx_users
 // REMOVE u IN myfoxx_users
 // RETURN i

--- a/_plugins/HintBlock.rb
+++ b/_plugins/HintBlock.rb
@@ -13,11 +13,13 @@ class HintTag < Liquid::Block
       #content.rstrip!
       indent = content.index(/[^ ]/) || 0
       content = content.lines.map{ |line| line.slice([indent, line.index(/[^ ]/) || 0].min, line.length) }.join ''
-      # Parse Markdown and collapse line breaks to spaces.
+      # Parse Markdown and collapse line breaks to spaces outside of <pre> blocks.
       # Line breaks can cause pre-mature closing of elements it seems,
       # observed when placing a hint block in a Markdown list,
       # leading to unwanted literal "</div>" (HTML-encoded) in the output.
-      content = converter.convert(content).gsub(/\R+/, ' ')
+      content = converter.convert(content).split(/(?=<\/?pre)/).map{
+        |s| s.start_with?('<pre') ? s : s.gsub(/\R+/, ' ')
+      }.join ''
 
       case @type
       when "tip"
@@ -39,7 +41,7 @@ class HintTag < Liquid::Block
 
       return "<div class=\"alert alert-#{className}\" style=\"display: flex\">" +
         "<i class=\"fa fa-#{icon}\" style=\"margin-right: 10px; margin-top: 4px;\"></i>" +
-        "<div>#{content}</div>" +
+        "<div style=\"min-width: 0\">#{content}</div>" +
         "</div>"
     end
   end


### PR DESCRIPTION
- `display: flex` makes the items default to `min-width: auto`, which made the content of the inner `<div>` overflow the hint box without showing a scrollbar. Setting `min-width: 0` makes the normal text wrap and displays a scrollbar for code blocks if it's too wide - affected page: https://www.arangodb.com/docs/stable/aql/functions-geo.html#within
- Don't substitute all line breaks after rendering the hint box Markdown body - this was implemented to avoid stray `</div>` from showing if a hint is placed inside of a Markdown list, which apparently closed elements prematurely. Line breaks are now preserved inside preformatted blocks to not put all of the code on a single line 
- Address some mistakes and formatting issues in the content about deprecated geo functions