### PR TITLE
remove deprecated graph-compatibility functions

### DIFF
--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -227,6 +227,8 @@ detailed information about breaking changes before upgrading.
   - `arangodb::GRAPH_BETWEENNESS`
   - `arangodb::GRAPH_RADIUS`
   - `arangodb::GRAPH_DIAMETER`
+  
+  These functions will be removed in ArangoDB 3.12.
 
 - **Specialized index creation methods in JavaScript API**:
   The following JavaScript methods for creating indexes from the ArangoShell

--- a/3.11/appendix-deprecated.md
+++ b/3.11/appendix-deprecated.md
@@ -244,6 +244,8 @@ detailed information about breaking changes before upgrading.
   - `arangodb::GRAPH_RADIUS`
   - `arangodb::GRAPH_DIAMETER`
 
+  These functions will be removed in ArangoDB 3.12.
+
 - **Specialized index creation methods in JavaScript API**:
   The following JavaScript methods for creating indexes from the ArangoShell
   (_arangosh_) or from within Foxx are deprecated:

--- a/3.12/appendix-deprecated.md
+++ b/3.12/appendix-deprecated.md
@@ -229,25 +229,6 @@ detailed information about breaking changes before upgrading.
   version 3.4.0 and have been removed in version 3.12.0. You can
   [traverse graphs with AQL](aql/graphs-traversals.html) instead.
 
-- **JavaScript-based AQL graph functions**: The following JavaScript-based AQL
-  graph functions are deprecated:
-  - `arangodb::GRAPH_EDGES`
-  - `arangodb::GRAPH_VERTICES`
-  - `arangodb::GRAPH_NEIGHBORS`
-  - `arangodb::GRAPH_COMMON_NEIGHBORS`
-  - `arangodb::GRAPH_COMMON_PROPERTIES`
-  - `arangodb::GRAPH_PATHS`
-  - `arangodb::GRAPH_SHORTEST_PATH`
-  - `arangodb::GRAPH_DISTANCE_TO`
-  - `arangodb::GRAPH_ABSOLUTE_ECCENTRICITY`
-  - `arangodb::GRAPH_ECCENTRICITY`
-  - `arangodb::GRAPH_ABSOLUTE_CLOSENESS`
-  - `arangodb::GRAPH_CLOSENESS`
-  - `arangodb::GRAPH_ABSOLUTE_BETWEENNESS`
-  - `arangodb::GRAPH_BETWEENNESS`
-  - `arangodb::GRAPH_RADIUS`
-  - `arangodb::GRAPH_DIAMETER`
-
 - **Specialized index creation methods in JavaScript API**:
   The following JavaScript methods for creating indexes from the ArangoShell
   (_arangosh_) or from within Foxx are deprecated:

--- a/3.12/release-notes-upgrading-changes312.md
+++ b/3.12/release-notes-upgrading-changes312.md
@@ -73,22 +73,22 @@ Users of the JavaScript-based traversal API should use
 The following long-deprecated compatibility graph functions have been removed
 in ArangoDB 3.12. These functions were implemented as JavaScript user-defined 
 AQL functions since ArangoDB 3.0:
-  - arangodb::GRAPH_EDGES(...)
-  - arangodb::GRAPH_VERTICES(...)
-  - arangodb::GRAPH_NEIGHBORS(...)
-  - arangodb::GRAPH_COMMON_NEIGHBORS(...)
-  - arangodb::GRAPH_COMMON_PROPERTIES(...)
-  - arangodb::GRAPH_PATHS(...)
-  - arangodb::GRAPH_SHORTEST_PATH(...)
-  - arangodb::GRAPH_DISTANCE_TO(...)
-  - arangodb::GRAPH_ABSOLUTE_ECCENTRICTIY(...)
-  - arangodb::GRAPH_ECCENTRICTIY(...)
-  - arangodb::GRAPH_ABSOLUTE_CLOSENESS(...)
-  - arangodb::GRAPH_CLOSENESS(...)
-  - arangodb::GRAPH_ABSOLUTE_BETWEENNESS(...)
-  - arangodb::GRAPH_BETWEENNESS(...)
-  - arangodb::GRAPH_RADIUS(...)
-  - arangodb::GRAPH_DIAMETER(...)
+  - `arangodb::GRAPH_EDGES(...)`
+  - `arangodb::GRAPH_VERTICES(...)`
+  - `arangodb::GRAPH_NEIGHBORS(...)`
+  - `arangodb::GRAPH_COMMON_NEIGHBORS(...)`
+  - `arangodb::GRAPH_COMMON_PROPERTIES(...)`
+  - `arangodb::GRAPH_PATHS(...)`
+  - `arangodb::GRAPH_SHORTEST_PATH(...)`
+  - `arangodb::GRAPH_DISTANCE_TO(...)`
+  - `arangodb::GRAPH_ABSOLUTE_ECCENTRICTIY(...)`
+  - `arangodb::GRAPH_ECCENTRICTIY(...)`
+  - `arangodb::GRAPH_ABSOLUTE_CLOSENESS(...)`
+  - `arangodb::GRAPH_CLOSENESS(...)`
+  - `arangodb::GRAPH_ABSOLUTE_BETWEENNESS(...)`
+  - `arangodb::GRAPH_BETWEENNESS(...)`
+  - `arangodb::GRAPH_RADIUS(...)`
+  - `arangodb::GRAPH_DIAMETER(...)`
 
 These functions were only available previously after explicitly calling the
 `_registerCompatibilityFunctions()` function from any of the JavaScript graph

--- a/3.12/release-notes-upgrading-changes312.md
+++ b/3.12/release-notes-upgrading-changes312.md
@@ -68,6 +68,35 @@ not handle larger amounts of data and were thus very limited.
 Users of the JavaScript-based traversal API should use
 [AQL traversal queries](aql/graphs-traversals.html) instead.
 
+### Graph compatibility functions
+
+The following long-deprecated compatibility graph functions have been removed
+in ArangoDB 3.12. These functions were implemented as JavaScript user-defined 
+AQL functions since ArangoDB 3.0:
+
+  - arangodb::GRAPH_EDGES(...)
+  - arangodb::GRAPH_VERTICES(...)
+  - arangodb::GRAPH_NEIGHBORS(...)
+  - arangodb::GRAPH_COMMON_NEIGHBORS(...)
+  - arangodb::GRAPH_COMMON_PROPERTIES(...)
+  - arangodb::GRAPH_PATHS(...)
+  - arangodb::GRAPH_SHORTEST_PATH(...)
+  - arangodb::GRAPH_DISTANCE_TO(...)
+  - arangodb::GRAPH_ABSOLUTE_ECCENTRICTIY(...)
+  - arangodb::GRAPH_ECCENTRICTIY(...)
+  - arangodb::GRAPH_ABSOLUTE_CLOSENESS(...)
+  - arangodb::GRAPH_CLOSENESS(...)
+  - arangodb::GRAPH_ABSOLUTE_BETWEENNESS(...)
+  - arangodb::GRAPH_BETWEENNESS(...)
+  - arangodb::GRAPH_RADIUS(...)
+  - arangodb::GRAPH_DIAMETER(...)
+
+These functions were only available previously after explicitly calling the
+`_registerCompatibilityFunctions()` function from any of the JavaScript graph
+modules.
+The `_registerCompatibilityFunctions()` exports have also been removed from
+the JavaScript graph modules.
+
 ## Startup options
 
 

--- a/3.12/release-notes-upgrading-changes312.md
+++ b/3.12/release-notes-upgrading-changes312.md
@@ -73,7 +73,6 @@ Users of the JavaScript-based traversal API should use
 The following long-deprecated compatibility graph functions have been removed
 in ArangoDB 3.12. These functions were implemented as JavaScript user-defined 
 AQL functions since ArangoDB 3.0:
-
   - arangodb::GRAPH_EDGES(...)
   - arangodb::GRAPH_VERTICES(...)
   - arangodb::GRAPH_NEIGHBORS(...)

--- a/3.9/appendix-deprecated.md
+++ b/3.9/appendix-deprecated.md
@@ -219,3 +219,5 @@ replace the old features with:
   - `arangodb::GRAPH_BETWEENNESS`
   - `arangodb::GRAPH_RADIUS`
   - `arangodb::GRAPH_DIAMETER`
+  
+  These functions will be removed in ArangoDB 3.12.


### PR DESCRIPTION
Docs PR for https://github.com/arangodb/arangodb/pull/19524/