### PR TITLE
Add .fixed class to a table

### DIFF
--- a/3.8/release-notes-api-changes38.md
+++ b/3.8/release-notes-api-changes38.md
@@ -290,6 +290,7 @@ as a database only. It may have an effect for Foxx applications that use HTTP
   | `rocksdbengine_throttle_bps` | `rocksdb_engine_throttle_bps` |
   | `rocksdb_write_stalls` | `arangodb_rocksdb_write_stalls_total` |
   | `rocksdb_write_stops` | `arangodb_rocksdb_write_stops_total` |
+  {:class="fixed"}
 
 ### Endpoints augmented
 


### PR DESCRIPTION
Set .fixed class for a specific table with very long words

Has no effect in Jekyll toolchain but will have one in Hugo