### PR TITLE
DOC-536 | Move Edition remarks up below headline or beginning of list, convert extra text to separate hint box

### DIFF
--- a/3.10/analyzers.md
+++ b/3.10/analyzers.md
@@ -1086,9 +1086,9 @@ Create different `segmentation` Analyzers to show the behavior of the different
 
 ### `minhash`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `minhash` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
@@ -1130,9 +1130,9 @@ Create a `minhash` Analyzers:
 
 ### `classification`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `classification` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1190,9 +1190,9 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 ### `nearest_neighbors`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `nearest_neighbors` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1371,9 +1371,9 @@ longitude, latitude order:
 
 ### `geo_s2`
 
-<small>Introduced in: v3.10.5</small>
-
 {% include hint-ee-arangograph.md feature="The `geo_s2` Analyzer" %}
+
+<small>Introduced in: v3.10.5</small>
 
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage

--- a/3.10/appendix-deprecated.md
+++ b/3.10/appendix-deprecated.md
@@ -185,7 +185,7 @@ detailed information about breaking changes before upgrading.
   The following options are deprecated for _arangorestore_:
   - `--default-number-of-shards` (use `--number-of-shards` instead)
   - `--default-replication-factor` (use `--replication-factor` instead)
-  
+
   The following options are deprecated for _arangodump_:
   - `--envelope`: setting this option to `true` previously wrapped every dumped 
     document into a `{data, type}` envelope. 
@@ -244,7 +244,7 @@ detailed information about breaking changes before upgrading.
   - `arangodb::GRAPH_BETWEENNESS`
   - `arangodb::GRAPH_RADIUS`
   - `arangodb::GRAPH_DIAMETER`
-  
+
   These functions will be removed in ArangoDB 3.12.
 
 - **Specialized index creation methods in JavaScript API**:

--- a/3.10/aql/graphs-traversals.md
+++ b/3.10/aql/graphs-traversals.md
@@ -127,8 +127,11 @@ FOR vertex[, edge[, path]]
       vertex collection.
     - The starting vertex is always allowed, even if it does not belong to one
       of the collections specified by a restriction.
-  - **parallelism** (number, *optional*): Optionally parallelize traversal
-    execution (introduced in v3.7.1). If omitted or set to a value of `1`,
+  - **parallelism** (number, *optional*):
+
+    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
+
+    Optionally parallelize traversal execution. If omitted or set to a value of `1`,
     traversal execution is not parallelized. If set to a value greater than `1`,
     then up to that many worker threads can be used for concurrently executing
     the traversal. The value is capped by the number of available cores on the
@@ -139,10 +142,12 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
-  - **maxProjections** (number, *optional*): Specifies the number of document
-    attributes per FOR loop to be used as projections. The default value is `5`.
+  - **maxProjections** (number, *optional*):
+
     {% include hint-ee-arangograph.md feature="Traversal projections" plural=true %}
+
+    Specifies the number of document attributes per `FOR` loop to be used as
+    projections. The default value is `5`.
   - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.

--- a/3.10/aql/invocation-with-arangosh.md
+++ b/3.10/aql/invocation-with-arangosh.md
@@ -432,6 +432,8 @@ the entire query result in RAM, use a streaming query (see the
 
 #### `allowDirtyReads`
 
+{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
+
 <small>Introduced in: v3.10.0</small>
 
 If you set this option to `true` and execute the query against a cluster
@@ -439,9 +441,9 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../http/document.html#read-from-followers)
 for details.
 
-{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
-
 #### `skipInaccessibleCollections`
+
+{% include hint-ee-arangograph.md feature="This option" %}
 
 Let AQL queries (especially graph traversals) treat collection to which a
 user has **no access** rights for as if these collections are empty.
@@ -450,15 +452,13 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{% include hint-ee-arangograph.md feature="This option" %}
-
 #### `satelliteSyncWait`
+
+{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
-
-{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 ## With `db._createStatement()` (ArangoStatement)
 

--- a/3.10/arangosearch-performance.md
+++ b/3.10/arangosearch-performance.md
@@ -472,9 +472,9 @@ Also see [Faceted Search with ArangoSearch](arangosearch-faceted-search.html).
 
 ## Field normalization value caching and caching of Geo Analyzer auxiliary data
 
-<small>Introduced in: v3.9.5, v3.10.2</small>
-
 {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
+<small>Introduced in: v3.9.5, v3.10.2</small>
 
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](analyzers.html#analyzer-features) enabled.

--- a/3.10/arangosearch-views.md
+++ b/3.10/arangosearch-views.md
@@ -81,7 +81,7 @@ During view modification the following directives apply:
   processed at each level of the document. Each key specifies the document
   attribute to be processed. Note that the value of `includeAllFields` is also
   consulted when selecting fields to be processed.
-  
+
   The `fields` property is a recursive data structure. This means that `fields`
   can be part of the Link properties again. This lets you index nested attributes.
   For example, you might have documents like the following in a collection named
@@ -177,8 +177,10 @@ During view modification the following directives apply:
   `inBackground` is an option that can be set when adding links. It does not get
   persisted as it is not a View property, but only a one-off option. Also see:
   [Creating Indexes in Background](indexing-index-basics.html#creating-indexes-in-background)
-  
+
 - **cache** (_optional_; type: `boolean`; default: `false`)
+
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
   <small>Introduced in: v3.9.5, v3.10.2</small>
 
@@ -201,8 +203,6 @@ During view modification the following directives apply:
   leader shards, see the
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
-
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
 ### View Properties
 
@@ -232,6 +232,8 @@ cache-related options and thus recreate inverted indexes and Views. See
   
 - **primarySortCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
   If you enable this option, then the primary sort columns are always cached in
@@ -247,9 +249,9 @@ cache-related options and thus recreate inverted indexes and Views. See
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-  
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
+
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
@@ -265,8 +267,6 @@ cache-related options and thus recreate inverted indexes and Views. See
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 
   <small>Introduced in: v3.7.1</small>
@@ -279,13 +279,13 @@ cache-related options and thus recreate inverted indexes and Views. See
   Each object is expected in the following form:
 
   `{ "fields": [ "attr1", "attr2", ... "attrN" ], "compression": "none", "cache": false }`
-  
+
   - The required `fields` attribute is an array of strings with one or more
     document attribute paths. The specified attributes are placed into a single
     column of the index. A column with all fields that are involved in common
     search queries is ideal for performance. The column should not include too
     many unneeded fields, however.
-  
+
   - The optional `compression` attribute defines the compression type used for
     the internal column-store, which can be `"lz4"` (LZ4 fast compression, default)
     or `"none"` (no compression).

--- a/3.10/backup-restore.md
+++ b/3.10/backup-restore.md
@@ -74,11 +74,11 @@ procedure is recommended.
 Hot Backups
 -----------
 
+{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
+
 Hot backup and restore associated operations can be performed with the
 [_arangobackup_](programs-arangobackup.html) client tool and the
 [Hot Backup HTTP API](http/hot-backup.html).
-
-{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
 
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.

--- a/3.10/graphs-pregel.md
+++ b/3.10/graphs-pregel.md
@@ -38,11 +38,10 @@ If you run a single ArangoDB instance in single-server mode, there are no
 requirements regarding the modeling of your data. All you need is at least one
 vertex collection and one edge collection.
 
-In cluster mode, the collections need to be sharded in a specific way to ensure
-correct results: The outgoing edges of a vertex need to be on the same DB-Server
-as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
-
-{% include hint-ee-arangograph.md feature="SmartGraphs (and thus Pregel in cluster deployments)" plural=true %}
+In cluster deployments, the collections need to be sharded in a specific way to
+ensure correct results: The outgoing edges of a vertex need to be on the same
+DB-Server as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
+Thus, Pregel in cluster deployments is not usable in the Community Edition.
 
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.
@@ -81,8 +80,8 @@ described in [Pregel Algorithms](graphs-pregel-algorithms.html).
 
 ### Status of an Algorithm Execution
 
-You can use the ID returned by the `pregel.start(...)` method to track the
-status of your algorithm:
+You can call `pregel.status()` and use the ID returned by the `pregel.start(...)`
+method to track the status of your algorithm:
 
 ```js
 var execution = pregel.start("sssp", "demograph", { source: "vertices/V" });
@@ -101,7 +100,7 @@ The `state` field has one of the following values:
 | `"loading"`    | The graph data is being loaded from the database into memory before executing the algorithm.
 | `"running"`    | The algorithm is executing normally.
 | `"storing"`    | The algorithm finished, but the results are still being written back into the collections. Only occurs if the `store` parameter is set to `true`.
-| `"done"`       | The execution is done. In version 3.7.1 and later, this means that storing is also done. In earlier versions, the results may not be written back into the collections yet. This event is announced in the server log (requires at least `info` log level for the `pregel` topic).
+| `"done"`       | The execution is done. In version 3.7.1 and later, this means that storing is also done. In earlier versions, the results may not be written back into the collections yet. This event is announced in the server log (requires at least the `info` log level for the `pregel` log topic).
 | `"canceled"`   | The execution was permanently canceled, either by the user or by an error.
 | `"in error"`   | The execution is in an error state. This can be caused by primary DB-Servers being unreachable or unresponsive. The execution might recover later, or switch to `canceled` if it is not able to recover successfully.
 | `"recovering"` | The execution is actively recovering and switches back to `running` if the recovery is successful.
@@ -127,7 +126,7 @@ The object returned by the `status()` method looks like this:
 ### Canceling an Execution / Discarding results
 
 To cancel an execution which is still running and discard any intermediate
-results, you can use the `cancel()` method. This immediately frees all
+results, you can use the `pregel.cancel()` method. This immediately frees all
 memory taken up by the execution, and makes you lose all intermediary data.
 
 ```js

--- a/3.10/http/document.md
+++ b/3.10/http/document.md
@@ -132,9 +132,9 @@ contains a JSON array of the same length.
 
 ### Read from followers
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="Reading from followers in cluster deployments" %}
+
+<small>Introduced in: v3.10.0</small>
 
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are

--- a/3.10/programs-arangobackup.md
+++ b/3.10/programs-arangobackup.md
@@ -1,27 +1,25 @@
 ---
 layout: default
 description: arangobackup is a command-line client tool to create global hot backups of an ArangoDB instance
-title: Arangobackup Client Tool
 ---
-Arangobackup
-============
+# _arangobackup_ client tool
 
-{% capture alternative %}
+{% include hint-ee.md feature="The arangobackup tool" %}
 
-Use [_arangodump_](programs-arangodump.html) and
+{% hint 'tip' %}
+In the Community Edition, use [_arangodump_](programs-arangodump.html) and
 [_arangorestore_](programs-arangorestore.html) for
-[logical backups](backup-restore.html#logical-backups) in the Community Edition.
-{% endcapture %}
-{% include hint-ee.md feature="The arangobackup tool" extra=alternative %}
+[logical backups](backup-restore.html#logical-backups).
+{% endhint %}
 
-_Arangobackup_ is a command-line client tool for instantaneous and
+_arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](backup-restore.html#hot-backups) of the data and
 structures stored in ArangoDB.
 
 Hot backups rely on hard link magic performed on the database's
 persistence layer.
 
-_Arangobackup_ can be used for all ArangoDB deployment modes
+_arangobackup_ can be used for all ArangoDB deployment modes
 (Single Instance, Active Failover, Cluster). It always creates what
 is most readily described as a persistence layer consistent snapshot
 of the entire instance. Therefore, no such thing as database or

--- a/3.10/security-auditing.md
+++ b/3.10/security-auditing.md
@@ -15,12 +15,12 @@ page-toc:
 {{ page.description }}
 {:class="lead"}
 
-{% capture arangograph %}
+{% include hint-ee.md feature="Audit logging" %}
 
+{% hint 'tip' %}
 A similar feature is also available in the
 [ArangoGraph Insights Platform](arangograph/access-control.html#using-an-audit-log).
-{% endcapture %}
-{% include hint-ee.md feature="Audit logging" extra=arangograph %}
+{% endhint %}
 
 ## Configuration
 

--- a/3.11/analyzers.md
+++ b/3.11/analyzers.md
@@ -1086,9 +1086,9 @@ Create different `segmentation` Analyzers to show the behavior of the different
 
 ### `minhash`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `minhash` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
@@ -1130,9 +1130,9 @@ Create a `minhash` Analyzers:
 
 ### `classification`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `classification` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1190,9 +1190,9 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 ### `nearest_neighbors`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `nearest_neighbors` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1371,9 +1371,9 @@ longitude, latitude order:
 
 ### `geo_s2`
 
-<small>Introduced in: v3.10.5</small>
-
 {% include hint-ee-arangograph.md feature="The `geo_s2` Analyzer" %}
+
+<small>Introduced in: v3.10.5</small>
 
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage

--- a/3.11/appendix-deprecated.md
+++ b/3.11/appendix-deprecated.md
@@ -191,7 +191,7 @@ detailed information about breaking changes before upgrading.
     special HTTP headers `x-http-method`, `x-method-override` or 
     `x-http-method-override`. This was originally intended for very restricted
     callers, which only supported HTTP GET and HTTP POST, but seems very
-    unnecessary nowadays. 
+    unnecessary nowadays.
     The functionality will be removed in ArangoDB 3.12.
   - `--http.hide-product-header`: whether or not to hide the `Server: ArangoDB`
     header in all responses served by arangod.

--- a/3.11/aql/graphs-traversals.md
+++ b/3.11/aql/graphs-traversals.md
@@ -127,8 +127,11 @@ FOR vertex[, edge[, path]]
       vertex collection.
     - The starting vertex is always allowed, even if it does not belong to one
       of the collections specified by a restriction.
-  - **parallelism** (number, *optional*): Optionally parallelize traversal
-    execution. If omitted or set to a value of `1`,
+  - **parallelism** (number, *optional*):
+
+    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
+
+    Optionally parallelize traversal execution. If omitted or set to a value of `1`,
     traversal execution is not parallelized. If set to a value greater than `1`,
     then up to that many worker threads can be used for concurrently executing
     the traversal. The value is capped by the number of available cores on the
@@ -139,10 +142,12 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
-  - **maxProjections** (number, *optional*): Specifies the number of document
-    attributes per FOR loop to be used as projections. The default value is `5`.
+  - **maxProjections** (number, *optional*):
+
     {% include hint-ee-arangograph.md feature="Traversal projections" plural=true %}
+
+    Specifies the number of document attributes per `FOR` loop to be used as
+    projections. The default value is `5`.
   - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.

--- a/3.11/aql/invocation-with-arangosh.md
+++ b/3.11/aql/invocation-with-arangosh.md
@@ -492,6 +492,8 @@ the entire query result in RAM, use a streaming query (see the
 
 #### `allowDirtyReads`
 
+{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
+
 <small>Introduced in: v3.10.0</small>
 
 If you set this option to `true` and execute the query against a cluster
@@ -499,9 +501,9 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../http/document.html#read-from-followers)
 for details.
 
-{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
-
 #### `skipInaccessibleCollections`
+
+{% include hint-ee-arangograph.md feature="This option" %}
 
 Let AQL queries (especially graph traversals) treat collection to which a
 user has **no access** rights for as if these collections are empty.
@@ -510,15 +512,13 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{% include hint-ee-arangograph.md feature="This option" %}
-
 #### `satelliteSyncWait`
+
+{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
-
-{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 ## With `db._createStatement()` (ArangoStatement)
 

--- a/3.11/arangosearch-performance.md
+++ b/3.11/arangosearch-performance.md
@@ -472,9 +472,9 @@ Also see [Faceted Search with ArangoSearch](arangosearch-faceted-search.html).
 
 ## Field normalization value caching and caching of Geo Analyzer auxiliary data
 
-<small>Introduced in: v3.9.5, v3.10.2</small>
-
 {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
+<small>Introduced in: v3.9.5, v3.10.2</small>
 
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](analyzers.html#analyzer-features) enabled.

--- a/3.11/arangosearch-views.md
+++ b/3.11/arangosearch-views.md
@@ -217,6 +217,8 @@ During view modification the following directives apply:
 
 - **cache** (_optional_; type: `boolean`; default: `false`)
 
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
   <small>Introduced in: v3.9.5, v3.10.2</small>
 
   If you enable this option, then field normalization values are always cached
@@ -239,8 +241,6 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-
 ### View Properties
 
 - **primarySort** (_optional_; type: `array`; default: `[]`; _immutable_)
@@ -260,6 +260,8 @@ During view modification the following directives apply:
 
 - **primarySortCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
   If you enable this option, then the primary sort columns are always cached in
@@ -275,9 +277,9 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
+
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
@@ -292,8 +294,6 @@ During view modification the following directives apply:
   leader shards, see the
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
-
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 

--- a/3.11/backup-restore.md
+++ b/3.11/backup-restore.md
@@ -68,11 +68,11 @@ Logical backups can be created and restored with the tools
 Hot Backups
 -----------
 
+{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
+
 Hot backup and restore associated operations can be performed with the
 [_arangobackup_](programs-arangobackup.html) client tool and the
 [Hot Backup HTTP API](http/hot-backup.html).
-
-{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
 
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.

--- a/3.11/graphs-pregel.md
+++ b/3.11/graphs-pregel.md
@@ -38,11 +38,10 @@ If you run a single ArangoDB instance in single-server mode, there are no
 requirements regarding the modeling of your data. All you need is at least one
 vertex collection and one edge collection.
 
-In cluster mode, the collections need to be sharded in a specific way to ensure
-correct results: The outgoing edges of a vertex need to be on the same DB-Server
-as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
-
-{% include hint-ee-arangograph.md feature="SmartGraphs (and thus Pregel in cluster deployments)" plural=true %}
+In cluster deployments, the collections need to be sharded in a specific way to
+ensure correct results: The outgoing edges of a vertex need to be on the same
+DB-Server as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
+Thus, Pregel in cluster deployments is not usable in the Community Edition.
 
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.
@@ -101,7 +100,7 @@ The `state` field has one of the following values:
 | `"loading"`    | The graph data is being loaded from the database into memory before executing the algorithm.
 | `"running"`    | The algorithm is executing normally.
 | `"storing"`    | The algorithm finished, but the results are still being written back into the collections. Only occurs if the `store` parameter is set to `true`.
-| `"done"`       | The execution is done. This means that storing is also done. This event is announced in the server log (requires at least `info` log level for the `pregel` topic).
+| `"done"`       | The execution is done. This means that storing is also done. This event is announced in the server log (requires at least the `info` log level for the `pregel` log topic).
 | `"canceled"`   | The execution was permanently canceled, either by the user or by an error.
 | `"in error"`   | The execution is in an error state. This can be caused by primary DB-Servers being unreachable or unresponsive. The execution might recover later, or switch to `canceled` if it is not able to recover successfully.
 | `"recovering"` | The execution is actively recovering and switches back to `running` if the recovery is successful.

--- a/3.11/http/document.md
+++ b/3.11/http/document.md
@@ -132,9 +132,9 @@ contains a JSON array of the same length.
 
 ### Read from followers
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="Reading from followers in cluster deployments" %}
+
+<small>Introduced in: v3.10.0</small>
 
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are

--- a/3.11/programs-arangobackup.md
+++ b/3.11/programs-arangobackup.md
@@ -1,27 +1,25 @@
 ---
 layout: default
 description: arangobackup is a command-line client tool to create global hot backups of an ArangoDB instance
-title: Arangobackup Client Tool
 ---
-Arangobackup
-============
+# _arangobackup_ client tool
 
-{% capture alternative %}
+{% include hint-ee.md feature="The arangobackup tool" %}
 
-Use [_arangodump_](programs-arangodump.html) and
+{% hint 'tip' %}
+In the Community Edition, use [_arangodump_](programs-arangodump.html) and
 [_arangorestore_](programs-arangorestore.html) for
-[logical backups](backup-restore.html#logical-backups) in the Community Edition.
-{% endcapture %}
-{% include hint-ee.md feature="The arangobackup tool" extra=alternative %}
+[logical backups](backup-restore.html#logical-backups).
+{% endhint %}
 
-_Arangobackup_ is a command-line client tool for instantaneous and
+_arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](backup-restore.html#hot-backups) of the data and
 structures stored in ArangoDB.
 
 Hot backups rely on hard link magic performed on the database's
 persistence layer.
 
-_Arangobackup_ can be used for all ArangoDB deployment modes
+_arangobackup_ can be used for all ArangoDB deployment modes
 (Single Instance, Active Failover, Cluster). It always creates what
 is most readily described as a persistence layer consistent snapshot
 of the entire instance. Therefore, no such thing as database or

--- a/3.11/security-auditing.md
+++ b/3.11/security-auditing.md
@@ -15,12 +15,12 @@ page-toc:
 {{ page.description }}
 {:class="lead"}
 
-{% capture arangograph %}
+{% include hint-ee.md feature="Audit logging" %}
 
+{% hint 'tip' %}
 A similar feature is also available in the
 [ArangoGraph Insights Platform](arangograph/access-control.html#using-an-audit-log).
-{% endcapture %}
-{% include hint-ee.md feature="Audit logging" extra=arangograph %}
+{% endhint %}
 
 ## Configuration
 

--- a/3.12/analyzers.md
+++ b/3.12/analyzers.md
@@ -1086,9 +1086,9 @@ Create different `segmentation` Analyzers to show the behavior of the different
 
 ### `minhash`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `minhash` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
@@ -1130,9 +1130,9 @@ Create a `minhash` Analyzers:
 
 ### `classification`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `classification` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1190,9 +1190,9 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 ### `nearest_neighbors`
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="The `nearest_neighbors` Analyzer" %}
+
+<small>Introduced in: v3.10.0</small>
 
 {% hint 'warning' %}
 This feature is experimental and under active development.
@@ -1371,9 +1371,9 @@ longitude, latitude order:
 
 ### `geo_s2`
 
-<small>Introduced in: v3.10.5</small>
-
 {% include hint-ee-arangograph.md feature="The `geo_s2` Analyzer" %}
+
+<small>Introduced in: v3.10.5</small>
 
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage

--- a/3.12/appendix-deprecated.md
+++ b/3.12/appendix-deprecated.md
@@ -122,7 +122,7 @@ detailed information about breaking changes before upgrading.
   it is much more useful.
 
 - **Database target version REST API**:
-  The `GET /_admin/database/target-version` is deprecated in favor of the
+  The `GET /_admin/database/target-version` endpoint is deprecated in favor of the
   more general version API with the endpoint `GET /_api/version`. The endpoint may be
   removed in a future version of ArangoDB.
 

--- a/3.12/aql/graphs-traversals.md
+++ b/3.12/aql/graphs-traversals.md
@@ -127,7 +127,11 @@ FOR vertex[, edge[, path]]
       vertex collection.
     - The starting vertex is always allowed, even if it does not belong to one
       of the collections specified by a restriction.
-  - **parallelism** (number, *optional*): Optionally parallelize traversal
+  - **parallelism** (number, *optional*):
+
+    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
+
+    Optionally parallelize traversal
     execution. If omitted or set to a value of `1`,
     traversal execution is not parallelized. If set to a value greater than `1`,
     then up to that many worker threads can be used for concurrently executing
@@ -139,10 +143,12 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {% include hint-ee-arangograph.md feature="Traversal parallelization" %}
-  - **maxProjections** (number, *optional*): Specifies the number of document
-    attributes per FOR loop to be used as projections. The default value is `5`.
+  - **maxProjections** (number, *optional*):
+
     {% include hint-ee-arangograph.md feature="Traversal projections" plural=true %}
+
+    Specifies the number of document
+    attributes per FOR loop to be used as projections. The default value is `5`.
   - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.

--- a/3.12/aql/invocation-with-arangosh.md
+++ b/3.12/aql/invocation-with-arangosh.md
@@ -492,6 +492,8 @@ the entire query result in RAM, use a streaming query (see the
 
 #### `allowDirtyReads`
 
+{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
+
 <small>Introduced in: v3.10.0</small>
 
 If you set this option to `true` and execute the query against a cluster
@@ -499,9 +501,9 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../http/document.html#read-from-followers)
 for details.
 
-{% include hint-ee-arangograph.md feature="Reading from followers in clusters" %}
-
 #### `skipInaccessibleCollections`
+
+{% include hint-ee-arangograph.md feature="This option" %}
 
 Let AQL queries (especially graph traversals) treat collection to which a
 user has **no access** rights for as if these collections are empty.
@@ -510,15 +512,13 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{% include hint-ee-arangograph.md feature="This option" %}
-
 #### `satelliteSyncWait`
+
+{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
-
-{% include hint-ee-arangograph.md feature="SatelliteCollections" plural=true %}
 
 ## With `db._createStatement()` (ArangoStatement)
 

--- a/3.12/arangosearch-performance.md
+++ b/3.12/arangosearch-performance.md
@@ -556,9 +556,9 @@ Also see [Faceted Search with ArangoSearch](arangosearch-faceted-search.html).
 
 ## Field normalization value caching and caching of Geo Analyzer auxiliary data
 
-<small>Introduced in: v3.9.5, v3.10.2</small>
-
 {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
+<small>Introduced in: v3.9.5, v3.10.2</small>
 
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](analyzers.html#analyzer-features) enabled.

--- a/3.12/arangosearch-views.md
+++ b/3.12/arangosearch-views.md
@@ -217,6 +217,8 @@ During view modification the following directives apply:
 
 - **cache** (_optional_; type: `boolean`; default: `false`)
 
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
   <small>Introduced in: v3.9.5, v3.10.2</small>
 
   If you enable this option, then field normalization values are always cached
@@ -239,8 +241,6 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-
 ### View Properties
 
 - **primarySort** (_optional_; type: `array`; default: `[]`; _immutable_)
@@ -260,6 +260,8 @@ During view modification the following directives apply:
 
 - **primarySortCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
+
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
   If you enable this option, then the primary sort columns are always cached in
@@ -275,9 +277,9 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
-
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
+
+  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
 
@@ -292,8 +294,6 @@ During view modification the following directives apply:
   leader shards, see the
   [`--arangosearch.columns-cache-only-leader` startup option](programs-arangod-options.html#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
-
-  {% include hint-ee-arangograph.md feature="ArangoSearch caching" %}
 
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 
@@ -342,6 +342,8 @@ During view modification the following directives apply:
 
 - **optimizeTopK** (_optional_; type: `array`; default: `[]`; _immutable_)
 
+  {% include hint-ee-arangograph.md feature="The ArangoSearch WAND optimization" %}
+
   <small>Introduced in: v3.12.0</small>
 
   An array of strings defining sort expressions that you want to optimize.
@@ -360,8 +362,6 @@ During view modification the following directives apply:
   You can define up tp 64 expressions per View.
 
   Example: `["BM25(@doc) DESC", "TFIDF(@doc, true) DESC"]`
-
-  {% include hint-ee-arangograph.md feature="The ArangoSearch WAND optimization" %}
 
 An inverted index is the heart of `arangosearch` Views.
 The index consists of several independent segments and the index **segment**

--- a/3.12/backup-restore.md
+++ b/3.12/backup-restore.md
@@ -68,11 +68,11 @@ Logical backups can be created and restored with the tools
 Hot Backups
 -----------
 
+{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
+
 Hot backup and restore associated operations can be performed with the
 [_arangobackup_](programs-arangobackup.html) client tool and the
 [Hot Backup HTTP API](http/hot-backup.html).
-
-{% include hint-ee-arangograph.md feature="The arangobackup tool and the Hot Backup API" plural=true %}
 
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.

--- a/3.12/graphs-pregel.md
+++ b/3.12/graphs-pregel.md
@@ -38,11 +38,10 @@ If you run a single ArangoDB instance in single-server mode, there are no
 requirements regarding the modeling of your data. All you need is at least one
 vertex collection and one edge collection.
 
-In cluster mode, the collections need to be sharded in a specific way to ensure
-correct results: The outgoing edges of a vertex need to be on the same DB-Server
-as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
-
-{% include hint-ee-arangograph.md feature="SmartGraphs (and thus Pregel in cluster deployments)" plural=true %}
+In cluster deployments, the collections need to be sharded in a specific way to
+ensure correct results: The outgoing edges of a vertex need to be on the same
+DB-Server as the vertex. This is guaranteed by [SmartGraphs](graphs-smart-graphs.html).
+Thus, Pregel in cluster deployments is not usable in the Community Edition.
 
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.

--- a/3.12/http/document.md
+++ b/3.12/http/document.md
@@ -132,9 +132,9 @@ contains a JSON array of the same length.
 
 ### Read from followers
 
-<small>Introduced in: v3.10.0</small>
-
 {% include hint-ee-arangograph.md feature="Reading from followers in cluster deployments" %}
+
+<small>Introduced in: v3.10.0</small>
 
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are

--- a/3.12/programs-arangobackup.md
+++ b/3.12/programs-arangobackup.md
@@ -1,27 +1,25 @@
 ---
 layout: default
 description: arangobackup is a command-line client tool to create global hot backups of an ArangoDB instance
-title: Arangobackup Client Tool
 ---
-Arangobackup
-============
+# _arangobackup_ client tool
 
-{% capture alternative %}
+{% include hint-ee.md feature="The arangobackup tool" %}
 
-Use [_arangodump_](programs-arangodump.html) and
+{% hint 'tip' %}
+In the Community Edition, use [_arangodump_](programs-arangodump.html) and
 [_arangorestore_](programs-arangorestore.html) for
-[logical backups](backup-restore.html#logical-backups) in the Community Edition.
-{% endcapture %}
-{% include hint-ee.md feature="The arangobackup tool" extra=alternative %}
+[logical backups](backup-restore.html#logical-backups).
+{% endhint %}
 
-_Arangobackup_ is a command-line client tool for instantaneous and
+_arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](backup-restore.html#hot-backups) of the data and
 structures stored in ArangoDB.
 
 Hot backups rely on hard link magic performed on the database's
 persistence layer.
 
-_Arangobackup_ can be used for all ArangoDB deployment modes
+_arangobackup_ can be used for all ArangoDB deployment modes
 (Single Instance, Active Failover, Cluster). It always creates what
 is most readily described as a persistence layer consistent snapshot
 of the entire instance. Therefore, no such thing as database or

--- a/3.12/security-auditing.md
+++ b/3.12/security-auditing.md
@@ -15,12 +15,12 @@ page-toc:
 {{ page.description }}
 {:class="lead"}
 
-{% capture arangograph %}
+{% include hint-ee.md feature="Audit logging" %}
 
+{% hint 'tip' %}
 A similar feature is also available in the
 [ArangoGraph Insights Platform](arangograph/access-control.html#using-an-audit-log).
-{% endcapture %}
-{% include hint-ee.md feature="Audit logging" extra=arangograph %}
+{% endhint %}
 
 ## Configuration
 


### PR DESCRIPTION
Related to https://github.com/arangodb/docs-hugo/pull/176