### PR TITLE
deprecated/remove arangodump startup options

### DIFF
--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -185,6 +185,21 @@ detailed information about breaking changes before upgrading.
   The following options are deprecated for _arangorestore_:
   - `--default-number-of-shards` (use `--number-of-shards` instead)
   - `--default-replication-factor` (use `--replication-factor` instead)
+  
+  The following options are deprecated for _arangodump_:
+  - `--envelope`: setting this option to `true` previously wrapped every dumped 
+    document into a `{data, type}` envelope. 
+    This was useful for the MMFiles storage engine, where dumps could also include 
+    document removals. With the RocksDB storage engine, the envelope only caused 
+    overhead and increased the size of the dumps. The default value of `--envelope`
+    was changed to false in ArangoDB 3.9 already, so by default all arangodump 
+    invocations since then create non-envelope dumps. 
+  - `--tick-start`: setting this option allowed to restrict the dumped data to some 
+    time range with the MMFiles storage engine. It has no effect for the RocksDB 
+    storage engine.
+  - `--tick-end`: setting this option allowed to restrict the dumped data to some 
+    time range with the MMFiles storage engine. It has no effect for the RocksDB 
+    storage engine.
 
   The following startup options are deprecated in _arangod_ and all client tools:
   - `--log` (use `--log.level` instead)

--- a/3.11/appendix-deprecated.md
+++ b/3.11/appendix-deprecated.md
@@ -207,6 +207,21 @@ detailed information about breaking changes before upgrading.
   - `--default-number-of-shards` (use `--number-of-shards` instead)
   - `--default-replication-factor` (use `--replication-factor` instead)
 
+  The following options are deprecated for _arangodump_:
+  - `--envelope`: setting this option to `true` previously wrapped every dumped 
+    document into a `{data, type}` envelope. 
+    This was useful for the MMFiles storage engine, where dumps could also include 
+    document removals. With the RocksDB storage engine, the envelope only caused 
+    overhead and increased the size of the dumps. The default value of `--envelope`
+    was changed to false in ArangoDB 3.9 already, so by default all arangodump 
+    invocations since then create non-envelope dumps. 
+  - `--tick-start`: setting this option allowed to restrict the dumped data to some 
+    time range with the MMFiles storage engine. It has no effect for the RocksDB 
+    storage engine.
+  - `--tick-end`: setting this option allowed to restrict the dumped data to some 
+    time range with the MMFiles storage engine. It has no effect for the RocksDB 
+    storage engine.
+
   The following startup options are deprecated in _arangod_ and all client tools:
   - `--log` (use `--log.level` instead)
   - `--log.use-local-time` (use `--log.time-format` instead)

--- a/3.12/programs-arangodump-examples.md
+++ b/3.12/programs-arangodump-examples.md
@@ -236,57 +236,6 @@ detects whether the data is compressed or not based on the file extension.
 arangorestore --input-directory "dump"
 ```
 
-Dump output format
-------------------
-
-<small>Introduced in: v3.8.0</small>
-
-Since its inception, _arangodump_ wrapped each dumped document into an extra
-JSON envelope, such as follows:
-
-```json
-{"type":2300,"key":"test","data":{"_key":"test","_rev":..., ...}}
-```
-
-This original dump format was useful when there was the MMFiles storage engine,
-which could use different `type` values in its datafiles.
-However, the RocksDB storage engine only uses `"type":2300` (document) when
-dumping data, so the JSON wrapper provides no further benefit except
-compatibility with older versions of ArangoDB.
-
-In case a dump taken with v3.8.0 or higher is known to never be used in older
-ArangoDB versions, the JSON envelopes can be turned off. The startup option
-`--envelope` controls this. The option defaults to `true`, meaning dumped
-documents are wrapped in envelopes, which makes new dumps compatible with
-older versions of ArangoDB.
-
-If that is not needed, the `--envelope` option can be set to `false`.
-In this case, the dump files only contain the raw documents, without any
-envelopes around them:
-
-```json
-{"_key":"test","_rev":..., ...}
-```
-
-Disabling the envelopes can **reduce dump sizes** a lot, especially if documents
-are small on average and the relative cost of the envelopes is high. Omitting
-the envelopes can also help to **save a bit on memory usage and bandwidth** for
-building up the dump results and sending them over the wire.
-
-As a bonus, turning off the envelopes turns _arangodump_ into a fast, concurrent
-JSONL exporter for one or multiple collections:
-
-```
-arangodump --collection "collection" --threads 8 --envelope false --compress-output false dump
-```
-
-The JSONL format is also supported by _arangoimport_ natively.
-
-{% hint 'warning' %}
-Dumps created with the `--envelope false` setting cannot be restored into any
-ArangoDB versions older than v3.8.0!
-{% endhint %}
-
 Threads
 -------
 

--- a/3.12/programs-arangorestore-examples.md
+++ b/3.12/programs-arangorestore-examples.md
@@ -315,21 +315,6 @@ The following factors affect speed of _arangorestore_ in a Cluster:
   be done by using the `--threads` option of _arangorestore_.
   Depending on your specific case, you might be able to achieve additional
   parallelization by restoring on multiple _Coordinators_ at the same time.
-- **Dump Format**: Since ArangoDB 3.8 arangodump can produce two different
-  dump formats: an enveloped format, which was the default format up to
-  including ArangoDB 3.8, and a non-envelop format, which is the default
-  since ArangoDB 3.9.0.
-  The enveloped format is downwards-compatible with all previous versions
-  of ArangoDB, and should only be used for dumps that need to be restored
-  into versions older than 3.9. The non-envelope format is only understood
-  since ArangoDB 3.8.0 and not compatible with previous versions. However, it
-  is smaller and slightly faster to produce. In addition, the non-envelope
-  format allows arangorestore to parallelize the restore operations not
-  only across collections but also within collections. The latter is not
-  possible with the envelope dump format.
-  In order to use the non-envelope dump format, invoke arangodump with the
-  option `--envelope false`. arangorestore can automatically parallelize
-  the restore of such dumps even for individual collections.
 
 ### Restoring collections with sharding prototypes
 

--- a/3.12/release-notes-upgrading-changes312.md
+++ b/3.12/release-notes-upgrading-changes312.md
@@ -131,3 +131,22 @@ the JavaScript graph modules.
 
 ## Client tools
 
+### arangodump
+
+This following startup options of arangodump are obsolete from ArangoDB 3.12 on:
+
+- `--envelope`: setting this option to `true` previously wrapped every dumped 
+  document into a `{data, type}` envelope. 
+  This was useful for the MMFiles storage engine, where dumps could also include 
+  document removals. With the RocksDB storage engine, the envelope only caused 
+  overhead and increased the size of the dumps. The default value of `--envelope`
+  was changed to false in ArangoDB 3.9 already, so by default all arangodump 
+  invocations since then created non-envelope dumps. With the option being removed 
+  now, all arangodump invocations will unconditionally create non-envelope dumps.
+- `--tick-start`: setting this option allowed to restrict the dumped data to some 
+  time range with the MMFiles storage engine. It had no effect for the RocksDB 
+  storage engine and so it is removed now.
+- `--tick-end`: setting this option allowed to restrict the dumped data to some 
+  time range with the MMFiles storage engine. It had no effect for the RocksDB 
+  storage engine and so it is removed now.
+

--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -991,7 +991,7 @@ and bandwidth:
 
 {% assign ver = "3.12" | version: "<" %}{% if ver -%}
 Also see [_arangodump_ Dump Output Format](programs-arangodump-examples.html#dump-output-format).
-{% else -%}
+{%- endif %}
 
 Using the new non-enveloped dump format also allows _arangorestore_ to
 parallelize restore operations for individual collections. This is not possible

--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -989,8 +989,6 @@ and bandwidth:
 {"_key":"test","_rev":..., ...}
 ```
 
-Also see [_arangodump_ Dump Output Format](programs-arangodump-examples.html#dump-output-format).
-
 Using the new non-enveloped dump format also allows _arangorestore_ to
 parallelize restore operations for individual collections. This is not possible
 with the old, enveloped format.

--- a/3.8/release-notes-new-features38.md
+++ b/3.8/release-notes-new-features38.md
@@ -989,6 +989,10 @@ and bandwidth:
 {"_key":"test","_rev":..., ...}
 ```
 
+{% assign ver = "3.12" | version: "<" %}{% if ver -%}
+Also see [_arangodump_ Dump Output Format](programs-arangodump-examples.html#dump-output-format).
+{% else -%}
+
 Using the new non-enveloped dump format also allows _arangorestore_ to
 parallelize restore operations for individual collections. This is not possible
 with the old, enveloped format.


### PR DESCRIPTION
Docs PR for the following changes:
* devel: https://github.com/arangodb/arangodb/pull/19680
* 3.11: https://github.com/arangodb/arangodb/pull/19687
* 3.10: https://github.com/arangodb/arangodb/pull/19688