### PR TITLE
Don't use 1., 2. et cetera in headlines

### DIFF
--- a/3.10/deployment-dc2dc.md
+++ b/3.10/deployment-dc2dc.md
@@ -1,18 +1,21 @@
 ---
 layout: default
-description: Datacenter-to-Datacenter Replication deployment overview
-title: DC2DC Replication Deployment
 ---
 # Datacenter-to-Datacenter Replication deployment
 
 {% include hint-ee.md feature="Datacenter-to-Datacenter Replication" %}
 
-This chapter describes how to deploy all the components needed for
-_Datacenter-to-Datacenter Replication (DC2DC)_.
-
 ## Deployment steps
 
-## 1. Cluster
+To deploy all the components needed for _Datacenter-to-Datacenter Replication (DC2DC)_,
+you need to set up the following components:
+
+1. An ArangoDB cluster in each data center
+2. Multiple ArangoSync Masters
+3. Multiple ArangoSync Workers
+4. Optional: Prometheus and Grafana for monitoring
+
+## Cluster
 
 Datacenter-to-Datacenter Replication requires an ArangoDB cluster in both data centers.
 
@@ -35,7 +38,7 @@ without much effort.
 Please refer to the [Cluster](deployment-dc2dc-cluster.html) section for
 more information.
 
-## 2. ArangoSync Master
+## ArangoSync Master
 
 The Sync Master is responsible for managing all synchronization, creating tasks and assigning
 those to workers.
@@ -60,7 +63,7 @@ Consider these machines to be crucial for your DC2DC setup.
 Please refer to the [ArangoSync Master](deployment-dc2dc-arango-sync-master.html)
 section for more information.
 
-## 3. ArangoSync Workers
+## ArangoSync Workers
 
 The Sync Worker is responsible for executing synchronization tasks.
 
@@ -83,7 +86,7 @@ The sync worker can be memory intensive when running lots of databases & collect
 Please refer to the [ArangoSync Workers](deployment-dc2dc-arango-sync-workers.html)
 for more information.
 
-## 4. Prometheus & Grafana (optional)
+## Prometheus & Grafana (optional)
 
 ArangoSync provides metrics in a format supported by [Prometheus](https://prometheus.io){:target="_blank"}.
 We also provide a standard set of dashboards for viewing those metrics in [Grafana](https://grafana.org){:target="_blank"}.

--- a/3.11/deployment-dc2dc.md
+++ b/3.11/deployment-dc2dc.md
@@ -1,18 +1,21 @@
 ---
 layout: default
-description: Datacenter-to-Datacenter Replication deployment overview
-title: DC2DC Replication Deployment
 ---
 # Datacenter-to-Datacenter Replication deployment
 
 {% include hint-ee.md feature="Datacenter-to-Datacenter Replication" %}
 
-This chapter describes how to deploy all the components needed for
-_Datacenter-to-Datacenter Replication (DC2DC)_.
-
 ## Deployment steps
 
-## 1. Cluster
+To deploy all the components needed for _Datacenter-to-Datacenter Replication (DC2DC)_,
+you need to set up the following components:
+
+1. An ArangoDB cluster in each data center
+2. Multiple ArangoSync Masters
+3. Multiple ArangoSync Workers
+4. Optional: Prometheus and Grafana for monitoring
+
+## Cluster
 
 Datacenter-to-Datacenter Replication requires an ArangoDB cluster in both data centers.
 
@@ -35,7 +38,7 @@ without much effort.
 Please refer to the [Cluster](deployment-dc2dc-cluster.html) section for
 more information.
 
-## 2. ArangoSync Master
+## ArangoSync Master
 
 The Sync Master is responsible for managing all synchronization, creating tasks and assigning
 those to workers.
@@ -60,7 +63,7 @@ Consider these machines to be crucial for your DC2DC setup.
 Please refer to the [ArangoSync Master](deployment-dc2dc-arango-sync-master.html)
 section for more information.
 
-## 3. ArangoSync Workers
+## ArangoSync Workers
 
 The Sync Worker is responsible for executing synchronization tasks.
 
@@ -83,7 +86,7 @@ The sync worker can be memory intensive when running lots of databases & collect
 Please refer to the [ArangoSync Workers](deployment-dc2dc-arango-sync-workers.html)
 for more information.
 
-## 4. Prometheus & Grafana (optional)
+## Prometheus & Grafana (optional)
 
 ArangoSync provides metrics in a format supported by [Prometheus](https://prometheus.io){:target="_blank"}.
 We also provide a standard set of dashboards for viewing those metrics in [Grafana](https://grafana.org){:target="_blank"}.

--- a/3.12/deployment-dc2dc.md
+++ b/3.12/deployment-dc2dc.md
@@ -1,18 +1,21 @@
 ---
 layout: default
-description: Datacenter-to-Datacenter Replication deployment overview
-title: DC2DC Replication Deployment
 ---
 # Datacenter-to-Datacenter Replication deployment
 
 {% include hint-ee.md feature="Datacenter-to-Datacenter Replication" %}
 
-This chapter describes how to deploy all the components needed for
-_Datacenter-to-Datacenter Replication (DC2DC)_.
-
 ## Deployment steps
 
-## 1. Cluster
+To deploy all the components needed for _Datacenter-to-Datacenter Replication (DC2DC)_,
+you need to set up the following components:
+
+1. An ArangoDB cluster in each data center
+2. Multiple ArangoSync Masters
+3. Multiple ArangoSync Workers
+4. Optional: Prometheus and Grafana for monitoring
+
+## Cluster
 
 Datacenter-to-Datacenter Replication requires an ArangoDB cluster in both data centers.
 
@@ -35,7 +38,7 @@ without much effort.
 Please refer to the [Cluster](deployment-dc2dc-cluster.html) section for
 more information.
 
-## 2. ArangoSync Master
+## ArangoSync Master
 
 The Sync Master is responsible for managing all synchronization, creating tasks and assigning
 those to workers.
@@ -60,7 +63,7 @@ Consider these machines to be crucial for your DC2DC setup.
 Please refer to the [ArangoSync Master](deployment-dc2dc-arango-sync-master.html)
 section for more information.
 
-## 3. ArangoSync Workers
+## ArangoSync Workers
 
 The Sync Worker is responsible for executing synchronization tasks.
 
@@ -83,7 +86,7 @@ The sync worker can be memory intensive when running lots of databases & collect
 Please refer to the [ArangoSync Workers](deployment-dc2dc-arango-sync-workers.html)
 for more information.
 
-## 4. Prometheus & Grafana (optional)
+## Prometheus & Grafana (optional)
 
 ArangoSync provides metrics in a format supported by [Prometheus](https://prometheus.io){:target="_blank"}.
 We also provide a standard set of dashboards for viewing those metrics in [Grafana](https://grafana.org){:target="_blank"}.


### PR DESCRIPTION
There is currently a mix of `datacenter` (majority) vs. `data center` but the Google style guide suggests `data center`.
Shall we address this in this PR?
- When referring to ArangoSync, `Datacenter-to-Datacenter Replication` -> `DataCenter-to-DataCenter-Replication`
- Otherwise `datacenter` -> `data center`