### PR TITLE
Installation | macOS client tools only

### DIFF
--- a/3.11/installation-mac-osx.md
+++ b/3.11/installation-mac-osx.md
@@ -7,7 +7,7 @@ Installing ArangoDB on macOS
 ============================
 
 You can use ArangoDB on macOS with [Docker images](#docker) and run the client
-tools using [_tar.gz_ archives](#installing-using-the-archive).
+tools using [_tar.gz_ archives](#installing-the-client-tools-using-the-archive).
 
 {% hint 'tip' %}
 Starting from version 3.10.0, ArangoDB has native support for the ARM

--- a/3.11/installation-mac-osx.md
+++ b/3.11/installation-mac-osx.md
@@ -1,16 +1,13 @@
 ---
 layout: default
-description: You can use ArangoDB on macOS via Docker images, DMG packages, or tar.gz archives
+description: You can use ArangoDB on macOS via Docker images, and run client tools using tar.gz archives
 title: Installing ArangoDB on macOS
 ---
 Installing ArangoDB on macOS
 ============================
 
-You can use ArangoDB on macOS in different ways:
-
-- [Docker images](#docker)
-- [_DMG_ packages](#package-installation)
-- [_tar.gz_ archives](#installing-using-the-archive)
+You can use ArangoDB on macOS with [Docker images](#docker) and run the client
+tools using [_tar.gz_ archives](#installing-using-the-archive).
 
 {% hint 'tip' %}
 Starting from version 3.10.0, ArangoDB has native support for the ARM
@@ -21,8 +18,12 @@ architecture and can run on Apple silicon (e.g. M1 chips).
 Running production environments on macOS is not supported.
 {% endhint %}
 
-Docker
-------
+{% hint 'info' %}
+Starting from version 3.11.0, ArangoDB Server binaries for macOS are not
+provided anymore.
+{% endhint %}
+
+## Docker
 
 The recommended way of using ArangoDB on macOS is to use the
 [ArangoDB Docker images](https://www.arangodb.com/download-major/docker/){:target="_blank"}
@@ -32,49 +33,10 @@ See the documentation on [Docker Hub](https://hub.docker.com/_/arangodb){:target
 as well as the [Deployments](architecture-deployment-modes.html) section about
 different deployment modes and methods including Docker containers.
 
-Package Installation
---------------------
-
-ArangoDB provide a command-line app called *ArangoDB-CLI*.
-
-Visit the official [Download](https://www.arangodb.com/download){:target="_blank"}
-page of the ArangoDB website and download the *DMG* Package for macOS.
-
-You may verify the download by comparing the SHA256 hash listed on the website
-to the hash of the file. For example, you can you run `openssl sha256 <filename>`
-or `shasum -a 256 <filename>` in a terminal. You may also run
-`codesign --verify --verbose <filename>` to validate the notarization of an
-executable.
-
-You can install the application in your application folder.
-
-Starting the application starts the server and opens a terminal window
-showing you the log-file.
-
-```
-ArangoDB server has been started
-
-The database directory is located at
-   '/Users/<user>/Library/ArangoDB/var/lib/arangodb3'
-
-The log file is located at
-   '/Users/<user>/Library/ArangoDB/var/log/arangodb3/arangod.log'
-
-You can access the server using a browser at 'http://127.0.0.1:8529/'
-or start the ArangoDB shell
-   '/Applications/ArangoDB3-CLI.app/Contents/Resources/arangosh'
-
-Switching to log-file now, killing this windows will NOT stop the server.
-
-
-2022-10-21T09:37:01Z [13373] INFO ArangoDB (version 3.9.3 [darwin]) is ready for business. Have fun!
-```
-
-Installing using the archive
-----------------------------
+## Installing the client tools using the archive
 
 1. Visit the official [Download](https://www.arangodb.com/download){:target="_blank"}
-   page of the ArangoDB website and download the _tar.gz_ archive for macOS.
+   page of the ArangoDB website and download the client tools _tar.gz_ archive for macOS.
 
 2. You may verify the download by comparing the SHA256 hash listed on the website
    to the hash of the file. For example, you can you run `openssl sha256 <filename>`

--- a/3.11/installation.md
+++ b/3.11/installation.md
@@ -10,8 +10,8 @@ system from the official [Download](https://www.arangodb.com/download){:target="
 page of the ArangoDB web site.
 
 You can find packages for various operating systems, including _RPM_ and _Debian_
-packages for Linux, and _dmg_ packages for macOS. `tar.gz` archives are available
-for both. For Windows, _Installers_ and `zip` archives are available.
+packages for Linux, including `tar.gz` archives. For macOS, only client tools `tar.gz`
+packages are available. For Windows, _Installers_ and `zip` archives are available.
 
 - [Linux](installation-linux.html)
 - [macOS](installation-mac-osx.html)
@@ -58,7 +58,12 @@ to use a page size of **4096 bytes** or less.
 
 ## macOS
 
-ArangoDB is available for the following architectures:
+{% hint 'info' %}
+Starting with version 3.11.0, ArangoDB Server binaries for macOS are not
+provided anymore.
+{% endhint %}
+
+Client tools are available for the following architectures:
 
 - **x86-64**: The processor(s) must support the **x86-64** architecture with the
   **SSE 4.2** and **AVX** instruction set extensions (Intel Sandy Bridge or better,

--- a/3.12/installation-mac-osx.md
+++ b/3.12/installation-mac-osx.md
@@ -7,7 +7,7 @@ Installing ArangoDB on macOS
 ============================
 
 You can use ArangoDB on macOS with [Docker images](#docker) and run the client
-tools using [_tar.gz_ archives](#installing-using-the-archive).
+tools using [_tar.gz_ archives](#installing-the-client-tools-using-the-archive).
 
 {% hint 'tip' %}
 Starting from version 3.10.0, ArangoDB has native support for the ARM

--- a/3.12/installation-mac-osx.md
+++ b/3.12/installation-mac-osx.md
@@ -1,16 +1,13 @@
 ---
 layout: default
-description: You can use ArangoDB on macOS via Docker images, DMG packages, or tar.gz archives
+description: You can use ArangoDB on macOS via Docker images, and run client tools using tar.gz archives
 title: Installing ArangoDB on macOS
 ---
 Installing ArangoDB on macOS
 ============================
 
-You can use ArangoDB on macOS in different ways:
-
-- [Docker images](#docker)
-- [_DMG_ packages](#package-installation)
-- [_tar.gz_ archives](#installing-using-the-archive)
+You can use ArangoDB on macOS with [Docker images](#docker) and run the client
+tools using [_tar.gz_ archives](#installing-using-the-archive).
 
 {% hint 'tip' %}
 Starting from version 3.10.0, ArangoDB has native support for the ARM
@@ -21,8 +18,12 @@ architecture and can run on Apple silicon (e.g. M1 chips).
 Running production environments on macOS is not supported.
 {% endhint %}
 
-Docker
-------
+{% hint 'info' %}
+Starting from version 3.11.0, ArangoDB Server binaries for macOS are not
+provided anymore.
+{% endhint %}
+
+## Docker
 
 The recommended way of using ArangoDB on macOS is to use the
 [ArangoDB Docker images](https://www.arangodb.com/download-major/docker/){:target="_blank"}
@@ -32,49 +33,10 @@ See the documentation on [Docker Hub](https://hub.docker.com/_/arangodb){:target
 as well as the [Deployments](architecture-deployment-modes.html) section about
 different deployment modes and methods including Docker containers.
 
-Package Installation
---------------------
-
-ArangoDB provide a command-line app called *ArangoDB-CLI*.
-
-Visit the official [Download](https://www.arangodb.com/download){:target="_blank"}
-page of the ArangoDB website and download the *DMG* Package for macOS.
-
-You may verify the download by comparing the SHA256 hash listed on the website
-to the hash of the file. For example, you can you run `openssl sha256 <filename>`
-or `shasum -a 256 <filename>` in a terminal. You may also run
-`codesign --verify --verbose <filename>` to validate the notarization of an
-executable.
-
-You can install the application in your application folder.
-
-Starting the application starts the server and opens a terminal window
-showing you the log-file.
-
-```
-ArangoDB server has been started
-
-The database directory is located at
-   '/Users/<user>/Library/ArangoDB/var/lib/arangodb3'
-
-The log file is located at
-   '/Users/<user>/Library/ArangoDB/var/log/arangodb3/arangod.log'
-
-You can access the server using a browser at 'http://127.0.0.1:8529/'
-or start the ArangoDB shell
-   '/Applications/ArangoDB3-CLI.app/Contents/Resources/arangosh'
-
-Switching to log-file now, killing this windows will NOT stop the server.
-
-
-2022-10-21T09:37:01Z [13373] INFO ArangoDB (version 3.9.3 [darwin]) is ready for business. Have fun!
-```
-
-Installing using the archive
-----------------------------
+## Installing the client tools using the archive
 
 1. Visit the official [Download](https://www.arangodb.com/download){:target="_blank"}
-   page of the ArangoDB website and download the _tar.gz_ archive for macOS.
+   page of the ArangoDB website and download the client tools _tar.gz_ archive for macOS.
 
 2. You may verify the download by comparing the SHA256 hash listed on the website
    to the hash of the file. For example, you can you run `openssl sha256 <filename>`

--- a/3.12/installation.md
+++ b/3.12/installation.md
@@ -10,8 +10,8 @@ system from the official [Download](https://www.arangodb.com/download){:target="
 page of the ArangoDB web site.
 
 You can find packages for various operating systems, including _RPM_ and _Debian_
-packages for Linux, and _dmg_ packages for macOS. `tar.gz` archives are available
-for both. For Windows, _Installers_ and `zip` archives are available.
+packages for Linux, including `tar.gz` archives. For macOS, only client tools `tar.gz`
+packages are available. For Windows, _Installers_ and `zip` archives are available.
 
 - [Linux](installation-linux.html)
 - [macOS](installation-mac-osx.html)
@@ -58,7 +58,12 @@ to use a page size of **4096 bytes** or less.
 
 ## macOS
 
-ArangoDB is available for the following architectures:
+{% hint 'info' %}
+Starting with version 3.11.0, ArangoDB Server binaries for macOS are not
+provided anymore.
+{% endhint %}
+
+Client tools are available for the following architectures:
 
 - **x86-64**: The processor(s) must support the **x86-64** architecture with the
   **SSE 4.2** and **AVX** instruction set extensions (Intel Sandy Bridge or better,


### PR DESCRIPTION
Starting with 3.11, only client tools are provided for macOS. 