### PR TITLE
Always set lead paragraph in front matter

### DIFF
--- a/3.10/analyzers.md
+++ b/3.10/analyzers.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-description: Analyzers parse input values and transform them into sets of sub-values, for example by breaking up text into words.
+description: >-
+  Analyzers allow you to transform data, for sophisticated text processing and
+  searching, either standalone or in combination with Views and inverted indexes
 title: Transforming data with Analyzers
 redirect_from:
   - arangosearch-analyzers.html # 3.8 -> 3.8
@@ -8,8 +10,7 @@ redirect_from:
 Transforming data with Analyzers
 ================================
 
-Analyzers allow you to transform data, for sophisticated text processing and
-searching, either standalone or in combination with Views
+{{ page.description }}
 {:class="lead"}
 
 While AQL string functions allow for basic text manipulation, true text

--- a/3.10/highlights.md
+++ b/3.10/highlights.md
@@ -1,12 +1,13 @@
 ---
 layout: default
-description: List of top features in Community and Enterprise Edition by release series
+description: >-
+  The most notable features in the Community and Enterprise Edition of ArangoDB,
+  grouped by version
 title: ArangoDB Highlights
 ---
 # Highlights by Version
 
-The most notable features in the Community and Enterprise Edition of ArangoDB,
-grouped by version
+{{ page.description }}
 {:class="lead"}
 
 ## Version 3.10

--- a/3.10/index.md
+++ b/3.10/index.md
@@ -1,24 +1,23 @@
 ---
 layout: default
 description: >-
-  ArangoDB is a scalable graph database system with native support for other
-  data models and a built-in search engine, for the cloud and on-premises
+  ArangoDB is a scalable graph database system to drive value from connected
+  data, faster
 title: Introduction to ArangoDB's Technical Documentation and Ecosystem
 ---
 # What is ArangoDB?
 
-ArangoDB is a scalable database management system for graphs, with a broad range
-of features and a rich ecosystem
+{{ page.description }}
 {:class="lead"}
 
 ![ArangoDB Overview Diagram](images/arangodb-overview-diagram.png)
 
-It supports a variety of data access patterns with a single, composable query
-language thanks to its multi-model approach that combines the analytical power
-of graphs with JSON documents, a key-value store, and a built-in search engine.
+ArangoDB combines the analytical power of native graphs with an integrated
+search engine, JSON support, and a variety of data access patterns via a single,
+composable query language.
 
-ArangoDB is available in an open-source and a commercial [edition](features.html),
-you can use it for on-premises deployments, as well as a fully managed
+ArangoDB is available in an open-source and a commercial [edition](features.html).
+You can use it for on-premises deployments, as well as a fully managed
 cloud service, the [ArangoGraph Insights Platform](arangograph/).
 
 ## What are Graphs?

--- a/3.11/analyzers.md
+++ b/3.11/analyzers.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-description: Analyzers parse input values and transform them into sets of sub-values, for example by breaking up text into words.
+description: >-
+  Analyzers allow you to transform data, for sophisticated text processing and
+  searching, either standalone or in combination with Views and inverted indexes
 title: Transforming data with Analyzers
 redirect_from:
   - arangosearch-analyzers.html # 3.8 -> 3.8
@@ -8,8 +10,7 @@ redirect_from:
 Transforming data with Analyzers
 ================================
 
-Analyzers allow you to transform data, for sophisticated text processing and
-searching, either standalone or in combination with Views
+{{ page.description }}
 {:class="lead"}
 
 While AQL string functions allow for basic text manipulation, true text

--- a/3.11/highlights.md
+++ b/3.11/highlights.md
@@ -1,12 +1,13 @@
 ---
 layout: default
-description: List of top features in Community and Enterprise Edition by release series
+description: >-
+  The most notable features in the Community and Enterprise Edition of ArangoDB,
+  grouped by version
 title: ArangoDB Highlights
 ---
 # Highlights by Version
 
-The most notable features in the Community and Enterprise Edition of ArangoDB,
-grouped by version
+{{ page.description }}
 {:class="lead"}
 
 ## Version 3.11

--- a/3.11/index.md
+++ b/3.11/index.md
@@ -1,24 +1,23 @@
 ---
 layout: default
 description: >-
-  ArangoDB is a scalable graph database system with native support for other
-  data models and a built-in search engine, for the cloud and on-premises
+  ArangoDB is a scalable graph database system to drive value from connected
+  data, faster
 title: Introduction to ArangoDB's Technical Documentation and Ecosystem
 ---
 # What is ArangoDB?
 
-ArangoDB is a scalable database management system for graphs, with a broad range
-of features and a rich ecosystem
+{{ page.description }}
 {:class="lead"}
 
 ![ArangoDB Overview Diagram](images/arangodb-overview-diagram.png)
 
-It supports a variety of data access patterns with a single, composable query
-language thanks to its multi-model approach that combines the analytical power
-of graphs with JSON documents, a key-value store, and a built-in search engine.
+ArangoDB combines the analytical power of native graphs with an integrated
+search engine, JSON support, and a variety of data access patterns via a single,
+composable query language.
 
-ArangoDB is available in an open-source and a commercial [edition](features.html),
-you can use it for on-premises deployments, as well as a fully managed
+ArangoDB is available in an open-source and a commercial [edition](features.html).
+You can use it for on-premises deployments, as well as a fully managed
 cloud service, the [ArangoGraph Insights Platform](arangograph/).
 
 ## What are Graphs?

--- a/3.12/analyzers.md
+++ b/3.12/analyzers.md
@@ -1,6 +1,8 @@
 ---
 layout: default
-description: Analyzers parse input values and transform them into sets of sub-values, for example by breaking up text into words.
+description: >-
+  Analyzers allow you to transform data, for sophisticated text processing and
+  searching, either standalone or in combination with Views and inverted indexes
 title: Transforming data with Analyzers
 redirect_from:
   - arangosearch-analyzers.html # 3.8 -> 3.8
@@ -8,8 +10,7 @@ redirect_from:
 Transforming data with Analyzers
 ================================
 
-Analyzers allow you to transform data, for sophisticated text processing and
-searching, either standalone or in combination with Views
+{{ page.description }}
 {:class="lead"}
 
 While AQL string functions allow for basic text manipulation, true text

--- a/3.12/highlights.md
+++ b/3.12/highlights.md
@@ -1,12 +1,13 @@
 ---
 layout: default
-description: List of top features in Community and Enterprise Edition by release series
+description: >-
+  The most notable features in the Community and Enterprise Edition of ArangoDB,
+  grouped by version
 title: ArangoDB Highlights
 ---
 # Highlights by Version
 
-The most notable features in the Community and Enterprise Edition of ArangoDB,
-grouped by version
+{{ page.description }}
 {:class="lead"}
 
 ## Version 3.12

--- a/3.12/index.md
+++ b/3.12/index.md
@@ -1,24 +1,23 @@
 ---
 layout: default
 description: >-
-  ArangoDB is a scalable graph database system with native support for other
-  data models and a built-in search engine, for the cloud and on-premises
+  ArangoDB is a scalable graph database system to drive value from connected
+  data, faster
 title: Introduction to ArangoDB's Technical Documentation and Ecosystem
 ---
 # What is ArangoDB?
 
-ArangoDB is a scalable database management system for graphs, with a broad range
-of features and a rich ecosystem
+{{ page.description }}
 {:class="lead"}
 
 ![ArangoDB Overview Diagram](images/arangodb-overview-diagram.png)
 
-It supports a variety of data access patterns with a single, composable query
-language thanks to its multi-model approach that combines the analytical power
-of graphs with JSON documents, a key-value store, and a built-in search engine.
+ArangoDB combines the analytical power of native graphs with an integrated
+search engine, JSON support, and a variety of data access patterns via a single,
+composable query language.
 
-ArangoDB is available in an open-source and a commercial [edition](features.html),
-you can use it for on-premises deployments, as well as a fully managed
+ArangoDB is available in an open-source and a commercial [edition](features.html).
+You can use it for on-premises deployments, as well as a fully managed
 cloud service, the [ArangoGraph Insights Platform](arangograph/).
 
 ## What are Graphs?


### PR DESCRIPTION
This is a general simplification and also makes the migration to Hugo easier.

Modifies the introduction to ArangoDB inspired by https://github.com/arangodb/arangodb/pull/17986, removing the mention of multi-model and key-value